### PR TITLE
feat: update `getBlockReceipts` to return `null` when block is not found

### DIFF
--- a/packages/relay/src/index.ts
+++ b/packages/relay/src/index.ts
@@ -71,7 +71,7 @@ export interface Eth {
 
   getBalance(account: string, blockNumber: string | null, requestDetails: RequestDetails): Promise<string>;
 
-  getBlockReceipts(blockHashOrNumber: string, requestDetails: RequestDetails): Promise<ITransactionReceipt[]>;
+  getBlockReceipts(blockHashOrNumber: string, requestDetails: RequestDetails): Promise<ITransactionReceipt[] | null>;
 
   getBlockByHash(hash: string, showDetails: boolean, requestDetails: RequestDetails): Promise<Block | null>;
 

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1108,7 +1108,7 @@ export class EthImpl implements Eth {
    *
    * @param {string } blockHashOrBlockNumber The block hash, block number, or block tag
    * @param {RequestDetails} requestDetails The request details for logging and tracking
-   * @returns {Promise<Receipt[]>} Array of transaction receipts for the block
+   * @returns {Promise<Receipt[] | null>} Array of transaction receipts for the block or null if block not found
    */
   @rpcMethod
   @rpcParamValidationRules({
@@ -1120,7 +1120,7 @@ export class EthImpl implements Eth {
   public async getBlockReceipts(
     blockHashOrBlockNumber: string,
     requestDetails: RequestDetails,
-  ): Promise<ITransactionReceipt[]> {
+  ): Promise<ITransactionReceipt[] | null> {
     return await this.blockService.getBlockReceipts(blockHashOrBlockNumber, requestDetails);
   }
 

--- a/packages/relay/src/lib/services/ethService/blockService/BlockService.ts
+++ b/packages/relay/src/lib/services/ethService/blockService/BlockService.ts
@@ -121,12 +121,12 @@ export class BlockService implements IBlockService {
    *
    * @param {string} blockHashOrBlockNumber The block hash, block number, or block tag
    * @param {RequestDetails} requestDetails The request details for logging and tracking
-   * @returns {Promise<Receipt[]>} Array of transaction receipts for the block
+   * @returns {Promise<Receipt[] | null>} Array of transaction receipts for the block or null if block not found
    */
   public async getBlockReceipts(
     blockHashOrBlockNumber: string,
     requestDetails: RequestDetails,
-  ): Promise<ITransactionReceipt[]> {
+  ): Promise<ITransactionReceipt[] | null> {
     const requestIdPrefix = requestDetails.formattedRequestId;
     if (this.logger.isLevelEnabled('trace')) {
       this.logger.trace(`${requestIdPrefix} getBlockReceipt(${JSON.stringify(blockHashOrBlockNumber)})`);
@@ -135,7 +135,7 @@ export class BlockService implements IBlockService {
     const block = await this.common.getHistoricalBlockResponse(requestDetails, blockHashOrBlockNumber);
 
     if (block == null) {
-      throw predefined.RESOURCE_NOT_FOUND(`Block: ${blockHashOrBlockNumber}`);
+      return null;
     }
 
     const blockNumber = block.number;

--- a/packages/relay/src/lib/services/ethService/blockService/IBlockService.ts
+++ b/packages/relay/src/lib/services/ethService/blockService/IBlockService.ts
@@ -12,7 +12,7 @@ export interface IBlockService {
   getBlockByHash: (hash: string, showDetails: boolean, requestDetails: RequestDetails) => Promise<Block | null>;
   getBlockTransactionCountByHash: (hash: string, requestDetails: RequestDetails) => Promise<string | null>;
   getBlockTransactionCountByNumber: (blockNum: string, requestDetails: RequestDetails) => Promise<string | null>;
-  getBlockReceipts: (blockHash: string, requestDetails: RequestDetails) => Promise<ITransactionReceipt[]>;
+  getBlockReceipts: (blockHash: string, requestDetails: RequestDetails) => Promise<ITransactionReceipt[] | null>;
   getUncleByBlockHashAndIndex: (requestDetails: RequestDetails) => Promise<null>;
   getUncleByBlockNumberAndIndex: (requestDetails: RequestDetails) => Promise<null>;
   getUncleCountByBlockHash: (requestDetails: RequestDetails) => Promise<string>;

--- a/packages/relay/tests/lib/eth/eth_getBlockReceipts.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getBlockReceipts.spec.ts
@@ -227,18 +227,14 @@ describe('@ethGetBlockReceipts using MirrorNode', async function () {
       expect(receipts.length).to.equal(0);
     });
 
-    it('should throw RESOURCE_NOT_FOUND error when block is null', async function () {
+    it('should return null when block is not found', async function () {
       const getHistoricalBlockResponseStub = sinon
         .stub(ethImpl['blockService']['common'], 'getHistoricalBlockResponse')
         .resolves(null);
 
-      await RelayAssertions.assertRejection(
-        predefined.RESOURCE_NOT_FOUND(`Block: 0x123456`),
-        ethImpl.getBlockReceipts,
-        true,
-        ethImpl,
-        ['0x123456', requestDetails],
-      );
+      const result = await ethImpl.getBlockReceipts('0x123456', requestDetails);
+
+      expect(result).to.be.null;
 
       getHistoricalBlockResponseStub.restore();
     });


### PR DESCRIPTION
**Description**:
When querying the eth_getBlockReceipts method in Hedera’s JSON-RPC API with a valid but nonexistent block hash, the endpoint throws an error. This behavior is inconsistent with Ethereum-compatible JSON-RPC endpoints (such as Sepolia), which return null for nonexistent blocks, as per the standard JSON-RPC specification.

**Related issue(s)**:

Fixes #3813 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
