### PR TITLE
Add support for empty ENV variables on deployment

### DIFF
--- a/helm-chart/templates/secret.yaml
+++ b/helm-chart/templates/secret.yaml
@@ -8,9 +8,9 @@ data:
   HEDERA_NETWORK: {{ .Values.config.HEDERA_NETWORK | b64enc }}
   OPERATOR_ID_MAIN: {{ .Values.config.OPERATOR_ID_MAIN | b64enc }}
   OPERATOR_KEY_MAIN: {{ .Values.config.OPERATOR_KEY_MAIN | b64enc }}
-  OPERATOR_ID_ETH_SENDRAWTRANSACTION: {{ .Values.config.OPERATOR_ID_ETH_SENDRAWTRANSACTION }}
-  OPERATOR_KEY_ETH_SENDRAWTRANSACTION: {{ .Values.config.OPERATOR_KEY_ETH_SENDRAWTRANSACTION }}
-  CHAIN_ID: {{ printf "%s" .Values.config.CHAIN_ID | b64enc }}
+  OPERATOR_ID_ETH_SENDRAWTRANSACTION: {{ .Values.config.OPERATOR_ID_ETH_SENDRAWTRANSACTION | default (printf "%q" "") }}
+  OPERATOR_KEY_ETH_SENDRAWTRANSACTION: {{ .Values.config.OPERATOR_KEY_ETH_SENDRAWTRANSACTION | default (printf "%q" "") }}
+  CHAIN_ID: {{ printf "%s" .Values.config.CHAIN_ID | default (printf "%q" "") |b64enc }}
   MIRROR_NODE_URL: {{ .Values.config.MIRROR_NODE_URL | b64enc }}
   LOCAL_NODE: {{ .Values.config.LOCAL_NODE | quote | b64enc }}
   SERVER_PORT: {{ .Values.config.SERVER_PORT | quote | b64enc }}


### PR DESCRIPTION
**Description**:

Without this change, when attempting to deploy a helm chart with an empty value for `OPERATOR_ID_ETH_SENDRAWTRANSACTION`,`OPERATOR_KEY_ETH_SENDRAWTRANSACTION`, or `CHAIN_ID` resulted in this error 
```
Error: UPGRADE FAILED: error validating "": error validating data: [unknown object type "nil" in Secret.data.CHAIN_ID, unknown object type "nil" in Secret.data.OPERATOR_ID_ETH_SENDRAWTRANSACTION, unknown object type "nil" in Secret.data.OPERATOR_KEY_ETH_SENDRAWTRANSACTION]
helm.go:84: [debug] error validating "": error validating data: [unknown object type "nil" in Secret.data.CHAIN_ID, unknown object type "nil" in Secret.data.OPERATOR_ID_ETH_SENDRAWTRANSACTION, unknown object type "nil" in Secret.data.OPERATOR_KEY_ETH_SENDRAWTRANSACTION]
```

This change corrects that error by setting a default of `""` but using the printf %q to ensure the default is safely escaped.  "%q a double-quoted string safely escaped" from [https://helm.sh/docs/chart_template_guide/function_list/#printf]
