### PR TITLE
fix: fixes check to remove duplicates from transactionArray

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2930,8 +2930,7 @@ export class EthImpl implements Eth {
     }
 
     transactionArray = this.populateSyntheticTransactions(showDetails, logs, transactionArray, requestDetails);
-    transactionArray = showDetails ? transactionArray : _.uniq(transactionArray);
-
+    transactionArray = _.uniqWith(transactionArray, _.isEqual);
     const formattedReceipts: IReceiptRootHash[] = ReceiptsRootUtils.buildReceiptRootHashes(
       transactionArray.map((tx) => (showDetails ? tx.hash : tx)),
       contractResults,

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2931,7 +2931,6 @@ export class EthImpl implements Eth {
     }
 
     transactionArray = this.populateSyntheticTransactions(showDetails, logs, transactionArray, requestDetails);
-    // transactionArray = _.uniqWith(transactionArray, _.isEqual);
     const formattedReceipts: IReceiptRootHash[] = ReceiptsRootUtils.buildReceiptRootHashes(
       transactionArray.map((tx) => (showDetails ? tx.hash : tx)),
       contractResults,

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -2863,6 +2863,7 @@ export class EthImpl implements Eth {
       );
     }
 
+    transactionsArray = _.uniqWith(transactionsArray, _.isEqual);
     return transactionsArray;
   }
 
@@ -2930,7 +2931,7 @@ export class EthImpl implements Eth {
     }
 
     transactionArray = this.populateSyntheticTransactions(showDetails, logs, transactionArray, requestDetails);
-    transactionArray = _.uniqWith(transactionArray, _.isEqual);
+    // transactionArray = _.uniqWith(transactionArray, _.isEqual);
     const formattedReceipts: IReceiptRootHash[] = ReceiptsRootUtils.buildReceiptRootHashes(
       transactionArray.map((tx) => (showDetails ? tx.hash : tx)),
       contractResults,

--- a/packages/relay/tests/lib/ethGetBlockBy.spec.ts
+++ b/packages/relay/tests/lib/ethGetBlockBy.spec.ts
@@ -277,5 +277,20 @@ describe('eth_getBlockBy', async function () {
       expect(txObjects[1].hash).to.equal(modelLog2.transactionHash);
       expect(txObjects[2].hash).to.equal(modelLog3.transactionHash);
     });
+
+    it('deduplicates duplicate transaction objects in the result', async function () {
+      const tx1 = getTransactionModel(modelLog1.transactionHash);
+      const tx2 = getTransactionModel(modelLog1.transactionHash); // duplicate hash, different object
+      const initTxObjects = [tx1, tx2];
+
+      const txObjects = initTxObjects.slice();
+      const returnedTxObjects = ethImpl.populateSyntheticTransactions(true, referenceLogs, txObjects, requestDetails);
+
+      // Should only have one object with modelLog1.transactionHash
+      const count = returnedTxObjects.filter((tx) => tx.hash === modelLog1.transactionHash).length;
+      expect(count).to.equal(1);
+
+      expect(returnedTxObjects.length).to.equal(referenceLogs.length);
+    });
   });
 });


### PR DESCRIPTION
**Description**:
This PR fixes a problem in the `getBlock()` method which caused duplicate transactions to be returned. 

The old code `transactionArray = showDetails ? transactionArray : _.uniq(transactionArray);` didn't account for the situation where duplicate transaction could be returned in some cases where one transaction emits multiple events (e.g. minting multiple NFT serials in one transaction). In that case, duplicate transactions would be generated from the logs. I have changed this line to account for that and exclude duplicates.

**Related issue(s)**:

Fixes #3724

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
