### PR TITLE
fix: return 32-byte block hash from `eth_getFilterChanges` to ensure EVM compatibility

### DIFF
--- a/packages/relay/src/lib/services/ethService/ethFilterService/FilterService.ts
+++ b/packages/relay/src/lib/services/ethService/ethFilterService/FilterService.ts
@@ -3,7 +3,7 @@
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
 import { Logger } from 'pino';
 
-import { generateRandomHex } from '../../../../formatters';
+import { generateRandomHex, toHash32 } from '../../../../formatters';
 import { MirrorNodeClient } from '../../../clients';
 import constants from '../../../constants';
 import { JsonRpcError, predefined } from '../../../errors/JsonRpcError';
@@ -278,7 +278,7 @@ export class FilterService implements IFilterService {
         : await this.common.getLatestBlockNumber(requestDetails),
     );
 
-    const result = blockResponse?.blocks?.map((r) => r.hash) || [];
+    const result = blockResponse?.blocks?.map((r) => toHash32(r.hash)) || [];
 
     return { result, latestBlockNumber };
   }

--- a/packages/relay/tests/lib/services/eth/filter.spec.ts
+++ b/packages/relay/tests/lib/services/eth/filter.spec.ts
@@ -22,7 +22,6 @@ import {
   toHex,
   withOverriddenEnvsInMochaTest,
 } from '../../../helpers';
-import { generateEthTestEnv } from '../../eth/eth-helpers';
 
 const logger = pino({ level: 'silent' });
 const registry = new Registry();
@@ -542,9 +541,21 @@ describe('Filter API Test Suite', async function () {
         200,
         JSON.stringify({
           blocks: [
-            { ...defaultBlock, number: defaultBlock.number + 1, hash: '0x1' },
-            { ...defaultBlock, number: defaultBlock.number + 2, hash: '0x2' },
-            { ...defaultBlock, number: defaultBlock.number + 3, hash: '0x3' },
+            {
+              ...defaultBlock,
+              number: defaultBlock.number + 1,
+              hash: '0x814c4894b0d8894966d79d6c22bee808bdf4150a9202cc82e97800b7dc540119cb84fcf5723e0d312322972551f2f6f3',
+            },
+            {
+              ...defaultBlock,
+              number: defaultBlock.number + 2,
+              hash: '0x6caf6ddba4d214b1c4bf5285950335df17499bb7f9a43929935181bc04c0a6193997e56fcaebbcae23a8f65b53df2c6c',
+            },
+            {
+              ...defaultBlock,
+              number: defaultBlock.number + 3,
+              hash: '0x08bac9fc00f257cba1215929cb19355c4ee08679c78e387ca0720142d50758925a0f5283c02dfa3fb37317116f0bc2a2',
+            },
           ],
         }),
       );
@@ -562,12 +573,14 @@ describe('Filter API Test Suite', async function () {
       );
 
       const result = await filterService.getFilterChanges(existingFilterId, requestDetails);
-
       expect(result).to.exist;
       expect(result.length).to.eq(3, 'returns correct number of blocks');
-      expect(result[0]).to.eq('0x1', 'result is in ascending order');
-      expect(result[1]).to.eq('0x2');
-      expect(result[2]).to.eq('0x3');
+      expect(result[0]).to.eq(
+        '0x814c4894b0d8894966d79d6c22bee808bdf4150a9202cc82e97800b7dc540119',
+        'result is in ascending order',
+      );
+      expect(result[1]).to.eq('0x6caf6ddba4d214b1c4bf5285950335df17499bb7f9a43929935181bc04c0a619');
+      expect(result[2]).to.eq('0x08bac9fc00f257cba1215929cb19355c4ee08679c78e387ca0720142d5075892');
 
       const secondResult = await filterService.getFilterChanges(existingFilterId, requestDetails);
       expect(secondResult).to.exist;

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -1091,14 +1091,14 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
         expect(result.length).to.gt(0, 'returns the latest block hashes');
 
         result.forEach((hash: string) => {
-          expect(RelayAssertions.validateHash(hash, 96)).to.eq(true);
+          expect(RelayAssertions.validateHash(hash, 64)).to.eq(true);
         });
 
         await new Promise((r) => setTimeout(r, 2000));
         const result2 = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_FILTER_CHANGES, [filterId], requestId);
         expect(result2).to.exist;
         expect(result2.length).to.be.greaterThanOrEqual(1);
-        expect(RelayAssertions.validateHash(result2[0], 96)).to.eq(true);
+        expect(RelayAssertions.validateHash(result2[0], 64)).to.eq(true);
       });
     });
 


### PR DESCRIPTION
**Description**:

Ensure `eth_getFilterChanges` returns a 32-byte block hash to match Ethereum's expectations.

- Truncate Hedera's 48-byte block hash (from mirror node record files) to 32 bytes
- Aligns with Ethereum's EVM compatibility requirements
- Enables valid usage of returned hashes with `eth_getBlockByHash`
- Fixes compatibility issue affecting downstream clients/tools

**Notes for reviewer**:

Previously, `eth_getFilterChanges` returned 48-byte block hashes, causing `eth_getBlockByHash` to fail with a parameter validation error. This PR ensures that only the first 32 bytes are returned, complying with Ethereum's JSON-RPC spec.

Example of uncorrected output response:
```json
{
    "result": [
      "0x3c08bbbee74d287b1dcd3f0ca6d1d2cb92c90883c4acf9747de9f3f3162ad25b999fc7e86699f60f2a3fb3ed9a646c6b"
    ],
    "jsonrpc": "2.0",
    "id": 1
}
```

Example of corrected output response:
```json
{
    "result": [
        "0x3c08bbbee74d287b1dcd3f0ca6d1d2cb92c90883c4acf9747de9f3f3162ad25b"
    ],
    "jsonrpc": "2.0",
    "id": 1
}
```

**Documentation**:

According to the [Ethereum JSON-RPC Specification](https://ethereum.github.io/execution-apis/docs/reference/eth_getfilterchanges), the `blockHash` must match the following pattern: `^0x[0-9a-f]{64}$`, which represents a 32-byte Ethereum block hash.

Fixes #3975.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
