### PR TITLE
feat: unify treatment of HEDERA_NETWORK value in Relay and WS charts

### DIFF
--- a/charts/hedera-json-rpc-relay-websocket/templates/configmap.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/templates/configmap.yaml
@@ -7,6 +7,10 @@ metadata:
     {{ include "json-rpc-relay-ws.labels" . | nindent 4 }}
 data:
   {{- range $key, $value := .Values.config }}
-    {{ $key }}: {{ if typeIs "float64" $value }}{{ $value | int64 | quote }}{{ else }}{{ $value | quote }}{{ end }}
+    {{- if eq $key "HEDERA_NETWORK" }}
+      {{ $key }}: {{ if typeIs "string" $value}} {{ $value | lower | quote }} {{else}} {{ printf "{%s}" (tpl (join "," $value | trimPrefix "[" | trimSuffix "]") $) | squote }} {{end}}
+    {{- else }}
+      {{ $key }}: {{ if typeIs "float64" $value }}{{ $value | int64 | quote }}{{ else }}{{ $value | quote }}{{ end }}
+    {{- end }}
   {{- end }}
   {{- include "json-rpc-relay-ws.redis-config" . | nindent 2 }}


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

The `HEDERA_NETWORK` value has special treatment because it can be a JSON string. By default, Helm treats { and } as a list[1](https://github.com/orgs/hashgraph/projects/15/views/5?sliceBy%5Bvalue%5D=natanasow&pane=issue&itemId=119371589&issue=hiero-ledger%7Chiero-json-rpc-relay%7C3921#user-content-fn-1-b3af5f22b487c1b1bedcf7321d1eec07) instead of leaving it as is. The fix was introduced here https://github.com/hiero-ledger/hiero-json-rpc-relay/pull/2498. However, this change was not applied in the WS chart, leading to the difference.

**Related issue(s)**:

Fixes #3921

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
