### PR TITLE
chore: update runners and codeowners to use hiero runners and teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,21 +2,21 @@
 ##### Global Protection Rule ######
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below
-*                                               @hiero-ledger/hiero-json-rpc-relay-maintainers
+*                                               @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers 
 
 #########################
 ##### Hedera Relay ######
 #########################
-/packages/relay/                                @hiero-ledger/hiero-json-rpc-relay-committers
-/packages/server/                               @Nana-EC @hiero-ledger/hiero-json-rpc-relay-committers
-/packages/ws-server/                            @georgi-l95 @Ivo-Yankov @hiero-ledger/hiero-json-rpc-relay-committers
+/packages/relay/                                @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers 
+/packages/server/                               @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers 
+/packages/ws-server/                            @Ivo-Yankov @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers 
 
 ###############################
 ##### Tools and Examples ######
 ###############################
-/dapp-example/                                  @georgi-l95 @Ivo-Yankov @hiero-ledger/hiero-json-rpc-relay-committers
-/k6/                                            @hiero-ledger/hiero-json-rpc-relay-committers
-/tools/                                         @georgi-l95 @Ivo-Yankov @hiero-ledger/hiero-json-rpc-relay-committers
+/dapp-example/                                  @Ivo-Yankov @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers
+/k6/                                            @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers
+/tools/                                         @Ivo-Yankov @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers
 
 ########################
 #####  Core Files  ######
@@ -25,16 +25,16 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-json-rpc-relay-maintainers
+/.github/                                       @hiero-ledger/github-maintainers @hiero-ledger/github-committers
 /.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-json-rpc-relay-maintainers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                     @hiero-ledger/github-maintainers
 
 # Protect the repository root files
-/README.md                                      @Nana-EC @hiero-ledger/github-maintainers @hiero-ledger/github-maintainers @hiero-ledger/hiero-json-rpc-relay-committers
-**/LICENSE                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-json-rpc-relay-maintainers
+/README.md                                      @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-json-rpc-relay-committers @hiero-ledger/hiero-json-rpc-relay-maintainers 
+**/LICENSE                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/tsc 
 
 # Git Ignore definitions
-**/.gitignore                                   @Nana-EC @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/github-maintainers @hiero-ledger/github-maintainers @hiero-ledger/hiero-json-rpc-relay-committers
-**/.gitignore.*                                 @Nana-EC @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/github-maintainers @hiero-ledger/github-maintainers @hiero-ledger/hiero-json-rpc-relay-committers
+**/.gitignore                                   @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-json-rpc-relay-committers
+**/.gitignore.*                                 @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-json-rpc-relay-committers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,14 +9,14 @@
 #########################
 /packages/relay/                                @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers 
 /packages/server/                               @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers 
-/packages/ws-server/                            @Ivo-Yankov @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers 
+/packages/ws-server/                            @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers 
 
 ###############################
 ##### Tools and Examples ######
 ###############################
-/dapp-example/                                  @Ivo-Yankov @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers
+/dapp-example/                                  @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers
 /k6/                                            @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers
-/tools/                                         @Ivo-Yankov @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers
+/tools/                                         @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/hiero-json-rpc-relay-committers
 
 ########################
 #####  Core Files  ######

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,21 +2,21 @@
 ##### Global Protection Rule ######
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below
-*                                               @hashgraph/hedera-smart-contracts @hashgraph/hedera-smart-contracts-product 
+*                                               @hiero-ledger/hiero-json-rpc-relay-maintainers
 
 #########################
 ##### Hedera Relay ######
 #########################
-/packages/relay/                                @hashgraph/hedera-smart-contracts @hashgraph/hedera-smart-contracts-product
-/packages/server/                               @Nana-EC @hashgraph/hedera-smart-contracts @hashgraph/hedera-smart-contracts-product
-/packages/ws-server/                            @georgi-l95 @Ivo-Yankov @hashgraph/hedera-smart-contracts @hashgraph/hedera-smart-contracts-product
+/packages/relay/                                @hiero-ledger/hiero-json-rpc-relay-committers
+/packages/server/                               @Nana-EC @hiero-ledger/hiero-json-rpc-relay-committers
+/packages/ws-server/                            @georgi-l95 @Ivo-Yankov @hiero-ledger/hiero-json-rpc-relay-committers
 
 ###############################
 ##### Tools and Examples ######
 ###############################
