### PR TITLE
fix: change urls to repo in charts directory

### DIFF
--- a/charts/hedera-json-rpc-relay-websocket/Chart.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-appVersion: "0.67.0-SNAPSHOT"
-description: Helm chart deployment of the hashgraph/hedera-json-rpc-relay web socket server
-home: https://github.com/hashgraph/hedera-json-rpc-relay
+appVersion: '0.67.0-SNAPSHOT'
+description: Helm chart deployment of the hiero-ledger/hiero-json-rpc-relay web socket server
+home: https://github.com/hiero-ledger/hiero-json-rpc-relay
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
 keywords:
   - blockchain
@@ -20,6 +20,6 @@ maintainers:
     email: engsmartcontracts@hedera.com
 name: hedera-json-rpc-relay-websocket
 sources:
-  - https://github.com/hashgraph/hedera-json-rpc-relay
+  - https://github.com/hiero-ledger/hiero-json-rpc-relay
 type: application
 version: 0.67.0-SNAPSHOT

--- a/charts/hedera-json-rpc-relay-websocket/Chart.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: '0.67.0-SNAPSHOT'
+appVersion: "0.67.0-SNAPSHOT"
 description: Helm chart deployment of the hiero-ledger/hiero-json-rpc-relay web socket server
 home: https://github.com/hiero-ledger/hiero-json-rpc-relay
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/charts/hedera-json-rpc-relay-websocket/values.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/values.yaml
@@ -20,7 +20,7 @@ config:
   MIRROR_NODE_RETRY_DELAY: 250
   MIRROR_NODE_LIMIT_PARAM: 100
   MIRROR_NODE_URL: ''
-  SUBSCRIPTIONS_ENABLED: true # must be true for websocket
+  SUBSCRIPTIONS_ENABLED: true  # must be true for websocket
   WEB_SOCKET_PORT: 8546
   WEB_SOCKET_HTTP_PORT: 8547
   WS_CONNECTION_LIMIT_PER_IP: 10
@@ -90,7 +90,7 @@ podSecurityContext:
 ports:
   - name: websocket
     containerPort: 8546
-  - name: metrics # port for http endpoints (metrics and health)
+  - name: metrics  # port for http endpoints (metrics and health)
     containerPort: 8547
 
 replicaCount: 2

--- a/charts/hedera-json-rpc-relay-websocket/values.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/values.yaml
@@ -20,7 +20,7 @@ config:
   MIRROR_NODE_RETRY_DELAY: 250
   MIRROR_NODE_LIMIT_PARAM: 100
   MIRROR_NODE_URL: ''
-  SUBSCRIPTIONS_ENABLED: true  # must be true for websocket
+  SUBSCRIPTIONS_ENABLED: true # must be true for websocket
   WEB_SOCKET_PORT: 8546
   WEB_SOCKET_HTTP_PORT: 8547
   WS_CONNECTION_LIMIT_PER_IP: 10
@@ -47,7 +47,7 @@ global:
 image:
   pullPolicy: IfNotPresent
   registry: ghcr.io
-  repository: hashgraph/hedera-json-rpc-relay
+  repository: hiero-ledger/hiero-json-rpc-relay
   # Overrides the image tag whose default is the chart appVersion.
   tag: ''
 
@@ -90,7 +90,7 @@ podSecurityContext:
 ports:
   - name: websocket
     containerPort: 8546
-  - name: metrics  # port for http endpoints (metrics and health)
+  - name: metrics # port for http endpoints (metrics and health)
     containerPort: 8547
 
 replicaCount: 2

--- a/charts/hedera-json-rpc-relay/Chart.yaml
+++ b/charts/hedera-json-rpc-relay/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-appVersion: "0.67.0-SNAPSHOT"
-description: Helm chart deployment of the hashgraph/hedera-json-rpc-relay
-home: https://github.com/hashgraph/hedera-json-rpc-relay
+appVersion: '0.67.0-SNAPSHOT'
+description: Helm chart deployment of the hiero-ledger/hiero-json-rpc-relay
+home: https://github.com/hiero-ledger/hiero-json-rpc-relay
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
 keywords:
   - blockchain
@@ -19,6 +19,6 @@ maintainers:
     email: engsmartcontracts@hedera.com
 name: hedera-json-rpc-relay
 sources:
-  - https://github.com/hashgraph/hedera-json-rpc-relay
+  - https://github.com/hiero-ledger/hiero-json-rpc-relay
 type: application
 version: 0.67.0-SNAPSHOT

