### PR TITLE
build(deps): restored sdk version and fixed package vuls in whbar-hardhat-exampl

### DIFF
--- a/tools/whbar-hardhat-example/package-lock.json
+++ b/tools/whbar-hardhat-example/package-lock.json
@@ -8,7 +8,7 @@
       "name": "whbar-hardhat-example",
       "version": "0.0.1",
       "dependencies": {
-        "@hashgraph/sdk": "^2.59.0",
+        "@hashgraph/sdk": "^2.63.0",
         "dotenv": "^16.4.7"
       },
       "devDependencies": {
@@ -3969,9 +3969,9 @@
       "license": "MIT"
     },
     "node_modules/base-x": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.10.tgz",
-      "integrity": "sha512-7d0s06rR9rYaIWHkpfLIFICM/tkSVdoPC9qYAQRpxn9DdKNWNsKC0uk++akckyLq16Tx2WIinnZ6WRriAt6njQ==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.11.tgz",
+      "integrity": "sha512-xz7wQ8xDhdyP7tQxwdteLYeFfS68tSMNCZ/Y37WJ4bhGfKPpqEIlmIyueQHqOyoPhE6xNUqjzRr8ra0eF9VRvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tools/whbar-hardhat-example/package.json
+++ b/tools/whbar-hardhat-example/package.json
@@ -7,7 +7,7 @@
     "hardhat": "^2.22.17"
   },
   "dependencies": {
-    "@hashgraph/sdk": "^2.59.0",
+    "@hashgraph/sdk": "^2.63.0",
     "dotenv": "^16.4.7"
   },
   "overrides": {


### PR DESCRIPTION
**Description**:
PR https://github.com/hiero-ledger/hiero-json-rpc-relay/pull/3767/files accidentally decreased the sdk package to 2.59. This PR restored back the version, also fixed 1 package vulneriblty using npm audit.

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-json-rpc-relay/issues/3827

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
