### PR TITLE
ci: Add gh-pages-sync workflow to json-rpc-relay

### DIFF
--- a/.github/workflows/gh-pages-sync.yaml
+++ b/.github/workflows/gh-pages-sync.yaml
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: GitHub Pages Sync
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 * * * *"
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Sync Pages
+    runs-on: hiero-smart-contracts-linux-medium
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: "hashgraph/hedera-json-rpc-relay"
+          ref: gh-pages
+          fetch-depth: "0"
+          token: ${{ secrets.GH_ACCESS_TOKEN_HG }}
+
+      - name: Add Remote
+        run: git remote add HIERO https://github.com/hiero-ledger/hiero-json-rpc-relay.git
+
+      - name: Get the latest from HIERO
+        run: git fetch HIERO
+
+      - name: Sync gh-pages locally
+        run: git rebase --merge HIERO/gh-pages
+
+      - name: Push updates
+        run: git push --force --set-upstream origin gh-pages


### PR DESCRIPTION
**Description**:
Adds the gh-pages-sync.yaml workflow to sync the public hiero-ledger/hiero-json-rpc-relay repository and the private hashgraph/hedera-json-rpc-relay.

**Related Issue(s)**:
Fixes #3577
