### PR TITLE
feat: ensure rpc params array length according to rpc definitions

### DIFF
--- a/packages/relay/src/lib/validators/index.ts
+++ b/packages/relay/src/lib/validators/index.ts
@@ -1,9 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { predefined } from '../errors/JsonRpcError';
 import { IMethodValidation } from '../types/validation';
 import { validateParam } from './utils';
 
 export function validateParams(params: any[], indexes: IMethodValidation) {
+  if (params.length > Object.keys(indexes).length) {
+    throw predefined.INVALID_REQUEST;
+  }
+
   for (const index of Object.keys(indexes)) {
     const validation = indexes[Number(index)];
     const param = params[Number(index)];

--- a/packages/relay/src/lib/validators/index.ts
+++ b/packages/relay/src/lib/validators/index.ts
@@ -6,7 +6,7 @@ import { validateParam } from './utils';
 
 export function validateParams(params: any[], indexes: IMethodValidation) {
   if (params.length > Object.keys(indexes).length) {
-    throw predefined.INVALID_REQUEST;
+    throw predefined.INVALID_PARAMETERS;
   }
 
   for (const index of Object.keys(indexes)) {

--- a/packages/relay/tests/lib/dispatcher/rpcMethodDispatcher.spec.ts
+++ b/packages/relay/tests/lib/dispatcher/rpcMethodDispatcher.spec.ts
@@ -386,6 +386,15 @@ describe('RpcMethodDispatcher', () => {
   });
 
   describe('End-to-end dispatch tests', () => {
+    it('should handle INVALID_PARAMETERS error properly', async () => {
+      validateParamsStub.throws(predefined.INVALID_PARAMETERS);
+      operationHandler[RPC_PARAM_VALIDATION_RULES_KEY] = { 0: { type: 'boolean' } };
+
+      const result = await dispatcher.dispatch(TEST_METHOD_NAME, ['false', null], TEST_REQUEST_DETAILS);
+      expect(result).to.be.instanceOf(JsonRpcError);
+      expect(result.code).to.equal(predefined.INVALID_PARAMETERS.code);
+    });
+
     it('should handle registered methods with and without parameter validation', async () => {
       // Test with no schema
       let result = await dispatcher.dispatch(TEST_METHOD_NAME, TEST_PARAMS, TEST_REQUEST_DETAILS);

--- a/packages/relay/tests/lib/validators/validators.spec.ts
+++ b/packages/relay/tests/lib/validators/validators.spec.ts
@@ -1,7 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
 import { expect } from 'chai';
 
-import * as Constants from '../../../src/lib/validators/constants';
 import { OBJECTS_VALIDATIONS, TracerType, TransactionObject, Validator } from '../../../src/lib/validators';
+import * as Constants from '../../../src/lib/validators/constants';
 
 describe('Validator', async () => {
   function expectInvalidParam(index: number | string, message: string, paramValue?: string) {
@@ -778,6 +779,12 @@ describe('Validator', async () => {
       expect(() => Validator.validateParams(['0x4422E9088662'], validation)).to.throw(
         "Error invoking RPC: Missing or unsupported param type 'undefined'",
       );
+    });
+
+    it('throws an error if passed params are more than defined validations', async () => {
+      const validation = { 0: { type: 'boolean' } };
+
+      expect(() => Validator.validateParams(['true', null], validation)).to.throw('Invalid params');
     });
 
     it('throws an error if validation type is unknown', async () => {

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -2216,8 +2216,9 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
 
           Assertions.expectedError();
         } catch (e: any) {
-          expect(e.response.status).to.equal(400);
-          Assertions.jsonRpcError(e.response.data.error, predefined.INVALID_REQUEST);
+          const res = e.response;
+          expect(res.status).to.equal(400);
+          Assertions.jsonRpcError(res.data.error, predefined.INVALID_REQUEST);
         }
       });
     };

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -2192,4 +2192,84 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
       );
     });
   });
+
+  describe('Validate length of the rpc parameters array', async function () {
+    const testClient = Axios.create({
+      baseURL: 'http://localhost:' + ConfigService.get('E2E_SERVER_PORT'),
+      responseType: 'json' as const,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      timeout: 30 * 1000,
+    });
+
+    const generateTest = (method, params) => {
+      it(method, async () => {
+        try {
+          await testClient.post('/', {
+            id: '2',
+            jsonrpc: '2.0',
+            method,
+            params,
+          });
+
+          Assertions.expectedError();
+        } catch (e: any) {
+          expect(e.response.status).to.equal(400);
+          Assertions.jsonRpcError(e.response.data.error, predefined.INVALID_REQUEST);
+        }
+      });
+    };
+
+    const TEST_SUITES = {
+      eth_getBalance: ['0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', '0x140d78a', null],
+      eth_getCode: ['0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', '0x140d78a', null],
+      eth_getBlockByHash: ['0x4cc9a77780cf0e6d0dc75373bf00e3437db450ede45cb51b5da936fb46342c99', false, null],
+      eth_getBlockByNumber: ['0x4cc9a7', false, null],
+      eth_getBlockTransactionCountByHash: ['0x4cc9a77780cf0e6d0dc75373bf00e3437db450ede45cb51b5da936fb46342c99', null],
+      eth_getBlockTransactionCountByNumber: ['0x4cc9a779', null],
+      eth_getTransactionByBlockHashAndIndex: [
+        '0x4cc9a77780cf0e6d0dc75373bf00e3437db450ede45cb51b5da936fb46342c99',
+        '0x1',
+        null,
+      ],
+      eth_getTransactionByBlockNumberAndIndex: ['0x4cc9a77', '0x1', null],
+      eth_getTransactionCount: ['0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266', '0x13455', null],
+      eth_sendRawTransaction: [
+        '0xf86a018203e882520894f17f52151ebef6c7334fad080c5704d77216b732896c6b935b8bbd400000801ba093129415f03b4794fd1512e79ee7f097e4271f66721020f8407aac92179893a5a0451b875d89721ec98be55201092980b0a87bb1c48507fccb86da713596b2a09e',
+        null,
+      ],
+      eth_call: [
+        {
+          to: '0x6b175474e89094c44da98b954eedeac495271d0f',
+          data: '0x70a082310000000000000000000000006E0d01A76C3Cf4288372a29124A26D4353EE51BE',
+        },
+        'latest',
+        null,
+      ],
+      eth_getTransactionByHash: ['0x4cc9a77780cf0e6d0dc75373bf00e3437db450ede45cb51b5da936fb46342c99', null],
+      eth_getTransactionReceipt: ['0x4cc9a77780cf0e6d0dc75373bf00e3437db450ede45cb51b5da936fb46342c99', null],
+      eth_getLogs: [
+        {
+          address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+        },
+        null,
+      ],
+      eth_getBlockReceipts: ['0x5661236', null],
+      eth_newFilter: [
+        {
+          address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
+        },
+        null,
+      ],
+      eth_getFilterLogs: ['0xdf2a59ba81f4f052230c9992443cb801', null],
+      eth_getFilterChanges: ['0xdf2a59ba81f4f052230c9992443cb801', null],
+      eth_uninstallFilter: ['0xdf2a59ba81f4f052230c9992443cb801', null],
+    };
+
+    for (const [method, params] of Object.entries(TEST_SUITES)) {
+      generateTest(method, params);
+    }
+  });
 });

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -2218,7 +2218,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
         } catch (e: any) {
           const res = e.response;
           expect(res.status).to.equal(400);
-          Assertions.jsonRpcError(res.data.error, predefined.INVALID_REQUEST);
+          Assertions.jsonRpcError(res.data.error, predefined.INVALID_PARAMETERS);
         }
       });
     };