-/dapp-example/                                  @georgi-l95 @Ivo-Yankov @hashgraph/hedera-smart-contracts @hashgraph/hedera-smart-contracts-product
-/k6/                                            @hashgraph/hedera-smart-contracts @hashgraph/hedera-smart-contracts-product
-/tools/                                         @georgi-l95 @Ivo-Yankov @hashgraph/hedera-smart-contracts @hashgraph/hedera-smart-contracts-product
+/dapp-example/                                  @georgi-l95 @Ivo-Yankov @hiero-ledger/hiero-json-rpc-relay-committers
+/k6/                                            @hiero-ledger/hiero-json-rpc-relay-committers
+/tools/                                         @georgi-l95 @Ivo-Yankov @hiero-ledger/hiero-json-rpc-relay-committers
 
 ########################
 #####  Core Files  ######
@@ -25,16 +25,16 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering @hashgraph/release-engineering-managers
-/.github/workflows/                             @hashgraph/platform-ci @hashgraph/platform-ci-committers @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts-managers
+/.github/                                       @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-json-rpc-relay-maintainers
+/.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-json-rpc-relay-maintainers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
-/CODEOWNERS                                     @hashgraph/release-engineering-managers
+/CODEOWNERS                                     @hiero-ledger/github-maintainers
 
 # Protect the repository root files
-/README.md                                      @Nana-EC @hashgraph/release-engineering-managers @hashgraph/platform-ci @hashgraph/hedera-smart-contracts @hashgraph/hedera-smart-contracts-product 
-**/LICENSE                                      @hashgraph/release-engineering-managers @hashgraph/hedera-smart-contracts-managers
+/README.md                                      @Nana-EC @hiero-ledger/github-maintainers @hiero-ledger/github-maintainers @hiero-ledger/hiero-json-rpc-relay-committers
+**/LICENSE                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-json-rpc-relay-maintainers
 
 # Git Ignore definitions
-**/.gitignore                                   @Nana-EC @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/platform-ci @hashgraph/hedera-smart-contracts @hashgraph/hedera-smart-contracts-product 
-**/.gitignore.*                                 @Nana-EC @hashgraph/release-engineering @hashgraph/release-engineering-managers @hashgraph/platform-ci @hashgraph/hedera-smart-contracts @hashgraph/hedera-smart-contracts-product 
+**/.gitignore                                   @Nana-EC @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/github-maintainers @hiero-ledger/github-maintainers @hiero-ledger/hiero-json-rpc-relay-committers
+**/.gitignore.*                                 @Nana-EC @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/github-maintainers @hiero-ledger/github-maintainers @hiero-ledger/hiero-json-rpc-relay-committers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,16 +25,16 @@
 # NOTE: Must be placed last to ensure enforcement over all other rules
 
 # Protection Rules for Github Configuration Files and Actions Workflows
-/.github/                                       @hiero-ledger/github-maintainers @hiero-ledger/github-committers
-/.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-json-rpc-relay-maintainers
+/.github/                                       @hiero-ledger/github-maintainers
+/.github/workflows/                             @hiero-ledger/github-maintainers @hiero-ledger/hiero-json-rpc-relay-maintainers
 
 # Self-protection for root CODEOWNERS files (this file should not exist and should definitely require approval)
 /CODEOWNERS                                     @hiero-ledger/github-maintainers
 
 # Protect the repository root files
-/README.md                                      @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-json-rpc-relay-committers @hiero-ledger/hiero-json-rpc-relay-maintainers 
+/README.md                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-json-rpc-relay-committers @hiero-ledger/hiero-json-rpc-relay-maintainers 
 **/LICENSE                                      @hiero-ledger/github-maintainers @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/tsc 
 
 # Git Ignore definitions
-**/.gitignore                                   @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-json-rpc-relay-committers
-**/.gitignore.*                                 @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/github-maintainers @hiero-ledger/github-committers @hiero-ledger/hiero-json-rpc-relay-committers
+**/.gitignore                                   @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/github-maintainers @hiero-ledger/hiero-json-rpc-relay-committers
+**/.gitignore.*                                 @hiero-ledger/hiero-json-rpc-relay-maintainers @hiero-ledger/github-maintainers @hiero-ledger/hiero-json-rpc-relay-committers

