### PR TITLE
Update the API version to avoid errors

### DIFF
--- a/charts/hedera-json-rpc-relay-websocket/templates/hpa.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/templates/hpa.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "json-rpc-relay-ws.fullname" . }}


### PR DESCRIPTION
Update API verison of HPA.
This change is required otherwise the deployment of HPA or the enablement of autoscaling fails with this error

```
The Kubernetes API could not find version "v2beta1" of autoscaling/HorizontalPodAutoscaler for requested resource integration-docker/integration-docker-websocket. Version "v2" of autoscaling/HorizontalPodAutoscaler is installed on the destination cluster.
```

This api is already in use by the [hedera-json-rpc-relay](https://github.com/hiero-ledger/hiero-json-rpc-relay/tree/main/charts/hedera-json-rpc-relay) chart but it seems to have been left out of the the websocket chart [hedera-json-rpc-relay-websocket](https://github.com/hiero-ledger/hiero-json-rpc-relay/tree/main/charts/hedera-json-rpc-relay-websocket)

Fixes https://github.com/hiero-ledger/hiero-json-rpc-relay/issues/3940