### PR TITLE
fix: remove custom cache logic from `getBlockReceipts`

### DIFF
--- a/packages/relay/src/lib/services/ethService/blockService/BlockService.ts
+++ b/packages/relay/src/lib/services/ethService/blockService/BlockService.ts
@@ -138,13 +138,6 @@ export class BlockService implements IBlockService {
       throw predefined.RESOURCE_NOT_FOUND(`Block: ${blockHashOrBlockNumber}`);
     }
 
-    const blockNumber = block.number;
-    const cacheKey = `${constants.CACHE_KEY.ETH_GET_BLOCK_RECEIPTS}_${blockNumber}`;
-    const cachedResponse = await this.cacheService.getAsync(cacheKey, constants.ETH_GET_BLOCK_RECEIPTS, requestDetails);
-    if (cachedResponse) {
-      return cachedResponse;
-    }
-
     const paramTimestamp: IContractResultsParams = {
       timestamp: [`lte:${block.timestamp.to}`, `gte:${block.timestamp.from}`],
     };


### PR DESCRIPTION
**Description**:

This PR removes `getBlockReceipts`' custom cache logic leftover from https://github.com/hiero-ledger/hiero-json-rpc-relay/pull/3758/files#r2098146076.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #3778.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
