### PR TITLE
fix: displayed error message for `InternalError`

### DIFF
--- a/packages/server/src/koaJsonRpc/index.ts
+++ b/packages/server/src/koaJsonRpc/index.ts
@@ -185,6 +185,7 @@ export default class KoaJsonRpc {
         return jsonResp(request.id, null, result);
       }
     } catch (err) {
+      /* istanbul ignore next: this catch block covers programmatic errors and should not happen */
       return jsonResp(request.id, new InternalError(err), undefined);
     }
   }

--- a/packages/server/src/koaJsonRpc/index.ts
+++ b/packages/server/src/koaJsonRpc/index.ts
@@ -184,8 +184,8 @@ export default class KoaJsonRpc {
       } else {
         return jsonResp(request.id, null, result);
       }
-    } catch (err: any) {
-      return jsonResp(request.id, new InternalError(err.message), undefined);
+    } catch (err) {
+      return jsonResp(request.id, new InternalError(err), undefined);
     }
   }
 

--- a/packages/server/src/koaJsonRpc/lib/RpcError.ts
+++ b/packages/server/src/koaJsonRpc/lib/RpcError.ts
@@ -40,13 +40,11 @@ export class InvalidParams extends JsonRpcError {
 }
 
 export class InternalError extends JsonRpcError {
-  constructor(err) {
-    let message;
-    if (err && err.message) {
-      message = err.message;
-    } else {
-      message = 'Internal error';
-    }
+  /**
+   * @param err The error object that caused this `InternalError`.
+   */
+  constructor(err: unknown) {
+    const message = err && typeof err === 'object' && 'message' in err ? err.message : 'Internal error';
     super(message, -32603, undefined);
   }
 }

--- a/packages/server/tests/integration/koaJsonRpc/rpcError.spec.ts
+++ b/packages/server/tests/integration/koaJsonRpc/rpcError.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { expect } from 'chai';
+
 import {
   HBARRateLimitExceeded,
   InternalError,
@@ -70,18 +71,19 @@ describe('RpcErrors', () => {
 
   describe('InternalError', () => {
     it('should create an InternalError with provided error message and code', () => {
-      const err = new Error('Specific internal error');
-      const error = new InternalError(err);
+      const error = new InternalError(new Error('Specific internal error'));
       expect(error.message).to.equal('Specific internal error');
       expect(error.code).to.equal(-32603);
       expect(error.data).to.be.undefined;
     });
 
-    it('should create an InternalError with default message when no error is provided', () => {
-      const error = new InternalError(undefined);
-      expect(error.message).to.equal('Internal error');
-      expect(error.code).to.equal(-32603);
-      expect(error.data).to.be.undefined;
+    [undefined, null, 'error', 1, {}].forEach((input) => {
+      it(`should create an InternalError with default message when input is '${input}'`, function () {
+        const error = new InternalError(input);
+        expect(error.message).to.equal('Internal error');
+        expect(error.code).to.equal(-32603);
+        expect(error.data).to.be.undefined;
+      });
     });
   });
 

--- a/packages/server/tests/integration/koaJsonRpc/rpcError.spec.ts
+++ b/packages/server/tests/integration/koaJsonRpc/rpcError.spec.ts
@@ -25,7 +25,7 @@ describe('RpcErrors', () => {
     });
 
     it('should set data as undefined if not provided', () => {
-      const error = new JsonRpcError('Test message', -32000);
+      const error = new JsonRpcError('Test message', -32000, undefined);
       expect(error.message).to.equal('Test message');
       expect(error.code).to.equal(-32000);
       expect(error.data).to.be.undefined;

--- a/packages/ws-server/src/controllers/jsonRpcController.ts
+++ b/packages/ws-server/src/controllers/jsonRpcController.ts
@@ -69,8 +69,8 @@ const handleSendingRequestsToRelay = async ({
     } else {
       return jsonResp(request.id, null, result);
     }
-  } catch (error: any) {
-    return jsonResp(request.id, new InternalError(error.message), undefined);
+  } catch (err) {
+    return jsonResp(request.id, new InternalError(err), undefined);
   }
 };
 


### PR DESCRIPTION
**Description**:

This PR correctly displays the root error message when an `InternalError` is returned.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #3949.

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
