### PR TITLE
chore(release): Bump versions for v0.70.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Expected response:
 ```
 {
     "relay": {
-        "version": "0.67.0-SNAPSHOT",
+        "version": "0.70.0-SNAPSHOT",
         "config": {
             "CHAIN_ID": "0x128",
             "CLIENT_TRANSPORT_SECURITY": "false",

--- a/charts/hedera-json-rpc-relay-websocket/Chart.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.69.0-SNAPSHOT"
+appVersion: "0.70.0-SNAPSHOT"
 description: Helm chart deployment of the hiero-ledger/hiero-json-rpc-relay web socket server
 home: https://github.com/hiero-ledger/hiero-json-rpc-relay
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -22,4 +22,4 @@ name: hedera-json-rpc-relay-websocket
 sources:
   - https://github.com/hiero-ledger/hiero-json-rpc-relay
 type: application
-version: 0.69.0-SNAPSHOT
+version: 0.70.0-SNAPSHOT

--- a/charts/hedera-json-rpc-relay/Chart.yaml
+++ b/charts/hedera-json-rpc-relay/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "0.69.0-SNAPSHOT"
+appVersion: "0.70.0-SNAPSHOT"
 description: Helm chart deployment of the hiero-ledger/hiero-json-rpc-relay
 home: https://github.com/hiero-ledger/hiero-json-rpc-relay
 icon: https://camo.githubusercontent.com/cca6b767847bb8ca5c7059481ba13a5fc81c5938/68747470733a2f2f7777772e6865646572612e636f6d2f6c6f676f2d6361706974616c2d686261722d776f72646d61726b2e6a7067
@@ -21,4 +21,4 @@ name: hedera-json-rpc-relay
 sources:
   - https://github.com/hiero-ledger/hiero-json-rpc-relay
 type: application
-version: 0.69.0-SNAPSHOT
+version: 0.70.0-SNAPSHOT

--- a/charts/hedera-json-rpc/Chart.yaml
+++ b/charts/hedera-json-rpc/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: '0.68.0-SNAPSHOT'
+appVersion: '0.70.0-SNAPSHOT'
 dependencies:
   - alias: relay
     condition: relay.enabled
@@ -36,4 +36,4 @@ name: hedera-json-rpc
 sources:
   - https://github.com/hiero-ledger/hiero-json-rpc-relay
 type: application
-version: 0.69.0-SNAPSHOT
+version: 0.70.0-SNAPSHOT

--- a/docs/openrpc.json
+++ b/docs/openrpc.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Hedera JSON-RPC Specification",
     "description": "A specification of the implemented Ethereum JSON RPC APIs interface for Hedera clients and adheres to the Ethereum execution APIs schema.",
-    "version": "0.69.0-SNAPSHOT"
+    "version": "0.70.0-SNAPSHOT"
   },
   "servers": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "root",
-  "version": "0.69.0-SNAPSHOT",
+  "version": "0.70.0-SNAPSHOT",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "root",
-      "version": "0.69.0-SNAPSHOT",
+      "version": "0.70.0-SNAPSHOT",
       "dependencies": {
         "@ethereumjs/rlp": "^5.0.2",
         "@ethereumjs/trie": "^6.2.1",
@@ -20283,7 +20283,7 @@
     },
     "packages/config-service": {
       "name": "@hashgraph/json-rpc-config-service",
-      "version": "0.69.0-SNAPSHOT",
+      "version": "0.70.0-SNAPSHOT",
       "dependencies": {
         "dotenv": "^16.4.5",
         "find-config": "^1.0.0",
@@ -20297,7 +20297,7 @@
     },
     "packages/relay": {
       "name": "@hashgraph/json-rpc-relay",
-      "version": "0.69.0-SNAPSHOT",
+      "version": "0.70.0-SNAPSHOT",
       "dependencies": {
         "@hashgraph/json-rpc-config-service": "file:../config-service",
         "@hashgraph/sdk": "^2.63.0",
@@ -20747,7 +20747,7 @@
     },
     "packages/server": {
       "name": "@hashgraph/json-rpc-server",
-      "version": "0.69.0-SNAPSHOT",
+      "version": "0.70.0-SNAPSHOT",
       "dependencies": {
         "@hashgraph/json-rpc-config-service": "file:../config-service",
         "@hashgraph/json-rpc-relay": "file:../relay",
@@ -20778,7 +20778,7 @@
         "axios-retry": "^4.5.0",
         "chai": "^4.3.6",
         "ethers": "^5.8.0",
-        "execution-apis": "git+ssh://git@github.com/ethereum/execution-apis.git#7907424db935b93c2fe6a3c0faab943adebe8557",
+        "execution-apis": "git://github.com/ethereum/execution-apis.git#7907424db935b93c2fe6a3c0faab943adebe8557",
         "mocha": "^10.6.0",
         "shelljs": "^0.8.5",
         "ts-mocha": "^9.0.2",
@@ -21234,7 +21234,7 @@
     },
     "packages/ws-server": {
       "name": "@hashgraph/json-rpc-ws-server",
-      "version": "0.69.0-SNAPSHOT",
+      "version": "0.70.0-SNAPSHOT",
       "dependencies": {
         "@hashgraph/json-rpc-config-service": "file:../config-service",
         "@hashgraph/json-rpc-relay": "file:../relay",
@@ -23143,7 +23143,7 @@
         "co-body": "6.2.0",
         "dotenv": "^16.0.0",
         "ethers": "^5.8.0",
-        "execution-apis": "git+ssh://git@github.com/ethereum/execution-apis.git#7907424db935b93c2fe6a3c0faab943adebe8557",
+        "execution-apis": "git://github.com/ethereum/execution-apis.git#7907424db935b93c2fe6a3c0faab943adebe8557",
         "koa": "^2.13.4",
         "koa-body-parser": "^0.2.1",
         "koa-cors": "^0.0.16",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "root",
-  "version": "0.69.0-SNAPSHOT",
+  "version": "0.70.0-SNAPSHOT",
   "devDependencies": {
     "@hashgraph/hedera-local": "^2.32.5",
     "@open-rpc/schema-utils-js": "^1.16.1",

--- a/packages/config-service/package.json
+++ b/packages/config-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/json-rpc-config-service",
-  "version": "0.69.0-SNAPSHOT",
+  "version": "0.70.0-SNAPSHOT",
   "description": "Hedera Hashgraph singleton implementation of environment variables provider",
   "main": "dist/index.js",
   "keywords": [],

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/json-rpc-relay",
-  "version": "0.69.0-SNAPSHOT",
+  "version": "0.70.0-SNAPSHOT",
   "description": "Hedera Hashgraph implementation of Ethereum JSON RPC APIs. Utilises both the Hedera Consensus Nodes and the Mirror Nodes for transaction management and information retrieval",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/json-rpc-server",
-  "version": "0.69.0-SNAPSHOT",
+  "version": "0.70.0-SNAPSHOT",
   "description": "Hedera Hashgraph Ethereum JSON RPC server. Accepts requests for Ethereum JSON RPC 2.0 APIs",
   "main": "dist/index.js",
   "keywords": [],

--- a/packages/ws-server/package.json
+++ b/packages/ws-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/json-rpc-ws-server",
-  "version": "0.69.0-SNAPSHOT",
+  "version": "0.70.0-SNAPSHOT",
   "description": "Hedera Hashgraph Ethereum JSON RPC socket server. Accepts socket connections for the purpose of subscribing to real-time data.",
   "main": "dist/index.js",
   "keywords": [],


### PR DESCRIPTION
**Description**:
Bump versions for v0.70.0-SNAPSHOT
Automated snapshot version bump for the next development cycle.

Fixes: https://github.com/hiero-ledger/hiero-json-rpc-relay/issues/3844