### PR TITLE
fix: allowed callTracer to return empty array if no call actions found

### DIFF
--- a/packages/relay/src/lib/debug.ts
+++ b/packages/relay/src/lib/debug.ts
@@ -444,6 +444,9 @@ export class DebugImpl implements Debug {
         throw predefined.RESOURCE_NOT_FOUND(`Failed to retrieve contract results for transaction ${transactionHash}`);
       }
 
+      // return empty array if no actions
+      if (actionsResponse.length === 0) return [];
+
       const { call_type: type } = actionsResponse[0];
       const formattedActions = await this.formatActionsResult(actionsResponse, requestDetails);
 

--- a/packages/relay/src/lib/debug.ts
+++ b/packages/relay/src/lib/debug.ts
@@ -429,7 +429,7 @@ export class DebugImpl implements Debug {
     transactionHash: string,
     tracerConfig: ICallTracerConfig,
     requestDetails: RequestDetails,
-  ): Promise<CallTracerResult> {
+  ): Promise<CallTracerResult | null> {
     try {
       const [actionsResponse, transactionsResponse] = await Promise.all([
         this.mirrorNodeClient.getContractsResultsActions(transactionHash, requestDetails),
@@ -445,7 +445,7 @@ export class DebugImpl implements Debug {
       }
 
       // return empty array if no actions
-      if (actionsResponse.length === 0) return [];
+      if (actionsResponse.length === 0) return null;
 
       const { call_type: type } = actionsResponse[0];
       const formattedActions = await this.formatActionsResult(actionsResponse, requestDetails);

--- a/packages/relay/src/lib/types/debug.ts
+++ b/packages/relay/src/lib/types/debug.ts
@@ -73,5 +73,5 @@ export interface TraceBlockByNumberTxResult {
   /**
    * The result of the trace, which can be either a {@link CallTracerResult} or an {@link EntityTraceStateMap}.
    */
-  result: CallTracerResult | EntityTraceStateMap;
+  result: CallTracerResult | EntityTraceStateMap | null;
 }

--- a/packages/relay/tests/lib/debug.spec.ts
+++ b/packages/relay/tests/lib/debug.spec.ts
@@ -433,7 +433,7 @@ describe('Debug API Test Suite', async function () {
             requestDetails,
           );
 
-          expect(result).to.be.empty;
+          expect(result).to.be.null;
         });
       });
 

--- a/packages/relay/tests/lib/debug.spec.ts
+++ b/packages/relay/tests/lib/debug.spec.ts
@@ -422,6 +422,19 @@ describe('Debug API Test Suite', async function () {
 
           expect(result).to.deep.equal(expectedResult);
         });
+
+        it('Should return empty array if no actions found', async function () {
+          restMock.onGet(CONTARCTS_RESULTS_ACTIONS).reply(200, JSON.stringify({ actions: [] }));
+
+          const result = await debugService.traceTransaction(
+            transactionHash,
+            callTracer,
+            tracerConfigFalse,
+            requestDetails,
+          );
+
+          expect(result).to.be.empty;
+        });
       });
 
       describe('opcodeLogger', async function () {


### PR DESCRIPTION
**Description**:
This PR allows callTracer to return an empty array if no call actions are found, effectively preventing the deconstruction of an undefined object.


**Related issue(s)**:

Fixes #3751

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