--- a/packages/ws-server/tests/helper/index.ts
+++ b/packages/ws-server/tests/helper/index.ts
@@ -19,7 +19,7 @@ export class WsTestHelper {
     } catch (error: any) {
       const errorToCheck = error.info || error;
       expect(errorToCheck.error).to.exist;
-      expect(errorToCheck.error.code).to.be.oneOf([-32000, -32602, -32603]);
+      expect(errorToCheck.error.code).to.be.oneOf([-32000, -32600, -32602, -32603]);
     }
   }
 
@@ -55,7 +55,7 @@ export class WsTestHelper {
     const response = await WsTestHelper.sendRequestToStandardWebSocket(method, params);
     WsTestHelper.assertJsonRpcObject(response);
     expect(response.error).to.exist;
-    expect(response.error.code).to.be.oneOf([-32000, -32602, -32603]);
+    expect(response.error.code).to.be.oneOf([-32000, -32600, -32602, -32603]);
   }
 
   static assertJsonRpcObject(obj: any) {

--- a/packages/ws-server/tests/helper/index.ts
+++ b/packages/ws-server/tests/helper/index.ts
@@ -19,7 +19,7 @@ export class WsTestHelper {
     } catch (error: any) {
       const errorToCheck = error.info || error;
       expect(errorToCheck.error).to.exist;
-      expect(errorToCheck.error.code).to.be.oneOf([-32000, -32600, -32602, -32603]);
+      expect(errorToCheck.error.code).to.be.oneOf([-32000, -32602, -32603]);
     }
   }
 
@@ -55,7 +55,7 @@ export class WsTestHelper {
     const response = await WsTestHelper.sendRequestToStandardWebSocket(method, params);
     WsTestHelper.assertJsonRpcObject(response);
     expect(response.error).to.exist;
-    expect(response.error.code).to.be.oneOf([-32000, -32600, -32602, -32603]);
+    expect(response.error.code).to.be.oneOf([-32000, -32602, -32603]);
   }
 
   static assertJsonRpcObject(obj: any) {


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

Some RPC endpoints, like eth_getBalance, do not validate the parameters array length properly. This can lead to a "500 Internal Server Error" when it should have been a 400 error instead.

**Solution**:

Ensure `params` array length is less or equal to `indexes` length [here](https://github.com/hiero-ledger/hiero-json-rpc-relay/blob/8ff3d144fe6bbee268f1d7cf5db74cd5225ff5de/packages/relay/src/lib/validators/index.ts#L7) and throw `INVALID_PARAMETERS` if needed.

**Affected JSON-RPC Methods**:
This issue affects the RPC endpoints that do not use a parameters layout, i.e., `RPC_LAYOUT.custom` nor `RPC_LAYOUT.REQUEST_DETAILS_ONLY`, and logs `requestDetails.formattedRequestId`. These are:
- eth_newFilter
- eth_getFilterLogs
- eth_getFilterChanges
- eth_uninstallFilter
- eth_getBalance
- eth_getCode
- eth_getBlockByHash
- eth_getBlockTransactionCountByHash
- eth_getBlockTransactionCountByNumber
- eth_getTransactionByBlockHashAndIndex
- eth_getTransactionByBlockNumberAndIndex
- eth_getBlockByNumber
- eth_getTransactionCount
- eth_sendRawTransaction
- eth_call
- eth_getTransactionByHash
- eth_getTransactionReceipt
- eth_getLogs
- eth_getBlockReceipts

**Related issue(s)**:

Fixes #3858 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