--- a/charts/hedera-json-rpc-relay/Chart.yaml
+++ b/charts/hedera-json-rpc-relay/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: '0.67.0-SNAPSHOT'
+appVersion: "0.67.0-SNAPSHOT"
 description: Helm chart deployment of the hiero-ledger/hiero-json-rpc-relay
 home: https://github.com/hiero-ledger/hiero-json-rpc-relay
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/charts/hedera-json-rpc-relay/templates/cronjob.yaml
+++ b/charts/hedera-json-rpc-relay/templates/cronjob.yaml
@@ -50,6 +50,6 @@ spec:
               command: 
                 - /bin/sh
                 - -c
-                - wget https://raw.githubusercontent.com/hashgraph/hedera-json-rpc-relay/main/charts/hedera-json-rpc-relay/postman.json ; newman run postman.json --env-var baseUrl=http://{{ include "json-rpc-relay.fullname" . }}:{{ .Values.service.port }}                     
+                - wget https://raw.githubusercontent.com/hiero-ledger/hiero-json-rpc-relay/main/charts/hedera-json-rpc-relay/postman.json ; newman run postman.json --env-var baseUrl=http://{{ include "json-rpc-relay.fullname" . }}:{{ .Values.service.port }}                     
 {{- end }}
             

--- a/charts/hedera-json-rpc-relay/value-test.yaml
+++ b/charts/hedera-json-rpc-relay/value-test.yaml
@@ -3,7 +3,7 @@
 replicaCount: 2
 
 image:
-  repository: ghcr.io/hashgraph/hedera-json-rpc-relay
+  repository: ghcr.io/hiero-ledger/hiero-json-rpc-relay
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: ''

--- a/charts/hedera-json-rpc-relay/values.yaml
+++ b/charts/hedera-json-rpc-relay/values.yaml
@@ -79,7 +79,7 @@ global:
 image:
   pullPolicy: IfNotPresent
   registry: ghcr.io
-  repository: hashgraph/hedera-json-rpc-relay
+  repository: hiero-ledger/hiero-json-rpc-relay
   # Overrides the image tag whose default is the chart appVersion.
   tag: ''
 

--- a/charts/hedera-json-rpc/Chart.yaml
+++ b/charts/hedera-json-rpc/Chart.yaml
@@ -1,16 +1,16 @@
 apiVersion: v2
-appVersion: '0.67.0-SNAPSHOT'
+appVersion: "0.67.0-SNAPSHOT"
 dependencies:
   - alias: relay
     condition: relay.enabled
     name: hedera-json-rpc-relay
     repository: file://../hedera-json-rpc-relay
-    version: '>=0.24.0-0'
+    version: ">=0.24.0-0"
   - alias: ws
     condition: ws.enabled
     name: hedera-json-rpc-relay-websocket
     repository: file://../hedera-json-rpc-relay-websocket
-    version: '>=0.24.0-0'
+    version: ">=0.24.0-0"
 description: Umbrella Helm chart deployment of the hiero-ledger/hiero-json-rpc products
 home: https://github.com/hiero-ledger/hiero-json-rpc-relay
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067

--- a/charts/hedera-json-rpc/Chart.yaml
+++ b/charts/hedera-json-rpc/Chart.yaml
@@ -1,18 +1,18 @@
 apiVersion: v2
-appVersion: "0.67.0-SNAPSHOT"
+appVersion: '0.67.0-SNAPSHOT'
 dependencies:
   - alias: relay
     condition: relay.enabled
     name: hedera-json-rpc-relay
     repository: file://../hedera-json-rpc-relay
-    version: ">=0.24.0-0"
+    version: '>=0.24.0-0'
   - alias: ws
     condition: ws.enabled
     name: hedera-json-rpc-relay-websocket
     repository: file://../hedera-json-rpc-relay-websocket
-    version: ">=0.24.0-0"
-description: Umbrella Helm chart deployment of the hashgraph/hedera-json-rpc products
-home: https://github.com/hashgraph/hedera-json-rpc-relay
+    version: '>=0.24.0-0'
+description: Umbrella Helm chart deployment of the hiero-ledger/hiero-json-rpc products
+home: https://github.com/hiero-ledger/hiero-json-rpc-relay
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
 keywords:
   - blockchain
@@ -29,6 +29,6 @@ maintainers:
     email: engsmartcontracts@hedera.com
 name: hedera-json-rpc
 sources:
-  - https://github.com/hashgraph/hedera-json-rpc-relay
+  - https://github.com/hiero-ledger/hiero-json-rpc-relay
 type: application
 version: 0.67.0-SNAPSHOT


### PR DESCRIPTION
**Description**:
This PR updates the links in the charts directory to point to the new repo home URL.

**Related issue(s)**:

Fixes #3582 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
