### PR TITLE
feat: adds Forwarded header to downstream MN requests + custom parsing for Forwarded headers

### DIFF
--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -54,6 +54,115 @@ describe('MirrorNodeClient', async function () {
     await cacheService.clear(requestDetails);
   });
 
+  describe('Forwarded Header', () => {
+    const testAccount = '0.0.123';
+    const mockAccountResponse = { account: testAccount };
+
+    it('should add Forwarded header with IPv4 address', async () => {
+      const ipv4Address = '192.168.1.1';
+      const requestDetailsWithIPv4 = new RequestDetails({
+        requestId: 'testRequest',
+        ipAddress: ipv4Address,
+      });
+
+      mock.onGet(`accounts/${testAccount}${noTransactions}`).reply(function (config) {
+        expect(config.headers!['Forwarded']).to.equal(`for="${ipv4Address}"`);
+        return [200, JSON.stringify(mockAccountResponse)];
+      });
+
+      const result = await mirrorNodeInstance.getAccount(testAccount, requestDetailsWithIPv4);
+      expect(result).to.exist;
+      expect(result.account).to.equal(testAccount);
+    });
+
+    it('should add Forwarded header with IPv6 address wrapped in brackets', async () => {
+      const ipv6Address = '2001:db8::1';
+      const expectedForwardedValue = `for="[${ipv6Address}]"`;
+      const requestDetailsWithIPv6 = new RequestDetails({
+        requestId: 'testRequest',
+        ipAddress: ipv6Address,
+      });
+
+      mock.onGet(`accounts/${testAccount}${noTransactions}`).reply(function (config) {
+        expect(config.headers!['Forwarded']).to.equal(expectedForwardedValue);
+        return [200, JSON.stringify(mockAccountResponse)];
+      });
+
+      const result = await mirrorNodeInstance.getAccount(testAccount, requestDetailsWithIPv6);
+      expect(result).to.exist;
+      expect(result.account).to.equal(testAccount);
+    });
+
+    it('should not add Forwarded header when IP address is empty', async () => {
+      const requestDetailsWithoutIP = new RequestDetails({
+        requestId: 'testRequest',
+        ipAddress: '',
+      });
+
+      mock.onGet(`accounts/${testAccount}${noTransactions}`).reply(function (config) {
+        expect(config.headers).to.not.have.property('Forwarded');
+        return [200, JSON.stringify(mockAccountResponse)];
+      });
+
+      const result = await mirrorNodeInstance.getAccount(testAccount, requestDetailsWithoutIP);
+      expect(result).to.exist;
+      expect(result.account).to.equal(testAccount);
+    });
+
+    it('should not add Forwarded header when IP address is null', async () => {
+      const requestDetailsWithoutIP = new RequestDetails({
+        requestId: 'testRequest',
+        ipAddress: '',
+      });
+
+      mock.onGet(`accounts/${testAccount}${noTransactions}`).reply(function (config) {
+        expect(config.headers).to.not.have.property('Forwarded');
+        return [200, JSON.stringify(mockAccountResponse)];
+      });
+
+      const result = await mirrorNodeInstance.getAccount(testAccount, requestDetailsWithoutIP);
+      expect(result).to.exist;
+      expect(result!.account).to.equal(testAccount);
+    });
+
+    it('should add Forwarded header for POST requests', async () => {
+      const ipv4Address = '10.0.0.1';
+      const requestDetailsWithIP = new RequestDetails({
+        requestId: 'testRequest',
+        ipAddress: ipv4Address,
+      });
+      const mockCallData = { data: 'test' };
+      const mockResponse = { result: '0x123' };
+
+      mock.onPost('contracts/call', mockCallData).reply(function (config) {
+        expect(config.headers!['Forwarded']).to.equal(`for="${ipv4Address}"`);
+        return [200, JSON.stringify(mockResponse)];
+      });
+
+      const result = await mirrorNodeInstance.postContractCall(mockCallData, requestDetailsWithIP);
+      expect(result).to.exist;
+      expect(result!.result).to.equal(mockResponse.result);
+    });
+
+    it('should not modify IPv6 address that already has brackets', async () => {
+      const ipv6AddressWithBrackets = '[2001:db8::1]';
+      const expectedForwardedValue = `for="${ipv6AddressWithBrackets}"`;
+      const requestDetailsWithIPv6 = new RequestDetails({
+        requestId: 'testRequest',
+        ipAddress: ipv6AddressWithBrackets,
+      });
+
+      mock.onGet(`accounts/${testAccount}${noTransactions}`).reply(function (config) {
+        expect(config.headers!['Forwarded']).to.equal(expectedForwardedValue);
+        return [200, JSON.stringify(mockAccountResponse)];
+      });
+
+      const result = await mirrorNodeInstance.getAccount(testAccount, requestDetailsWithIPv6);
+      expect(result).to.exist;
+      expect(result.account).to.equal(testAccount);
+    });
+  });
+
   describe('handleError', async () => {
     const CONTRACT_CALL_ENDPOINT = 'contracts/call';
     const nullResponseCodes = [404];

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -105,10 +105,15 @@ function parseForwardedHeader(forwardedHeader: string): string | null {
     const char = firstEntry[valueStart];
 
     if (char === '"') {
-      // Quoted value: for="192.168.1.1"
+      // Quoted value: for="192.168.1.1" or for="[2001:db8::1]"
       const closeQuoteIndex = firstEntry.indexOf('"', valueStart + 1);
       if (closeQuoteIndex === -1) return null;
       ip = firstEntry.substring(valueStart + 1, closeQuoteIndex);
+
+      // Handle IPv6 in brackets within quotes: for="[2001:db8::1]"
+      if (ip.startsWith('[') && ip.endsWith(']')) {
+        ip = ip.substring(1, ip.length - 1);
+      }
     } else if (char === '[') {
       // IPv6 in brackets: for=[2001:db8::1]
       const closeBracketIndex = firstEntry.indexOf(']', valueStart + 1);


### PR DESCRIPTION

**Description**:
With app.proxy enabled, we already parse X-Forwarded-For headers correctly. Custom parsing for Forwarded headers has been added, along with passing a Forwarded header with the original client IP to the mirror node (if present). All of this was included in the tests coverage

**Related issue(s)**:

Fixes #3772 

