### PR TITLE
feat: support non-zero shard/realm

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -1398,18 +1398,23 @@ export class MirrorNodeClient {
           : Promise.reject(),
       ];
 
-      // only add long zero evm addresses for tokens as they do not refer to actual contract addresses but rather encoded entity nums
-      if (entityIdentifier.startsWith(constants.LONG_ZERO_PREFIX)) {
-        promises.push(
-          searchableTypes.find((t) => t === constants.TYPE_TOKEN)
-            ? buildPromise(
-                this.getTokenById(`0.0.${parseInt(entityIdentifier, 16)}`, requestDetails, retries).catch(() => {
-                  return null;
-                }),
-              )
-            : Promise.reject(),
-        );
-      }
+      const toEntityId = (eid: string) => {
+        eid = eid.slice(2);
+        const shard = eid.slice(0, 4 * 2);
+        const realm = eid.slice(4 * 2, 12 * 2);
+        const num = eid.slice(12 * 2);
+        return `${parseInt(shard, 16)}.${parseInt(realm, 16)}.${parseInt(num, 16)}`;
+      };
+
+      promises.push(
+        searchableTypes.find((t) => t === constants.TYPE_TOKEN)
+          ? buildPromise(
+              this.getTokenById(toEntityId(entityIdentifier), requestDetails, retries).catch(() => {
+                return null;
+              }),
+            )
+          : Promise.reject(),
+      );
 
       // maps the promises with indices of the promises array
       // because there is no such method as Promise.anyWithIndex in js

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -1398,12 +1398,12 @@ export class MirrorNodeClient {
           : Promise.reject(),
       ];
 
