### PR TITLE
fix: eth_sendRawTransaction now handles malformed RLP data correctly

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1935,8 +1935,9 @@ export class EthImpl implements Eth {
     networkGasPriceInWeiBars: number,
     requestDetails: RequestDetails,
   ): Promise<EthersTransaction> {
-    const parsedTx = Precheck.parseTxIfNeeded(transaction);
+    let parsedTx;
     try {
+      parsedTx = Precheck.parseTxIfNeeded(transaction);
       if (this.logger.isLevelEnabled('debug')) {
         this.logger.debug(
           `${requestDetails.formattedRequestId} Transaction undergoing prechecks: transaction=${JSON.stringify(
@@ -1949,6 +1950,9 @@ export class EthImpl implements Eth {
       await this.precheck.sendRawTransactionCheck(parsedTx, networkGasPriceInWeiBars, requestDetails);
       return parsedTx;
     } catch (e: any) {
+      if (e.code === 'INVALID_ARGUMENT') {
+        throw predefined.INVALID_ARGUMENTS(e.message.toString());
+      }
       this.logger.error(
         `${requestDetails.formattedRequestId} Precheck failed: transaction=${JSON.stringify(parsedTx)}`,
       );

--- a/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_sendRawTransaction.spec.ts
@@ -125,8 +125,8 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
       sdkClientStub = sinon.createStubInstance(SDKClient);
       sinon.stub(hapiServiceInstance, 'getSDKClient').returns(sdkClientStub);
       restMock.onGet(accountEndpoint).reply(200, JSON.stringify(ACCOUNT_RES));
-   JSON.stringify(   restMock.onGet(receiverAccountEndpoint).reply(200, JSON.stringify(RECEIVER_ACCOUNT_RES)));
-   JSON.stringify(   restMock.onGet(networkExchangeRateEndpoint).reply(200, JSON.stringify(mockedExchangeRate)));
+      JSON.stringify(restMock.onGet(receiverAccountEndpoint).reply(200, JSON.stringify(RECEIVER_ACCOUNT_RES)));
+      JSON.stringify(restMock.onGet(networkExchangeRateEndpoint).reply(200, JSON.stringify(mockedExchangeRate)));
     });
 
     afterEach(() => {
@@ -192,6 +192,18 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
         false,
         ethImpl,
         [txHash, requestDetails],
+      );
+    });
+
+    it('should return a predefined INVALID_ARGUMENTS when transaction has invalid format', async function () {
+      const invalidTx =
+        '0xf8748201280585800e8dfc0085800e8dfc00832dc6c094aca85ef7e1fce27079bbf99b60fcf6fd19b99b248502540be40080c001a0210446cfb671c3174392410d52fa3cd58723d8417e40cc67c6225b8f7e3ff693a02674b392846c59f783ea96655d39560956dd987051972064a5d853cea0b6f6d711';
+      await RelayAssertions.assertRejection(
+        predefined.INVALID_ARGUMENTS('invalid hex string'),
+        ethImpl.sendRawTransaction,
+        false,
+        ethImpl,
+        [invalidTx, requestDetails],
       );
     });
 

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -1541,6 +1541,17 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           await Assertions.assertPredefinedRpcError(error, sendRawTransaction, true, relay, [signedTx, requestDetails]);
         });
 
+        it('should fail "eth_sendRawTransaction" when transaction has invalid format', async function () {
+          const invalidTx =
+            '0xf8748201280585800e8dfc0085800e8dfc00832dc6c094aca85ef7e1fce27079bbf99b60fcf6fd19b99b248502540be40080c001a0210446cfb671c3174392410d52fa3cd58723d8417e40cc67c6225b8f7e3ff693a02674b392846c59f783ea96655d39560956dd987051972064a5d853cea0b6f6d711';
+          const error = predefined.INVALID_ARGUMENTS('invalid hex string');
+
+          await Assertions.assertPredefinedRpcError(error, sendRawTransaction, true, relay, [
+            invalidTx,
+            requestDetails,
+          ]);
+        });
+
         it('should fail "eth_sendRawTransaction" for EIP155 transaction with not enough gas', async function () {
           const gasLimit = 100;
           const transaction = {

--- a/packages/ws-server/tests/acceptance/sendRawTransaction.spec.ts
+++ b/packages/ws-server/tests/acceptance/sendRawTransaction.spec.ts
@@ -39,10 +39,8 @@ describe('@web-socket-batch-2 eth_sendRawTransaction', async function () {
   const requestId = 'sendRawTransactionTest_ws-server';
   const requestDetails = new RequestDetails({ requestId: requestId, ipAddress: '0.0.0.0' });
 
-  let tx: any,
-    sendHbarToProxyContractDeployerTx: any,
-    accounts: AliasAccount[] = [],
-    ethersWsProvider: WebSocketProvider;
+  let tx: any, sendHbarToProxyContractDeployerTx: any, ethersWsProvider: WebSocketProvider;
+  const accounts: AliasAccount[] = [];
 
   before(async () => {
     const initialAccount: AliasAccount = global.accounts[0];
@@ -112,6 +110,16 @@ describe('@web-socket-batch-2 eth_sendRawTransaction', async function () {
       expect(fromAccountInfo.evm_address).to.eq(accounts[0].address.toLowerCase());
     });
 
+    it(`Should fail eth_sendRawTransaction on Standard Web Socket when transaction has invalid format`, async () => {
+      const invalidTx =
+        '0xf8748201280585800e8dfc0085800e8dfc00832dc6c094aca85ef7e1fce27079bbf99b60fcf6fd19b99b248502540be40080c001a0210446cfb671c3174392410d52fa3cd58723d8417e40cc67c6225b8f7e3ff693a02674b392846c59f783ea96655d39560956dd987051972064a5d853cea0b6f6d711';
+      const response = await WsTestHelper.sendRequestToStandardWebSocket(METHOD_NAME, [invalidTx], 1000);
+
+      const expectedError = predefined.INVALID_ARGUMENTS('invalid hex string');
+      expect(response.error.code).to.eq(expectedError.code);
+      expect(response.error.message).to.contain(expectedError.message);
+    });
+
     it(`Should execute eth_sendRawTransaction on Standard Web Socket for the deterministic deployment transaction`, async () => {
       // send gas money to the proxy deployer
       sendHbarToProxyContractDeployerTx.nonce = await global.relay.getAccountNonce(accounts[0].address);
@@ -176,6 +184,18 @@ describe('@web-socket-batch-2 eth_sendRawTransaction', async function () {
 
       expect(txReceipt.to).to.eq(accounts[2].address.toLowerCase());
       expect(fromAccountInfo.evm_address).to.eq(accounts[1].address.toLowerCase());
+    });
+
+    it(`Should fail eth_sendRawTransaction on Ethers Web Socket Provider when transaction has invalid format`, async () => {
+      const invalidTx = '0xinvalidtransactionformat';
+      try {
+        await ethersWsProvider.send(METHOD_NAME, [invalidTx]);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        const expectedError = predefined.INVALID_ARGUMENTS('invalid hex string');
+        expect(error.info.error.code).to.eq(expectedError.code);
+        expect(error.info.error.message).to.contain(expectedError.message);
+      }
     });
 
     it(`Should execute eth_sendRawTransaction on Ethers Web Socket Provider for the deterministic deployment transaction`, async () => {


### PR DESCRIPTION
**Description**:
In this PR, the `eth_sendRawTransaction` logic now handles malformed RLP data correctly by checking for INVALID_ARGUMENT error and returning a predifined error and 400 status code.

**Related issue(s)**:

Fixes #3652 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
