### PR TITLE
chore: fix k6 issues found when running release `0.67` tests

### DIFF
--- a/k6/README.md
+++ b/k6/README.md
@@ -5,7 +5,7 @@ This module covers the [k6](https://k6.io/) based performance tests for the Hede
 ## Install k6
 
 1. The k6 test engine is needed to run the tests. Please follow
-   the [official documentation](https://k6.io/docs/getting-started/installation/) to install k6.
+   the [official documentation](https://grafana.com/docs/k6/latest/set-up/install-k6/) to install k6.
 
 2. Node packages
    ```shell

--- a/k6/src/prepare/prep.js
+++ b/k6/src/prepare/prep.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import Greeter from './contracts/Greeter.json' assert { type: 'json' };
+import Greeter from './contracts/Greeter.json' with { type: 'json' };
 import { ethers, formatEther, parseEther } from 'ethers';
 import * as fs from 'fs';
 import path from 'path';

--- a/k6/src/scenarios/test/index.js
+++ b/k6/src/scenarios/test/index.js
@@ -43,7 +43,6 @@ import * as eth_syncing from './eth_syncing.js';
 import * as net_listening from './net_listening.js';
 import * as net_version from './net_version.js';
 import * as web3_clientVersion from './web3_clientVersion.js';
-import * as web3_client_version from './web3_client_version.js'
 
 // add test modules here
 const tests = {


### PR DESCRIPTION
**Description**:

This PR fixes some issues found when running release `0.67` tests. In particular

- Fix `npm run prep` script on Node 23.
- Fix broken link in `README`.
- Remove `web3_client_version` test module.


<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #3642.
Fixes #3643.
Fixes #3644.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