-      const toEntityId = (eid: string) => {
-        eid = eid.slice(2);
-        const shard = eid.slice(0, 4 * 2);
-        const realm = eid.slice(4 * 2, 12 * 2);
-        const num = eid.slice(12 * 2);
-        return `${parseInt(shard, 16)}.${parseInt(realm, 16)}.${parseInt(num, 16)}`;
+      const toEntityId = (address: string) => {
+        address = address.slice(2);
+        const shardNum = address.slice(0, 8);
+        const realmNum = address.slice(8, 24);
+        const accountNum = address.slice(24);
+        return `${parseInt(shardNum, 16)}.${parseInt(realmNum, 16)}.${parseInt(accountNum, 16)}`;
       };
 
       promises.push(

--- a/packages/relay/src/lib/constants.ts
+++ b/packages/relay/src/lib/constants.ts
@@ -110,7 +110,6 @@ export default {
   ETH_FEE_HISTORY_TTL: `${CACHE_TTL.HALF_HOUR}`,
   TRANSACTION_ID_REGEX: /\d{1}\.\d{1}\.\d{1,10}\@\d{1,10}\.\d{1,9}/,
 
-  LONG_ZERO_PREFIX: '0x000000000000',
   CHAIN_IDS: {
     mainnet: 0x127,
     testnet: 0x128,

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2502,7 +2502,7 @@ export class EthImpl implements Eth {
     }
   }
 
-  async resolveEvmAddress(
+  private async resolveEvmAddress(
     address: string,
     requestDetails: RequestDetails,
     searchableTypes = [constants.TYPE_CONTRACT, constants.TYPE_TOKEN, constants.TYPE_ACCOUNT],

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -94,9 +94,6 @@ export class EthImpl implements Eth {
     reward: [],
     oldestBlock: EthImpl.zeroHex,
   };
-  static redirectBytecodePrefix = '6080604052348015600f57600080fd5b506000610167905077618dc65e';
-  static redirectBytecodePostfix =
-    '600052366000602037600080366018016008845af43d806000803e8160008114605857816000f35b816000fdfea2646970667358221220d8378feed472ba49a0005514ef7087017f707b45fb9bf56bb81bb93ff19a238b64736f6c634300080b0033';
   static iHTSAddress = '0x0000000000000000000000000000000000000167';
   static invalidEVMInstruction = '0xfe';
   static blockHashLength = 66;
@@ -2763,8 +2760,11 @@ export class EthImpl implements Eth {
     return numberTo0x(gasPriceForTimestamp);
   }
 
-  private static redirectBytecodeAddressReplace(address: string): string {
-    return `${this.redirectBytecodePrefix}${address.slice(2)}${this.redirectBytecodePostfix}`;
+  static redirectBytecodeAddressReplace(address: string): string {
+    const redirectBytecodePrefix = '6080604052348015600f57600080fd5b506000610167905077618dc65e';
+    const redirectBytecodePostfix =
+      '600052366000602037600080366018016008845af43d806000803e8160008114605857816000f35b816000fdfea2646970667358221220d8378feed472ba49a0005514ef7087017f707b45fb9bf56bb81bb93ff19a238b64736f6c634300080b0033';
+    return `0x${redirectBytecodePrefix}${address.slice(2)}${redirectBytecodePostfix}`;
   }
 
   private static prune0x(input: string): string {

--- a/packages/relay/tests/lib/eth/eth_getCode.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getCode.spec.ts
@@ -21,6 +21,16 @@ import { generateEthTestEnv } from './eth-helpers';
 
 use(chaiAsPromised);
 
+function entityIdToEvmAddress(entityId: string): string {
+  const pad = (num: string, n: number) =>
+    Number(num)
+      .toString(16)
+      .padStart(n * 2, '0');
+  const [shardNum, realmNum, accountNum] = entityId.split('.');
+
+  return `0x${pad(shardNum, 4)}${pad(realmNum, 8)}${pad(accountNum, 8)}`;
+}
+
 describe('@ethGetCode using MirrorNode', async function () {
   this.timeout(10000);
   const { restMock, ethImpl, cacheService } = generateEthTestEnv();
@@ -258,17 +268,8 @@ describe('@ethGetCode using MirrorNode', async function () {
     });
 
     it('should return redirect bytecode for HTS when accountId has non-zero shard/realm', async function () {
-      const pad = (n, b) =>
-        Number(n)
-          .toString(16)
-          .padStart(b * 2, '0');
-      function toAddress(accountId: string) {
-        const [shardNum, realmNum, accountNum] = accountId.split('.');
-        return `0x${pad(shardNum, 4)}${pad(realmNum, 8)}${pad(accountNum, 8)}`;
-      }
-
       const accountId = '1.2.3';
-      const addr = toAddress(accountId);
+      const addr = entityIdToEvmAddress(accountId);
 
       restMock.onGet(`contracts/${addr}`).reply(404, JSON.stringify(null));
       restMock.onGet(`accounts/${addr}?limit=100`).reply(404, JSON.stringify(null));

--- a/packages/relay/tests/lib/eth/eth_getCode.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getCode.spec.ts
@@ -95,11 +95,8 @@ describe('@ethGetCode using MirrorNode', async function () {
       restMock.onGet(`contracts/${HTS_TOKEN_ADDRESS}`).reply(404, JSON.stringify(null));
       restMock.onGet(`accounts/${HTS_TOKEN_ADDRESS}?limit=100`).reply(404, JSON.stringify(null));
       restMock.onGet(`tokens/0.0.${parseInt(HTS_TOKEN_ADDRESS, 16)}`).reply(200, JSON.stringify(DEFAULT_HTS_TOKEN));
-      const redirectBytecode = `6080604052348015600f57600080fd5b506000610167905077618dc65e${HTS_TOKEN_ADDRESS.slice(
-        2,
-      )}600052366000602037600080366018016008845af43d806000803e8160008114605857816000f35b816000fdfea2646970667358221220d8378feed472ba49a0005514ef7087017f707b45fb9bf56bb81bb93ff19a238b64736f6c634300080b0033`;
       const res = await ethImpl.getCode(HTS_TOKEN_ADDRESS, null, requestDetails);
-      expect(res).to.equal(redirectBytecode);
+      expect(res).to.be.equal(EthImpl.redirectBytecodeAddressReplace(HTS_TOKEN_ADDRESS));
     });
 
     it('should return the static bytecode for address(0x167) call', async () => {
@@ -214,10 +211,7 @@ describe('@ethGetCode using MirrorNode', async function () {
       );
 
       const res = await ethImpl.getCode(HTS_TOKEN_ADDRESS, blockNumberAfterCreation, requestDetails);
-      const expectedRedirectBytecode = `6080604052348015600f57600080fd5b506000610167905077618dc65e${HTS_TOKEN_ADDRESS.slice(
-        2,
-      )}600052366000602037600080366018016008845af43d806000803e8160008114605857816000f35b816000fdfea2646970667358221220d8378feed472ba49a0005514ef7087017f707b45fb9bf56bb81bb93ff19a238b64736f6c634300080b0033`;
-      expect(res).to.equal(expectedRedirectBytecode);
+      expect(res).to.be.equal(EthImpl.redirectBytecodeAddressReplace(HTS_TOKEN_ADDRESS));
     });
 
     it('should throw error for invalid block number', async () => {
@@ -261,6 +255,26 @@ describe('@ethGetCode using MirrorNode', async function () {
 
       const res = await ethImpl.getCode(CONTRACT_ADDRESS_1, 'earliest', requestDetails);
       expect(res).to.equal(EthImpl.emptyHex);
+    });
+
+    it('should return redirect bytecode for HTS when accountId has non-zero shard/realm', async function () {
+      const pad = (n, b) =>
+        Number(n)
+          .toString(16)
+          .padStart(b * 2, '0');
+      function toAddress(accountId: string) {
+        const [shardNum, realmNum, accountNum] = accountId.split('.');
+        return `0x${pad(shardNum, 4)}${pad(realmNum, 8)}${pad(accountNum, 8)}`;
+      }
+
+      const accountId = '1.2.3';
+      const addr = toAddress(accountId);
+
+      restMock.onGet(`contracts/${addr}`).reply(404, JSON.stringify(null));
+      restMock.onGet(`accounts/${addr}?limit=100`).reply(404, JSON.stringify(null));
+      restMock.onGet(`tokens/${accountId}`).reply(200, JSON.stringify(DEFAULT_HTS_TOKEN));
+      const res = await ethImpl.getCode(addr, null, requestDetails);
+      expect(res).to.be.equal(EthImpl.redirectBytecodeAddressReplace(addr));
     });
   });
 });

--- a/packages/server/tests/acceptance/erc20.spec.ts
+++ b/packages/server/tests/acceptance/erc20.spec.ts
@@ -1,21 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // External resources
-import { solidity } from 'ethereum-waffle';
-import chai, { expect } from 'chai';
-
-// Local resources
-import { AliasAccount } from '../types/AliasAccount';
-import { Utils } from '../helpers/utils';
-import { ethers } from 'ethers';
-import ERC20MockJson from '../contracts/ERC20Mock.json';
-import Assertions from '../helpers/assertions';
 import { EthImpl } from '@hashgraph/json-rpc-relay/dist/lib/eth';
+import chai, { expect } from 'chai';
+import { solidity } from 'ethereum-waffle';
+import { ethers } from 'ethers';
 
 // Constants from local resources
 import Constants from '../../../server/tests/helpers/constants';
-import ServicesClient from '../clients/servicesClient';
 import RelayClient from '../clients/relayClient';
+import ServicesClient from '../clients/servicesClient';
+import ERC20MockJson from '../contracts/ERC20Mock.json';
+import Assertions from '../helpers/assertions';
+import { Utils } from '../helpers/utils';
+// Local resources
+import { AliasAccount } from '../types/AliasAccount';
 
 chai.use(solidity);
 
@@ -43,10 +42,10 @@ describe('@erc20 Acceptance Tests', async function () {
   const symbol = Utils.randomString(5);
   const initialSupply = BigInt(10000);
 
-  const ERC20 = 'ERC20 Contract';
-  const HTS = 'HTS token';
-
-  const testTitles = [{ testName: ERC20, expectedBytecode: ERC20MockJson.deployedBytecode }, { testName: HTS }];
+  const testTitles = [
+    { testName: 'ERC20 Contract', expectedBytecode: ERC20MockJson.deployedBytecode },
+    { testName: 'HTS token' },
+  ];
 
   this.beforeAll(async () => {
     requestId = Utils.generateRequestId();
@@ -111,14 +110,9 @@ describe('@erc20 Acceptance Tests', async function () {
 
       it('Relay can execute "eth_getCode" for ERC20 contract with evmAddress', async function () {
         const res = await relay.call('eth_getCode', [contract.target, 'latest'], requestId);
-        const expectedBytecode = `${EthImpl.redirectBytecodePrefix}${contract.target.slice(2)}${
-          EthImpl.redirectBytecodePostfix
-        }`;
-        if (testTitles[i].testName !== HTS) {
-          expect(res).to.eq(testTitles[i].expectedBytecode);
-        } else {
-          expect(res).to.eq(expectedBytecode);
-        }
+        expect(res).to.be.equal(
+          testTitles[i].expectedBytecode ?? EthImpl.redirectBytecodeAddressReplace(contract.target),
+        );
       });
 
       describe('should behave like erc20', function () {

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -730,7 +730,6 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
     let mainContract: ethers.Contract;
     let mainContractAddress: string;
     let NftHTSTokenContractAddress: string;
-    let redirectBytecode: string;
     let blockBeforeContractCreation: number;
     let basicContract: ethers.Contract;
     let basicContractAddress: string;
@@ -770,14 +769,12 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
     });
 
     it('should execute "eth_getCode" for hts token', async function () {
-      const tokenAddress = NftHTSTokenContractAddress.slice(2);
-      redirectBytecode = `6080604052348015600f57600080fd5b506000610167905077618dc65e${tokenAddress}600052366000602037600080366018016008845af43d806000803e8160008114605857816000f35b816000fdfea2646970667358221220d8378feed472ba49a0005514ef7087017f707b45fb9bf56bb81bb93ff19a238b64736f6c634300080b0033`;
       const res = await relay.call(
         RelayCalls.ETH_ENDPOINTS.ETH_GET_CODE,
         [NftHTSTokenContractAddress, 'latest'],
         requestId,
       );
-      expect(res).to.equal(redirectBytecode);
+      expect(res).to.be.equal(EthImpl.redirectBytecodeAddressReplace(NftHTSTokenContractAddress));
     });
 
     it('@release should return empty bytecode for HTS token when a block earlier than the token creation is passed', async function () {

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -26,7 +26,7 @@ import storageContractJson from '../contracts/Storage.json';
 import TokenCreateJson from '../contracts/TokenCreateContract.json';
 // Assertions from local resources
 import Assertions from '../helpers/assertions';
-import { Utils } from '../helpers/utils';
+import { entityIdToEvmAddress, toHex, Utils } from '../helpers/utils';
 import { AliasAccount } from '../types/AliasAccount';
 
 describe('@api-batch-2 RPC Server Acceptance Tests', function () {
@@ -58,8 +58,8 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
   let accounts0StartBalance: bigint;
 
   const CHAIN_ID = ConfigService.get('CHAIN_ID');
-  const ONE_TINYBAR = Utils.add0xPrefix(Utils.toHex(ethers.parseUnits('1', 10)));
-  const ONE_WEIBAR = Utils.add0xPrefix(Utils.toHex(ethers.parseUnits('1', 18)));
+  const ONE_TINYBAR = Utils.add0xPrefix(toHex(ethers.parseUnits('1', 10)));
+  const ONE_WEIBAR = Utils.add0xPrefix(toHex(ethers.parseUnits('1', 18)));
 
   const BASIC_CONTRACT_PING_CALL_DATA = '0x5c36b186';
   const PING_CALL_ESTIMATED_GAS = '0x6122';
@@ -129,7 +129,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
     blockNumberAtStartOfTests = blockNumber as number;
     accounts0StartBalance = balance as bigint;
 
-    htsAddress = Utils.idToEvmAddress(tokenId.toString());
+    htsAddress = entityIdToEvmAddress(tokenId.toString());
     await Promise.all([
       accounts[0].client.associateToken(tokenId, requestId),
       accounts[1].client.associateToken(tokenId, requestId),
@@ -817,13 +817,13 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
     });
 
     it('should return 0x0 for account evm_address on eth_getCode', async function () {
-      const evmAddress = Utils.idToEvmAddress(accounts[2].accountId.toString());
+      const evmAddress = entityIdToEvmAddress(accounts[2].accountId.toString());
       const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_CODE, [evmAddress, 'latest'], requestId);
       expect(res).to.eq(EthImpl.emptyHex);
     });
 
     it('should return 0x0 for account alias on eth_getCode', async function () {
-      const alias = Utils.idToEvmAddress(accounts[2].accountId.toString());
+      const alias = entityIdToEvmAddress(accounts[2].accountId.toString());
       const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_CODE, [alias, 'latest'], requestId);
       expect(res).to.eq(EthImpl.emptyHex);
     });

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -26,7 +26,7 @@ import storageContractJson from '../contracts/Storage.json';
 import TokenCreateJson from '../contracts/TokenCreateContract.json';
 // Assertions from local resources
 import Assertions from '../helpers/assertions';
-import { entityIdToEvmAddress, toHex, Utils } from '../helpers/utils';
+import { Utils } from '../helpers/utils';
 import { AliasAccount } from '../types/AliasAccount';
 
 describe('@api-batch-2 RPC Server Acceptance Tests', function () {
@@ -58,8 +58,8 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
   let accounts0StartBalance: bigint;
 
   const CHAIN_ID = ConfigService.get('CHAIN_ID');
-  const ONE_TINYBAR = Utils.add0xPrefix(toHex(ethers.parseUnits('1', 10)));
-  const ONE_WEIBAR = Utils.add0xPrefix(toHex(ethers.parseUnits('1', 18)));
+  const ONE_TINYBAR = Utils.add0xPrefix(Utils.toHex(ethers.parseUnits('1', 10)));
+  const ONE_WEIBAR = Utils.add0xPrefix(Utils.toHex(ethers.parseUnits('1', 18)));
 
   const BASIC_CONTRACT_PING_CALL_DATA = '0x5c36b186';
   const PING_CALL_ESTIMATED_GAS = '0x6122';
@@ -129,7 +129,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
     blockNumberAtStartOfTests = blockNumber as number;
     accounts0StartBalance = balance as bigint;
 
-    htsAddress = entityIdToEvmAddress(tokenId.toString());
+    htsAddress = Utils.idToEvmAddress(tokenId.toString());
     await Promise.all([
       accounts[0].client.associateToken(tokenId, requestId),
       accounts[1].client.associateToken(tokenId, requestId),
@@ -817,13 +817,13 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
     });
 
     it('should return 0x0 for account evm_address on eth_getCode', async function () {
-      const evmAddress = entityIdToEvmAddress(accounts[2].accountId.toString());
+      const evmAddress = Utils.idToEvmAddress(accounts[2].accountId.toString());
       const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_CODE, [evmAddress, 'latest'], requestId);
       expect(res).to.eq(EthImpl.emptyHex);
     });
 
     it('should return 0x0 for account alias on eth_getCode', async function () {
-      const alias = entityIdToEvmAddress(accounts[2].accountId.toString());
+      const alias = Utils.idToEvmAddress(accounts[2].accountId.toString());
       const res = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_CODE, [alias, 'latest'], requestId);
       expect(res).to.eq(EthImpl.emptyHex);
     });

--- a/packages/server/tests/helpers/utils.ts
+++ b/packages/server/tests/helpers/utils.ts
@@ -20,34 +20,38 @@ import { AliasAccount } from '../types/AliasAccount';
 import { HeapDifferenceStatistics } from '../types/HeapDifferenceStatistics';
 import Assertions from './assertions';
 
-/**
- * Converts a number to its hexadecimal representation.
- *
- * @param {number | bigint | string} num The number to convert to hexadecimal.
- * @returns {string} The hexadecimal representation of the number.
- */
-export function toHex(num: number | bigint | string): string {
-  return Number(num).toString(16);
-}
-
-/**
- * Converts a given Hedera account ID to an EVM compatible address.
- *
- * @param entityId The Hedera account ID to convert.
- * @returns The EVM compatible address.
- */
-export function entityIdToEvmAddress(entityId: string): string {
-  const pad = (num: string, n: number) => toHex(num).padStart(n, '0');
-  Assertions.assertId(entityId);
-  const [shardNum, realmNum, accountNum] = entityId.split('.');
-
-  return `0x${pad(shardNum, 8)}${pad(realmNum, 16)}${pad(accountNum, 16)}`;
-}
-
 export class Utils {
   static readonly HEAP_SIZE_DIFF_MEMORY_LEAK_THRESHOLD: number = 4e6; // 4 MB
   static readonly HEAP_SIZE_DIFF_SNAPSHOT_THRESHOLD: number = 5e6; // 5 MB
   static readonly WARM_UP_TEST_COUNT: number = 3;
+
+  /**
+   * Converts a number to its hexadecimal representation.
+   *
+   * @param {number | bigint | string} num The number to convert to hexadecimal.
+   * @returns {string} The hexadecimal representation of the number.
+   */
+  static toHex = (num: number | bigint | string): string => {
+    return Number(num).toString(16);
+  };
+
+  /**
+   * Converts a given Hedera account ID to an EVM compatible address.
+   *
+   * @param {string} id The Hedera account ID to convert.
+   * @returns {string} The EVM compatible address.
+   */
+  static idToEvmAddress = (id: string): string => {
+    Assertions.assertId(id);
+    const [shard, realm, num] = id.split('.');
+
+    return [
+      '0x',
+      this.toHex(shard).padStart(8, '0'),
+      this.toHex(realm).padStart(16, '0'),
+      this.toHex(num).padStart(16, '0'),
+    ].join('');
+  };
 
   /**
    * Converts a value from tinybars to weibars.
@@ -168,7 +172,7 @@ export class Utils {
       htsResult.client.operatorAccountId!,
       requestId,
     );
-    const evmAddress = entityIdToEvmAddress(htsResult.receipt.tokenId!.toString());
+    const evmAddress = Utils.idToEvmAddress(htsResult.receipt.tokenId!.toString());
     return new ethers.Contract(evmAddress, abi, owner.wallet);
   };
 


### PR DESCRIPTION
**Description**:

This PR adds preliminary support for non-zero shard/realm numbers. As described in #3614, it was mostly related to `eth_getCode` and the redirect bytecode. This was refactored to avoid duplication.

In addition it now includes `0x` hex prefix in the HTS redirect bytecode. The spec indicated that `eth_getCode` result response should be a hex encoded value starting with `0x`.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #3614

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
