### PR TITLE
feat: edit `rpc_relay_eth_executions` and `rpc_websocket_connection_duration_seconds_bucket` metrics

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -268,9 +268,6 @@ export class EthImpl implements Eth {
     if (callDataSize >= constants.FUNCTION_SELECTOR_CHAR_LENGTH) {
       this.eventEmitter.emit(constants.EVENTS.ETH_EXECUTION, {
         method: constants.ETH_ESTIMATE_GAS,
-        functionSelector: callData!.substring(0, constants.FUNCTION_SELECTOR_CHAR_LENGTH),
-        from: transaction.from || '',
-        to: transaction.to || '',
         requestDetails: requestDetails,
       });
     }
@@ -986,9 +983,6 @@ export class EthImpl implements Eth {
 
     this.eventEmitter.emit(constants.EVENTS.ETH_EXECUTION, {
       method: 'eth_call',
-      functionSelector: callData?.substring(0, constants.FUNCTION_SELECTOR_CHAR_LENGTH) || '',
-      from: call.from || '',
-      to: call.to || '',
       requestDetails: requestDetails,
     });
 

--- a/packages/relay/src/lib/services/ethService/transactionService/TransactionService.ts
+++ b/packages/relay/src/lib/services/ethService/transactionService/TransactionService.ts
@@ -331,22 +331,11 @@ export class TransactionService implements ITransactionService {
 
   /**
    * Emits an Ethereum execution event with transaction details
-   * @param parsedTx The parsed transaction object
-   * @param originalCallerAddress The address of the original caller
-   * @param toAddress The destination address
    * @param requestDetails The request details for logging and tracking
    */
-  private emitEthExecutionEvent(
-    parsedTx: EthersTransaction,
-    originalCallerAddress: string,
-    toAddress: string,
-    requestDetails: RequestDetails,
-  ): void {
+  private emitEthExecutionEvent(requestDetails: RequestDetails): void {
     this.eventEmitter.emit(constants.EVENTS.ETH_EXECUTION, {
       method: constants.ETH_SEND_RAW_TRANSACTION,
-      functionSelector: parsedTx.data?.substring(0, constants.FUNCTION_SELECTOR_CHAR_LENGTH) || '',
-      from: originalCallerAddress,
-      to: toAddress,
       requestDetails: requestDetails,
     });
   }
@@ -560,9 +549,8 @@ export class TransactionService implements ITransactionService {
 
     const requestIdPrefix = requestDetails.formattedRequestId;
     const originalCallerAddress = parsedTx.from?.toString() || '';
-    const toAddress = parsedTx.to?.toString() || '';
 
-    this.emitEthExecutionEvent(parsedTx, originalCallerAddress, toAddress, requestDetails);
+    this.emitEthExecutionEvent(requestDetails);
 
     const { txSubmitted, submittedTransactionId, error } = await this.submitTransaction(
       transactionBuffer,

--- a/packages/relay/src/lib/services/metricService/metricService.ts
+++ b/packages/relay/src/lib/services/metricService/metricService.ts
@@ -117,7 +117,7 @@ export default class MetricService {
     });
 
     this.eventEmitter.on(constants.EVENTS.ETH_EXECUTION, (args: IEthExecutionEventPayload) => {
-      this.ethExecutionsCounter.labels(args.method, args.functionSelector, args.from, args.to).inc();
+      this.ethExecutionsCounter.labels(args.method).inc();
     });
   }
 
@@ -262,7 +262,7 @@ export default class MetricService {
     return new Counter({
       name: metricCounterName,
       help: `Relay ${metricCounterName} function`,
-      labelNames: ['method', 'function', 'from', 'to'],
+      labelNames: ['method'],
       registers: [register],
     });
   }

--- a/packages/relay/src/lib/types/events.ts
+++ b/packages/relay/src/lib/types/events.ts
@@ -27,8 +27,5 @@ export interface IExecuteQueryEventPayload {
 
 export interface IEthExecutionEventPayload {
   method: string;
-  functionSelector: string;
-  from: string;
-  to: string;
   requestDetails: RequestDetails;
 }

--- a/packages/relay/tests/lib/services/metricService/metricService.spec.ts
+++ b/packages/relay/tests/lib/services/metricService/metricService.spec.ts
@@ -322,15 +322,9 @@ describe('Metric Service', function () {
 
   describe('ethExecutionsCounter', () => {
     const mockedMethod = 'eth_sendRawTransaction';
-    const mockedFunctionSelector = '0x12345678';
-    const mockedFrom = '0x1234567890123456789012345678901234567890';
-    const mockedTo = '0x0987654321098765432109876543210987654321';
 
     const mockedEthExecutionEventPayload = {
       method: mockedMethod,
-      functionSelector: mockedFunctionSelector,
-      from: mockedFrom,
-      to: mockedTo,
       requestDetails,
     };
 
@@ -339,14 +333,7 @@ describe('Metric Service', function () {
       const counterBefore = await metricService['ethExecutionsCounter'].get();
 
       // Find the initial value for our specific labels, or use 0 if not found
-      const initialValue =
-        counterBefore.values.find(
-          (metric) =>
-            metric.labels.method === mockedMethod &&
-            metric.labels.function === mockedFunctionSelector &&
-            metric.labels.from === mockedFrom &&
-            metric.labels.to === mockedTo,
-        )?.value || 0;
+      const initialValue = counterBefore.values.find((metric) => metric.labels.method === mockedMethod)?.value || 0;
 
       eventEmitter.emit(constants.EVENTS.ETH_EXECUTION, mockedEthExecutionEventPayload);
 
@@ -354,13 +341,7 @@ describe('Metric Service', function () {
       const counterAfter = await metricService['ethExecutionsCounter'].get();
 
       // Find the value for our specific labels after the event
-      const metricValue = counterAfter.values.find(
-        (metric) =>
-          metric.labels.method === mockedMethod &&
-          metric.labels.function === mockedFunctionSelector &&
-          metric.labels.from === mockedFrom &&
-          metric.labels.to === mockedTo,
-      )?.value;
+      const metricValue = counterAfter.values.find((metric) => metric.labels.method === mockedMethod)?.value;
 
       expect(metricValue).to.eq(initialValue + 1);
     });

--- a/packages/ws-server/src/utils/constants.ts
+++ b/packages/ws-server/src/utils/constants.ts
@@ -36,7 +36,6 @@ export const WS_CONSTANTS = {
   connectionDuration: {
     name: 'rpc_websocket_connection_duration_seconds',
     help: 'Histogram of WebSocket connection duration in seconds',
-    labelNames: ['connectionID'],
     buckets: [1, 5, 10, 30, 60, 300, 600, 1800, 3600, 7200, 18000, 43200, 86400], // s (seconds)
   },
   messageDuration: {

--- a/packages/ws-server/src/utils/utils.ts
+++ b/packages/ws-server/src/utils/utils.ts
@@ -48,7 +48,7 @@ export const handleConnectionClose = async (
   const durationInSeconds = endTime[0] + endTime[1] / 1e9; // Convert duration to seconds
 
   // Update the connection duration histogram with the calculated duration
-  wsMetricRegistry.getHistogram('connectionDuration').labels(ctx.websocket.id).observe(durationInSeconds);
+  wsMetricRegistry.getHistogram('connectionDuration').observe(durationInSeconds);
 
   // terminate connection
   ctx.websocket.terminate();

--- a/packages/ws-server/tests/unit/utils.spec.ts
+++ b/packages/ws-server/tests/unit/utils.spec.ts
@@ -183,10 +183,7 @@ describe('Utilities unit tests', async function () {
     });
 
     it('should update the connection duration histogram', async () => {
-      const labelsStub = wsMetricRegistryStub.getHistogram('connectionDuration').labels as sinon.SinonStub;
-      const observeSpy = labelsStub().observe as sinon.SinonSpy;
-
-      expect(labelsStub.calledWith(ctxStub.websocket.id)).to.be.true;
+      const observeSpy = wsMetricRegistryStub.getHistogram('connectionDuration').observe as sinon.SinonSpy;
       expect(observeSpy.calledOnce).to.be.true;
     });
 


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

Currently, we have increased cost of the Grafana due to several unique IDs labels that are populated in Prometheus.

**Solution**:
- remove `from`, `to`, and `function` from `rpc_relay_eth_executions`
- remove the label from `rpc_websocket_connection_duration_seconds_bucket`

**Related issue(s)**:

Fixes #3853

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
