### PR TITLE
ci: Add GPG sign-off to commit options

### DIFF
--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -122,7 +122,7 @@ jobs:
         with:
           commit_author: ${{ steps.gpg_importer.outputs.name }} <${{ steps.gpg_importer.outputs.email }}>
           commit_message: 'chore(release): Bump versions for ${{ env.RELEASE_TAG }}'
-          commit_options: '--no-verify --signoff'
+          commit_options: '--no-verify --signoff --gpg-sign'
           commit_user_name: ${{ steps.gpg_importer.outputs.name }}
           commit_user_email: ${{ steps.gpg_importer.outputs.email }}
           tagging_message: ${{ env.RELEASE_TAG }}


### PR DESCRIPTION
**Description**:

Add `--gpg-sign` to the commit options in release workflow commit-and-tag step

**Related Issue(s)**:
Fixes #3603 