### PR TITLE
RPC API Batch 1 - Acceptance Test - Improvement

### DIFF
--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -286,7 +286,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 const currentBlock = Number(await relay.call('eth_blockNumber', [], requestId));
                 let blocksBehindLatest = 0;
                 if(currentBlock > 10) {
-                    blocksBehindLatest = Number(await relay.call('eth_blockNumber', [], requestId)) - 10;
+                    blocksBehindLatest = currentBlock - 10;
                 }
                 const logs = await relay.call('eth_getLogs', [{
                     'fromBlock': EthImpl.numberTo0x(blocksBehindLatest),


### PR DESCRIPTION
**Description**:
changed the hardcoded value of "blocksBehindLatest" from 40 to 10, since is enough for the purpose of the test and gives higher chances that even if the tests and the hardware used to run the tests improves in the future, the test will continue to work.

Update:
Only if currentBlock is bigger than 10, we fetch past 10 blocks, otherwise we fetch everything since the block 0.

**Related issue(s)**:

Fixes #1049 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
