### PR TITLE
chore: add proof handling for empty hex responses in web3.js and ethers.js without exceptions

### DIFF
--- a/tools/hardhat-example/test/rpc.js
+++ b/tools/hardhat-example/test/rpc.js
@@ -36,6 +36,15 @@ describe('RPC', function () {
     expect(res).to.be.equal('initial_msg');
   });
 
+  it('should NOT throw exception upon empty hex response (0x)', async function () {
+    const provider = new hre.ethers.getDefaultProvider(process.env.RELAY_ENDPOINT);
+    const result = await provider.call({
+      to: '0x00000000000000000000000000000000002e7a5d', // random non-existed address
+      data: '0x',
+    });
+    expect(result).to.be.equal('0x'); // successfully process empty hex response and throw no exception
+  });
+
   it('should be able to make a contract call', async function () {
     const msg = 'updated_msg';
     await hre.run('contract-call', { contractAddress, msg });

--- a/tools/web3js-example/test/rpc.js
+++ b/tools/web3js-example/test/rpc.js
@@ -2,6 +2,7 @@
 
 const { expect } = require('chai');
 const { Web3 } = require('web3');
+require('dotenv').config();
 
 describe('RPC', function () {
   this.timeout(5 * 60000); // 5 minutes
@@ -51,5 +52,14 @@ describe('RPC', function () {
     const res = await contractViewCall(contractAddress);
 
     expect(res).to.be.equal(updatedMsg);
+  });
+
+  it('should NOT throw exception upon empty hex response (0x)', async function () {
+    const web3 = new Web3(new Web3.providers.HttpProvider(process.env.RELAY_ENDPOINT));
+    const result = await web3.eth.call({
+      to: '0x00000000000000000000000000000000002e7a5d', // random non-existed address
+      data: '0x',
+    });
+    expect(result).to.be.equal('0x'); // successfully process empty hex response and throw no exception
   });
 });


### PR DESCRIPTION
## Concerns

For the eth_call method, the response is defined as follows:
```typescript
return contractCallResponse?.result ? prepend0x(contractCallResponse.result) : EthImpl.emptyHex;
```
This indicates that if contractCallResponse.result is not present, the method returns emptyHex, which is "0x".

There is a concern that returning "0x" might impact the decoding logic of some tools, such as Ethers.js, which may not expect an empty hex string in this context.

## Findings
- The /contracts/call endpoint from the Mirror Node returns "0x" when no result is found.
```bash
> curl -X 'POST' \
  'https://testnet.mirrornode.hedera.com/api/v1/contracts/call' \
  -H 'accept: application/json' \
  -H 'Content-Type: application/json' \
  -d '{
  "data": "0x",
  "to": "0x00000000000000000000000000000000002e7a5d"
}'
> {"result": "0x"}
```

- Other major providers (e.g., Alchemy, QuickNode, Infura) also return "0x" in similar cases.
```bash
> curl --location 'https://eth-sepolia.g.alchemy.com/v2/API_KEY' \
--header 'Content-Type: application/json' \
--data '{
    "id":1,
    "jsonrpc":"2.0",
    "method":"eth_call",
    "params":[
        {"to":"0x00000000000000000000000000000000002e7a5d","data":"0x"},"latest"
    ]
}'
> {"jsonrpc": "2.0", "id": 1, "result": "0x"}
```


- This PR includes proof-of-concept tests with Web3.js and Ethers.js, confirming that both libraries handle an empty hex response without throwing exceptions.

## Conclusion
- This PR provides evidence that "0x" is a valid and widely accepted response when no result is found.
- Common tools such as Web3.js and Ethers.js are capable of processing this value without raising exceptions.

**Related issue(s)**:

Fixes #3611 
