### PR TITLE
fix: fixed net_listening to return boolean `true`

### DIFF
--- a/charts/hedera-json-rpc-relay/postman.json
+++ b/charts/hedera-json-rpc-relay/postman.json
@@ -862,7 +862,7 @@
               "pm.test(\"Success\", () => {",
               "    var response = pm.response.json();",
               "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-              "    pm.expect(response.result).to.equal(\"false\");",
+              "    pm.expect(response.result).to.be.true;",
               "    pm.expect(response.id).to.equal(\"test_id\");",
               "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
               "});",

--- a/packages/relay/src/lib/net.ts
+++ b/packages/relay/src/lib/net.ts
@@ -15,7 +15,7 @@ export class NetImpl implements Net {
    * We always return true for this.
    */
   listening(): boolean {
-    return false;
+    return true;
   }
 
   /**

--- a/packages/relay/tests/lib/net.spec.ts
+++ b/packages/relay/tests/lib/net.spec.ts
@@ -15,7 +15,7 @@ describe('Net', async function () {
   it('should execute "net_listening"', function () {
     relay = new Relay(logger, new Registry());
     const result = relay.net().listening();
-    expect(result).to.eq(false);
+    expect(result).to.eq(true);
   });
 
   it('should execute "net_version"', function () {

--- a/packages/server/src/routes/netRoutes.ts
+++ b/packages/server/src/routes/netRoutes.ts
@@ -10,10 +10,10 @@ const defineNetRoutes = function (app: KoaJsonRpc, relay: Relay, logger: pino.Lo
   /**
    * Returns true if client is actively listening for network connections.
    *
-   * @returns false
+   * @returns boolean
    */
   app.useRpc('net_listening', async () => {
-    return logAndHandleResponse('net_listening', [], () => '' + relay.net().listening(), app, logger);
+    return logAndHandleResponse('net_listening', [], () => relay.net().listening(), app, logger);
   });
 
   /**

--- a/packages/server/tests/acceptance/data/conformity-tests-batch-3.json
+++ b/packages/server/tests/acceptance/data/conformity-tests-batch-3.json
@@ -36,7 +36,7 @@
     },
     "net_listening": {
       "request": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"net_listening\",\"params\":[]}",
-      "response": "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":\"false\"}"
+      "response": "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":true}"
     },
     "net_version": {
       "request": "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"net_version\",\"params\":[]}",

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -601,7 +601,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
 
     it('should execute "net_listening"', async function () {
       const res = await relay.call(RelayCalls.ETH_ENDPOINTS.NET_LISTENING, [], requestId);
-      expect(res).to.be.equal('false');
+      expect(res).to.be.equal(true);
     });
 
     it('should execute "net_version"', async function () {

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -306,7 +306,7 @@ describe('RPC Server', function () {
     });
 
     BaseTest.defaultResponseChecks(res);
-    expect(res.data.result).to.be.equal('false');
+    expect(res.data.result).to.be.equal(true);
   });
 
   it('should execute "web3_sha"', async function () {

--- a/packages/server/tests/postman.json
+++ b/packages/server/tests/postman.json
@@ -862,7 +862,7 @@
               "pm.test(\"Success\", () => {",
               "    var response = pm.response.json();",
               "    pm.expect(JSON.stringify(response.error)).to.equal(undefined);",
-              "    pm.expect(response.result).to.equal(\"false\");",
+              "    pm.expect(response.result).to.be.true;",
               "    pm.expect(response.id).to.equal(\"test_id\");",
               "    pm.expect(response.jsonrpc).to.equal(\"2.0\");",
               "});",


### PR DESCRIPTION
**Description**:
This PR updates `net_listening` to return a boolean `true` instead of the previous string `'false'`. It also updates all test coverage to align with the new logic.

**Related issue(s)**:

Fixes #3590

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
