### PR TITLE
fix: charts install workflow after introducing Read-Only mode

### DIFF
--- a/charts/hedera-json-rpc-relay-websocket/ci/default-values.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/ci/default-values.yaml
@@ -5,6 +5,7 @@ config:
   MIRROR_NODE_URL: 'https://testnet.mirrornode.hedera.com'
   OPERATOR_ID_MAIN: ""
   OPERATOR_KEY_MAIN: ""
+  READ_ONLY: true
 
 image:
   registry: registry:5001

--- a/charts/hedera-json-rpc-relay/ci/default-values.yaml
+++ b/charts/hedera-json-rpc-relay/ci/default-values.yaml
@@ -5,6 +5,7 @@ config:
   MIRROR_NODE_URL: 'https://testnet.mirrornode.hedera.com'
   OPERATOR_ID_MAIN: ""
   OPERATOR_KEY_MAIN: ""
+  READ_ONLY: true
 
 image:
   registry: registry:5001

--- a/charts/hedera-json-rpc/ci/default-values.yaml
+++ b/charts/hedera-json-rpc/ci/default-values.yaml
@@ -4,6 +4,7 @@ relay:
     CHAIN_ID: '0x128'
     HEDERA_NETWORK: 'testnet'
     MIRROR_NODE_URL: 'https://testnet.mirrornode.hedera.com'
+    READ_ONLY: true
 
   image:
     registry: registry:5001
@@ -14,6 +15,7 @@ ws:
     CHAIN_ID: '0x128'
     HEDERA_NETWORK: 'testnet'
     MIRROR_NODE_URL: 'https://testnet.mirrornode.hedera.com'
+    READ_ONLY: true
 
   image:
     registry: registry:5001


### PR DESCRIPTION
**Description**:

This PR fixes the chart test workflow by setting the `READ_ONLY` flag. In Read-Only mode, both `OPERATOR_ID_MAIN` and `OPERATOR_KEY_MAIN` values are not checked at the start of the Relay/WebSocket.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #3931.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