--- a/.github/workflows/acceptance-public.yml
+++ b/.github/workflows/acceptance-public.yml
@@ -38,7 +38,7 @@ jobs:
     if: ${{ !cancelled() }}
     needs:
       - release-tests
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/acceptance-workflow.yml
+++ b/.github/workflows/acceptance-workflow.yml
@@ -40,7 +40,7 @@ on:
 
 jobs:
   acceptance-workflow:
-    runs-on: smart-contracts-linux-large
+    runs-on: hiero-smart-contracts-linux-large
     timeout-minutes: 50
     permissions:
       contents: read

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -174,7 +174,7 @@ jobs:
       - websocket-batch-3
       - cacheservice
 
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/charts.yml
+++ b/.github/workflows/charts.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   lint:
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
@@ -41,7 +41,7 @@ jobs:
         run: ct lint --config .github/ct.yaml --all
 
   install:
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/conformity-workflow.yml
+++ b/.github/workflows/conformity-workflow.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   clone-and-build-execution-apis:
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
 
     steps:
       - name: Harden Runner
@@ -47,7 +47,7 @@ jobs:
           path: ./execution-apis/openrpc.json
 
   build-and-test:
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     needs: clone-and-build-execution-apis
 
     steps:

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   setup-local-hedera:
     name: Dapp Tests
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     timeout-minutes: 45 # Set to 45 minutes for now
     permissions:
       contents: write

--- a/.github/workflows/dev-tool-workflow.yml
+++ b/.github/workflows/dev-tool-workflow.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   dev-tool-workflow:
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     permissions:
       contents: write
       actions: read

--- a/.github/workflows/flow-pr-title-check.yml
+++ b/.github/workflows/flow-pr-title-check.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   title-check:
     name: Title Check
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     if: ${{ !github.event.pull_request.head.repo.fork }}
     permissions:
       statuses: write

--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: true
 
     name: Foundry project
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/manual-testing.yml
+++ b/.github/workflows/manual-testing.yml
@@ -192,7 +192,7 @@ jobs:
       - websocket-batch-3
       - cacheservice
 
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/postman.yml
+++ b/.github/workflows/postman.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   setup-local-hedera:
     name: Postman Endpoint Tests
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     permissions:
       contents: write
       actions: read

--- a/.github/workflows/pr-label-milestone-check.yml
+++ b/.github/workflows/pr-label-milestone-check.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check_pr:
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/release-acceptance.yml
+++ b/.github/workflows/release-acceptance.yml
@@ -18,7 +18,7 @@ permissions:
   
 jobs:
   release-acceptance-test:
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   branch_bump_tag:
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     env:
       RELEASE_NOTES_FILENAME: release_notes
     outputs:
@@ -141,7 +141,7 @@ jobs:
 
   create_snapshot_pr:
     name: Create snapshot PR
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     needs: branch_bump_tag
     if: ${{ needs.branch_bump_tag.outputs.create_pr == 'true' }}
     env:

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   publish:
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   docker-image-publish:
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
 
     steps:
       - name: Harden Runner
@@ -54,7 +54,7 @@ jobs:
           tags: ${{ env.REGISTRY }}/${{ github.repository }}:${{env.TAG}}
 
   npm-package-artifact:
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
 
     steps:
       - name: Harden Runner
@@ -90,7 +90,7 @@ jobs:
           if-no-files-found: error
 
   helm-chart-release:
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     permissions:
       contents: write
     steps:

--- a/.github/workflows/subgraph.yml
+++ b/.github/workflows/subgraph.yml
@@ -16,7 +16,7 @@ permissions:
     
 jobs:
   subgraph-workflow:
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     permissions:
       contents: write
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   test-node:
     name: Tests
-    runs-on: smart-contracts-linux-medium
+    runs-on: hiero-smart-contracts-linux-medium
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0


### PR DESCRIPTION
**Description**:

- Update the CODEOWNERS file to use the `hiero-ledger` organization teams
- Update actions to use the `hiero-ledger` runners

**Related Issue(s)**:

 Fixes #3560
 