### PR TITLE
feat: Prepare Additional Conformity Test Scenarios (#3886)

### DIFF
--- a/packages/server/tests/acceptance/conformityTests.spec.ts
+++ b/packages/server/tests/acceptance/conformityTests.spec.ts
@@ -124,15 +124,40 @@ async function getLatestBlockHash() {
 
 function splitReqAndRes(content) {
   /**
-   * Splits a given input string into distinct segments representing the request and the response.
+   * Splits a given input string into distinct segments representing the request, the response, and optional wildcard fields.
    *
    * @param {string} content - The input string to be segmented.
-   * @returns {{ request: string, response: string }} - An object containing the separated request and response strings.
+   * @returns {{ request: string, response: string, wildcards: string[] }} - An object containing the separated request, response strings, and wildcard fields.
    */
-  const lines = content.split('\n');
-  const filteredLines = lines.filter((line) => line != '' && !line.startsWith('//')).map((line) => line.slice(3));
+  const lines = content
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  const wildcards = [];
 
-  return { request: filteredLines[0], response: filteredLines[1] };
+  const requestLine = lines.find((line) => line.startsWith('>>'));
+  const responseLine = lines.find((line) => line.startsWith('<<'));
+  const wildcardLine = lines.find((line) => line.startsWith('## wildcard:'));
+
+  if (wildcardLine) {
+    wildcards.push(
+      ...wildcardLine
+        .replace('## wildcard:', '')
+        .trim()
+        .split(',')
+        .map((field) => field.trim()),
+    );
+  }
+
+  if (!requestLine || !responseLine) {
+    throw new Error('Missing or improperly formatted request/response lines');
+  }
+
+  return {
+    request: requestLine.slice(2).trim(),
+    response: responseLine.slice(2).trim(),
+    wildcards,
+  };
 }
 
 async function sendRequestToRelay(request, needError) {
@@ -220,15 +245,61 @@ async function checkRequestBody(fileName, request) {
   return request;
 }
 
-function checkResponseFormat(actualReponse, expectedResponse) {
-  const actualResponseKeys = extractKeys(actualReponse);
+function checkResponseFormat(actualResponse, expectedResponse, wildcards = []) {
+  const actualResponseKeys = extractKeys(actualResponse);
   const expectedResponseKeys = extractKeys(expectedResponse);
   const missingKeys = expectedResponseKeys.filter((key) => !actualResponseKeys.includes(key));
   if (missingKeys.length > 0) {
     return true;
-  } else {
+  }
+
+  return checkValues(actualResponse, expectedResponse, wildcards);
+}
+
+function checkValues(actual, expected, wildcards, path = '') {
+  if (expected === null || expected === undefined) {
+    return actual !== null && actual !== undefined;
+  }
+
+  if (typeof actual !== typeof expected) {
+    return true;
+  }
+
+  if (typeof expected !== 'object') {
+    return actual !== expected;
+  }
+
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual) || actual.length !== expected.length) {
+      return true;
+    }
+
+    for (let i = 0; i < expected.length; i++) {
+      if (checkValues(actual[i], expected[i], wildcards, `${path}[${i}]`)) {
+        return true;
+      }
+    }
+
     return false;
   }
+
+  for (const key in expected) {
+    const newPath = path ? `${path}.${key}` : key;
+
+    if (wildcards.includes(newPath)) {
+      continue;
+    }
+
+    if (!(key in actual)) {
+      return true;
+    }
+
+    if (checkValues(actual[key], expected[key], wildcards, newPath)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 const findSchema = function (file) {
@@ -317,10 +388,22 @@ async function processFileContent(directory, file, content) {
   const needError = JSON.parse(content.response).error;
   const response = await sendRequestToRelay(modifiedRequest, needError);
   const schema = findSchema(directory);
-  const valid = needError
-    ? checkResponseFormat(response.response.data, content.response)
-    : isResponseValid(schema, response);
-  expect(valid).to.be.true;
+
+  const wildcards = content.wildcards || [];
+
+  if (needError) {
+    const valid = checkResponseFormat(response.response.data, content.response, wildcards);
+    expect(valid).to.be.false;
+  } else {
+    if (schema && wildcards.length === 0) {
+      const valid = isResponseValid(schema, response);
+      expect(valid).to.be.true;
+      if (response.result) expect(response.result).to.be.equal(JSON.parse(content.response).result);
+    } else {
+      const hasMissingKeys = checkResponseFormat(response, JSON.parse(content.response), wildcards);
+      expect(hasMissingKeys).to.be.false;
+    }
+  }
 }
 
 const synthesizeTestCases = function (testCases, updateParamIfNeeded) {

--- a/packages/server/tests/acceptance/data/conformity/overwrites/eth_getTransactionByBlockHashAndIndex/get-block-n.io
+++ b/packages/server/tests/acceptance/data/conformity/overwrites/eth_getTransactionByBlockHashAndIndex/get-block-n.io
@@ -1,0 +1,10 @@
+// gets tx 0 in a non-empty block
+// Reason for override: The transaction is generated during test execution and the entire response is replaced
+//
+// The following fields are treated as wildcards — only their presence is validated, not their values
+// All other fields must match exactly.
+
+## wildcard: result.blockHash, result.blockNumber, result.transactionIndex, result.hash, result.nonce, result.r, result.s, result.v
+
+>> {"jsonrpc":"2.0","id":1,"method":"eth_getTransactionByBlockHashAndIndex","params":["0xbb198addc8a129024ed75dbe52a8c89a6baa97980c855241790439db182a210b","0x0"]}
+<< {"jsonrpc":"2.0","id":1,"result":{"blockHash":"0x542b67a7e4bc32e8e047aa6d71b2a94928727e118214df47d06fda59e1750309","blockNumber":"0x7fc","chainId":"0x12a","from":"0xc37f417fa09933335240fca72dd257bfbde9c275","gas":"0x30d40","gasPrice":"0x2c68af0bb14000","hash":"0x3b933c75acd2cd0d0719070ff29981bd290ed2c5f9bae34a0b6239e414725af4","input":"0x","nonce":"0x15","r":"0x7fbd2b7b38a78038a7e29619ac30037356e8c1ac68d5ff398017c3d139e9899a","s":"0x3fe4f050ca5c8d5c8026e0afb1001408009ebb0da88b2f79653218795ec603a8","to":"0x67d8d32e9bf1a9968a5ff53b87d777aa8ebbee69","transactionIndex":"0x4","type":"0x0","v":"0x277","value":"0x2e90edd000"}}

--- a/packages/server/tests/acceptance/data/conformity/overwrites/eth_getTransactionByBlockNumberAndIndex/get-block-n.io
+++ b/packages/server/tests/acceptance/data/conformity/overwrites/eth_getTransactionByBlockNumberAndIndex/get-block-n.io
@@ -1,0 +1,10 @@
+// gets tx 0 in a non-empty block
+// Reason for override: The transaction is generated during test execution and the entire response is replaced
+//
+// The following fields are treated as wildcards — only their presence is validated, not their values
+// All other fields must match exactly.
+
+## wildcard: result.blockHash, result.blockNumber, result.transactionIndex, result.hash, result.nonce, result.r, result.s, result.v
+
+>> {"jsonrpc":"2.0","id":1,"method":"eth_getTransactionByBlockNumberAndIndex","params":["0x1","0x0"]}
+<< {"jsonrpc":"2.0","id":1,"result":{"blockHash":"0xbb198addc8a129024ed75dbe52a8c89a6baa97980c855241790439db182a210b","blockNumber":"0x1","from":"0x7435ed30a8b4aeb0877cef0c6e8cffe834eb865f","gas":"0x13a54","gasPrice":"0x1","hash":"0xc1d605c6612a5fe84dc95810030bfe5b1d327652b381bc695e28f50d13b2b09e","input":"0x600d380380600d6000396000f360004381526020014681526020014181526020014881526020014481526020013281526020013481526020016000f3","nonce":"0x0","to":null,"transactionIndex":"0x0","value":"0x0","type":"0x0","v":"0x1c","r":"0xd642ba4d1f9388c5fd312bb9fb42d189a0b3c796de55093c85f30802a85147c8","s":"0x37aa8680923f811a6988c03dd414ca00cd25d6876ba5925c7ca8ac6aad21669d"}}

--- a/packages/server/tests/acceptance/data/conformity/overwrites/eth_getTransactionCount/get-nonce.io
+++ b/packages/server/tests/acceptance/data/conformity/overwrites/eth_getTransactionCount/get-nonce.io
@@ -1,0 +1,16 @@
+// gets nonce for a known account
+//
+// Reason for override: This test originally uses an address corresponding to a predeployed account included
+// in the chain.rlp block data: https://github.com/ethereum/execution-apis/blob/main/tests/chain.rlp
+//
+// Since we do not replay those transactions before starting the tests, we need a modified version of the test
+// that queries the transaction count for an address (`sendAccountAddress`) that exists on our test node.
+//
+// Note: This is the original test file, modified for our test purposes: https://github.com/ethereum/execution-apis/blob/main/tests/eth_getTransactionCount/get-nonce.io
+// Only the `params[0]` field and the `result` field have been changed:
+// - `params[0]` now points to `sendAccountAddress`
+// - `result` is set to the value returned by `conformityTest` for that address
+// All other fields must remain unchanged to preserve the integrity of the original test case.
+
+>> {"jsonrpc":"2.0","id":1,"method":"eth_getTransactionCount","params":["0xc37f417fA09933335240FCA72DD257BFBdE9C275","latest"]}
+<< {"jsonrpc":"2.0","id":1,"result":"0x7"}

--- a/packages/server/tests/acceptance/data/conformity/overwrites/eth_sendRawTransaction/send-access-list-transaction.io
+++ b/packages/server/tests/acceptance/data/conformity/overwrites/eth_sendRawTransaction/send-access-list-transaction.io
@@ -1,0 +1,37 @@
+// sends a transaction with access list
+// Reason for override: Hedera JSON-RPC does not support access lists defined in EIP-2930.
+//
+// The transaction was prepared with EIP-2930 structure:
+//
+// const tx = {
+//     type: "0x1",
+//     chainId, nonce, gas, gasPrice, to, value,
+//     accessList: [
+//         {
+//             address: "0x67D8d32E9Bf1a9968a5ff53B87d777Aa8EBBEe69",
+//             storageKeys: [],
+//         },
+//     ],
+// };
+//
+// The transaction was successfully received by the Hedera mirror node:
+//
+// Response from mirror node (status=200):
+// method=GET
+// path=/contracts/results/0x4d8eaa41ae21302cac9b746a7aa9007231dd774e04afca6702f95ef67b5d9194
+//
+// Part of the response:
+// {
+//     "access_list": "0x",        // access list was ignored
+//     "chain_id": "0x12a",
+//     "type": 0,                  // transaction type downgraded to legacy
+//     "result": "SUCCESS",
+//     ...
+// }
+//
+// Although the transaction was signed and sent as type 0x1 with an access list,
+// Hedera ignored the accessList field and treated it as a legacy (type 0) transaction.
+// The field "access_list": "0x" confirms that Hedera currently does not support or process EIP-2930 access lists.
+
+>> {"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":["0x01f88783aa36a7808504a817c8008261a89467d8d32e9bf1a9968a5ff53b87d777aa8ebbee69872386f26fc1000080d7d69467d8d32e9bf1a9968a5ff53b87d777aa8ebbee69c001a033f979b49e404e079e6efdcd24f461f776dbffa64cbe46a30241fe378da6c68da02423fbd1c1e50eeae47e50918b4821ad20ff9f370d9984439c039f1610c2664d"]}
+<< {"jsonrpc":"2.0","id":1,"result":"0x4d8eaa41ae21302cac9b746a7aa9007231dd774e04afca6702f95ef67b5d9194"}

--- a/packages/server/tests/acceptance/data/conformity/overwrites/eth_sendRawTransaction/send-dynamic-fee-access-list-transaction.io
+++ b/packages/server/tests/acceptance/data/conformity/overwrites/eth_sendRawTransaction/send-dynamic-fee-access-list-transaction.io
@@ -1,0 +1,41 @@
+// sends a transaction with dynamic fee and access list
+// Reason for override: Combined EIP-1559 and EIP-2930 transactions are not supported on Hedera.
+//
+// The transaction was prepared with EIP-1559 (type: 0x2) and included an access list:
+//
+// const tx = {
+//     type: "0x2",
+//     maxFeePerGas, maxPriorityFeePerGas
+//     chainId, nonce, gasLimit,
+//     to, value,
+//     accessList: [
+//         {
+//             address: "0x67D8d32E9Bf1a9968a5ff53B87d777Aa8EBBEe69",
+//             storageKeys: [],
+//         },
+//     ],
+// };
+//
+// The transaction was successfully received by the Hedera mirror node:
+//
+// Response from mirror node (status=200):
+// method=GET
+// path=/contracts/results/0x1a60a6a335dfb2801c19ee64693769b5a1b156cad5ebcddc35267832324f7cfa
+//
+// Part of the response:
+// {
+//     "access_list": "0x",        // access list was ignored
+//     "chain_id": "0x12a",
+//     "type": 0,                  // transaction type downgraded to legacy
+//     "result": "SUCCESS",
+//     ...
+// }
+//
+// Although the transaction was signed and sent as type 0x2 with a dynamic fee and access list,
+// Hedera ignored both EIP-1559 fee parameters and the access list,
+// treating the transaction as a legacy type (type 0).
+// The field "access_list": "0x" confirms that Hedera currently does not support or process
+// access lists defined in EIP-2930 nor dynamic fee structure from EIP-1559.
+
+>> {"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":["0x02f88c83aa36a78084773594008506fc23ac008261a89467d8d32e9bf1a9968a5ff53b87d777aa8ebbee69872386f26fc1000080d7d69467d8d32e9bf1a9968a5ff53b87d777aa8ebbee69c001a01b39fcf43c10acf60445c7b8796759bbe46b496d580953c559240c4d940c9dc4a00f866cb12cb33f7bff97cf8a8516cc1f8d3ab6fd3201ade6f4d1af5f92798d6b"]}
+<< {"jsonrpc":"2.0","id":1,"result":"0x1a60a6a335dfb2801c19ee64693769b5a1b156cad5ebcddc35267832324f7cfa"}

--- a/packages/server/tests/acceptance/data/conformity/overwrites/eth_sendRawTransaction/send-dynamic-fee-transaction.io
+++ b/packages/server/tests/acceptance/data/conformity/overwrites/eth_sendRawTransaction/send-dynamic-fee-transaction.io
@@ -1,0 +1,34 @@
+// sends a create transaction with dynamic fee
+// Reason for override: Hedera JSON-RPC does not support dynamic fee transactions as defined in EIP-1559.
+//
+// The transaction was prepared with EIP-1559 structure:
+//
+// const tx = {
+//     type: "0x2",
+//     chainId, nonce, to, value, gas,
+//     maxFeePerGas, maxPriorityFeePerGas,
+// };
+//
+// The transaction was successfully received by the Hedera mirror node:
+//
+// Response from mirror node (status=200):
+// method=GET
+// path=/contracts/results/0x1a60a6a335dfb2801c19ee64693769b5a1b156cad5ebcddc35267832324f7cfa
+//
+// Part of the response:
+// {
+//     "type": 0,                        // transaction type downgraded to legacy
+//     "gas_price": "0x1312d0",          // classic gas price used instead of EIP-1559 fields
+//     "max_fee_per_gas": "0x",          // ignored
+//     "max_priority_fee_per_gas": "0x", // ignored
+//     "chain_id": "0x12a",
+//     "result": "SUCCESS",
+//     ...
+// }
+//
+// Although the transaction was signed and sent as type 0x2 with dynamic fee parameters,
+// Hedera ignored the EIP-1559-specific fields and processed it as a legacy transaction (type 0).
+// The presence of "max_fee_per_gas": "0x" and "type": 0 confirms that Hedera currently does not support dynamic fee transactions as defined in EIP-1559.
+
+>> {"jsonrpc":"2.0","id":1,"method":"eth_sendRawTransaction","params":[" 0x02f87583aa36a78084773594008506fc23ac008261a89467d8d32e9bf1a9968a5ff53b87d777aa8ebbee69872386f26fc1000080c080a08b3d60fb1acec0d7f9f65561c13783e02d2c9d7d301493cece3b82375066ef36a020dc52be8de0ca284323a12687a6124a7c22f01ded937217c411ed5a4d7af93d"]}
+<< {"jsonrpc":"2.0","id":1,"result":"0x1a60a6a335dfb2801c19ee64693769b5a1b156cad5ebcddc35267832324f7cfa"}


### PR DESCRIPTION
**Description**:
Add additional conformity tests and extend `conformityTests.spec.ts` to cover Ethereum JSON-RPC methods.

**Related issue(s)**:
Fixes #3886 

**Checklist**

* [ ] Documented (Code comments, README, etc.)
* [ ] Tested (unit, integration, etc.)
