### PR TITLE
feat: adds new decorators following the typescript v5 standard

### DIFF
--- a/packages/relay/src/lib/decorators/cache.decorator.ts
+++ b/packages/relay/src/lib/decorators/cache.decorator.ts
@@ -27,23 +27,139 @@ interface CacheOptions {
 }
 
 /**
- * Iterates through the provided 'params' array and checks if any argument in 'args' at the specified 'index'
- * matches one of the pipe-separated values in 'value'. If a match is found, caching should be skipped.
+ * This decorator uses a `CacheService` to attempt to retrieve a cached result before executing the original method. If
+ * no cached response exists, the method is executed and its result may be stored in the cache depending on configurable
+ * options. Caching can be conditionally skipped based on runtime arguments via `skipParams` (for positional args)
+ * and `skipNamedParams` (for object args).
  *
- * @param args - The arguments passed to the method in an array
- * @param params - An array of CacheSingleParam caching rules
- * @returns 'true' if any argument matches a rule and caching should be skipped; otherwise, 'false'.
+ * Legacy decorator for TypeScript 4.x with --experimentalDecorators.
+ * For TypeScript 5+ standard decorators, use @cacheStandard instead.
+ *
+ * @param cacheService - The caching service used to store and retrieve cache entries.
+ * @param options - Optional configuration for caching behavior.
+ *   @property skipParams - An array of rules for skipping caching based on specific argument values.
+ *   @property skipNamedParams - An array of rules for skipping caching based on fields within argument objects.
+ *   @property ttl - Optional time-to-live for the cache entry; falls back to global config if not provided.
+ *
+ * @returns A method decorator function that wraps the original method with caching logic.
  *
  * @example
- *   [{
- *     index: '0',
- *     value: 'pending|safe'
+ *   @cache(CacheService, { skipParams: [...], skipNamesParams: [...], ttl: 300 })
+ */
+export function cache(cacheService: CacheService, options: CacheOptions = {}) {
+  return function (_target: any, _propertyKey: string, descriptor: PropertyDescriptor) {
+    const method = descriptor.value;
+
+    descriptor.value = async function (...args: unknown[]) {
+      const requestDetails = extractRequestDetails(args);
+      const cacheKey = generateCacheKey(method.name, args);
+
+      const cachedResponse = await cacheService.getAsync(cacheKey, method, requestDetails);
+      if (cachedResponse) {
+        return cachedResponse;
+      }
+
+      const result = await method.apply(this, args);
+      if (
+        result &&
+        !shouldSkipCachingForSingleParams(args, options?.skipParams) &&
+        !shouldSkipCachingForNamedParams(args, options?.skipNamedParams)
+      ) {
+        await cacheService.set(
+          cacheKey,
+          result,
+          method,
+          requestDetails,
+          options?.ttl ?? ConfigService.get('CACHE_TTL'),
+        );
+      }
+
+      return result;
+    };
+  };
+}
+
+/**
+ * TypeScript 5+ standard cache decorator.
+ * This is the clean, modern version for TypeScript 5+ without legacy compatibility.
+ *
+ * Uses a `CacheService` to attempt to retrieve a cached result before executing the original method. If
+ * no cached response exists, the method is executed and its result may be stored in the cache depending on configurable
+ * options. Caching can be conditionally skipped based on runtime arguments via `skipParams` (for positional args)
+ * and `skipNamedParams` (for object args).
+ *
+ * @param cacheService - The caching service used to store and retrieve cache entries.
+ * @param options - Optional configuration for caching behavior.
+ *   @property skipParams - An array of rules for skipping caching based on specific argument values.
+ *   @property skipNamedParams - An array of rules for skipping caching based on fields within argument objects.
+ *   @property ttl - Optional time-to-live for the cache entry; falls back to global config if not provided.
+ *
+ * @returns A method decorator function that wraps the original method with caching logic.
+ *
+ * @example
+ *   @cacheStandard(CacheService, { skipParams: [...], skipNamesParams: [...], ttl: 300 })
+ */
+export function cacheStandard(cacheService: CacheService, options: CacheOptions = {}) {
+  return function (target: any, context: ClassMethodDecoratorContext): void {
+    if (context.kind !== 'method') {
+      throw new Error(`@cacheStandard can only be applied to methods, received: ${context.kind}`);
+    }
+
+    const methodName = String(context.name);
+
+    // Use addInitializer to replace the method implementation with cached version
+    context.addInitializer(function (this: any) {
+      const originalMethod = this[context.name as string | symbol];
+
+      // Replace the method with the cached version
+      this[context.name as string | symbol] = async function (this: any, ...args: unknown[]) {
+        const requestDetails = extractRequestDetails(args);
+        const cacheKey = generateCacheKey(methodName, args);
+
+        const cachedResponse = await cacheService.getAsync(cacheKey, methodName, requestDetails);
+        if (cachedResponse) {
+          return cachedResponse;
+        }
+
+        const result = await originalMethod.apply(this, args);
+        if (
+          result &&
+          !shouldSkipCachingForSingleParams(args, options?.skipParams) &&
+          !shouldSkipCachingForNamedParams(args, options?.skipNamedParams)
+        ) {
+          await cacheService.set(
+            cacheKey,
+            result,
+            methodName,
+            requestDetails,
+            options?.ttl ?? ConfigService.get('CACHE_TTL'),
+          );
+        }
+
+        return result;
+      };
+    });
+  };
+}
+
+/**
+ * This is a predicate function that takes a list of arguments and parameters,
+ * and it checks whether the given function should skip caching based on specific positional argument values.
+ *
+ * @param args - A list of arguments passed to a function
+ * @param params - An array of rules for skipping caching
+ * @returns A boolean indicating whether caching should be skipped for the provided arguments
+ *
+ * @example
+ *   skipParams: [{
+ *     index: "0",
+ *     value: "latest|pending"
  *   }]
  */
 const shouldSkipCachingForSingleParams = (args: unknown[], params: CacheSingleParam[] = []): boolean => {
   for (const item of params) {
     const values = item.value.split('|');
-    if (values.indexOf(args[item.index]) > -1) {
+    if (values.includes(args[item.index])) {
       return true;
     }
 
@@ -58,23 +174,20 @@ const shouldSkipCachingForSingleParams = (args: unknown[], params: CacheSinglePa
 };
 
 /**
- * Determines whether caching should be skipped based on field-level conditions within specific argument objects. For each
- * item in 'params', the function inspects a corresponding argument at the specified 'index' in 'args'. It builds
- * a list of field-based skip conditions and checks if any of the fields in the input argument match any of the provided
- * values (supports multiple values via pipe '|' separators).
+ * This is a predicate function that takes a list of arguments and parameters,
+ * and it checks whether the given function should skip caching based on fields within argument objects.
  *
- * @param args - The function's arguments object, where values are accessed by index.
- * @param params - An array of `CacheNamedParams` defining which arguments and which fields to inspect.
- * @returns `true` if any field value matches a skip condition; otherwise, `false`.
+ * @param args - A list of arguments passed to a function
+ * @param params - An array of rules for skipping caching
+ * @returns A boolean indicating whether caching should be skipped for the provided arguments
  *
  * @example
- *   [{
- *     index: '0',
+ *   skipNamedParams: [{
+ *     index: "0",
  *     fields: [{
- *       name: 'fromBlock', value: 'pending|safe'
- *     }, {
- *       name: 'toBlock', value: 'safe|finalized'
- *     }],
+ *       name: "blockTag",
+ *       value: "latest|pending"
+ *     }]
  *   }]
  */
 const shouldSkipCachingForNamedParams = (args: unknown[], params: CacheNamedParams[] = []): boolean => {
@@ -150,56 +263,6 @@ const extractRequestDetails = (args: unknown[]): RequestDetails => {
 
   return new RequestDetails({ requestId: '', ipAddress: '' });
 };
-
-/**
- * This decorator uses a `CacheService` to attempt to retrieve a cached result before executing the original method. If
- * no cached response exists, the method is executed and its result may be stored in the cache depending on configurable
- * options. Caching can be conditionally skipped based on runtime arguments via `skipParams` (for positional args)
- * and `skipNamedParams` (for object args).
- *
- * @param cacheService - The caching service used to store and retrieve cache entries.
- * @param options - Optional configuration for caching behavior.
- *   @property skipParams - An array of rules for skipping caching based on specific argument values.
- *   @property skipNamedParams - An array of rules for skipping caching based on fields within argument objects.
- *   @property ttl - Optional time-to-live for the cache entry; falls back to global config if not provided.
- *
- * @returns A method decorator function that wraps the original method with caching logic.
- *
- * @example
- *   @cache(CacheService, { skipParams: [...], skipNamesParams: [...], ttl: 300 })
- */
-export function cache(cacheService: CacheService, options: CacheOptions = {}) {
-  return function (_target: any, _propertyKey: string, descriptor: PropertyDescriptor) {
-    const method = descriptor.value;
-
-    descriptor.value = async function (...args: unknown[]) {
-      const requestDetails = extractRequestDetails(args);
-      const cacheKey = generateCacheKey(method.name, args);
-
-      const cachedResponse = await cacheService.getAsync(cacheKey, method, requestDetails);
-      if (cachedResponse) {
-        return cachedResponse;
-      }
-
-      const result = await method.apply(this, args);
-      if (
-        result &&
-        !shouldSkipCachingForSingleParams(args, options?.skipParams) &&
-        !shouldSkipCachingForNamedParams(args, options?.skipNamedParams)
-      ) {
-        await cacheService.set(
-          cacheKey,
-          result,
-          method,
-          requestDetails,
-          options?.ttl ?? ConfigService.get('CACHE_TTL'),
-        );
-      }
-
-      return result;
-    };
-  };
-}
 
 // export private methods under __test__ "namespace" but using const
 // due to `ES2015 module syntax is preferred over namespaces` eslint warning

--- a/packages/relay/src/lib/decorators/rpcMethod.decorator.ts
+++ b/packages/relay/src/lib/decorators/rpcMethod.decorator.ts
@@ -45,12 +45,15 @@ export function rpcMethod(_target: any, _propertyKey: string, descriptor: Proper
  *   }
  * }
  * ```
+ *
+ * @param target - The prototype of the class
+ * @param context - The context of the method
+ * @returns void
  */
 export function rpcMethodStandard(target: any, context: ClassMethodDecoratorContext): void {
   if (context.kind !== 'method') {
     throw new Error(`@rpcMethodStandard can only be applied to methods, received: ${context.kind}`);
   }
 
-  // Mark the method as RPC-enabled
   (target as any)[RPC_METHOD_KEY] = true;
 }

--- a/packages/relay/src/lib/decorators/rpcMethod.decorator.ts
+++ b/packages/relay/src/lib/decorators/rpcMethod.decorator.ts
@@ -7,8 +7,10 @@
 export const RPC_METHOD_KEY = 'hedera-rpc-method';
 
 /**
- * Decorator that marks a class method as an RPC method.
+ * Legacy decorator that marks a class method as an RPC method (TypeScript 4.x with --experimentalDecorators).
  * When applied to a method, it marks that method as available for RPC invocation.
+ *
+ * For TypeScript 5+ standard decorators, use @rpcMethodStandard instead.
  *
  * @example
  * ```typescript
@@ -28,4 +30,27 @@ export const RPC_METHOD_KEY = 'hedera-rpc-method';
 export function rpcMethod(_target: any, _propertyKey: string, descriptor: PropertyDescriptor) {
   descriptor.value[RPC_METHOD_KEY] = true;
   return descriptor;
+}
+
+/**
+ * TypeScript 5+ standard decorator that marks a class method as an RPC method.
+ * This is the clean, modern version for TypeScript 5+ without legacy compatibility.
+ *
+ * @example
+ * ```typescript
+ * class NetImpl {
+ *   @rpcMethodStandard
+ *   listening(): boolean {
+ *     return false;
+ *   }
+ * }
+ * ```
+ */
+export function rpcMethodStandard(target: any, context: ClassMethodDecoratorContext): void {
+  if (context.kind !== 'method') {
+    throw new Error(`@rpcMethodStandard can only be applied to methods, received: ${context.kind}`);
+  }
+
+  // Mark the method as RPC-enabled
+  (target as any)[RPC_METHOD_KEY] = true;
 }

--- a/packages/relay/src/lib/decorators/rpcParamLayoutConfig.decorator.ts
+++ b/packages/relay/src/lib/decorators/rpcParamLayoutConfig.decorator.ts
@@ -60,31 +60,35 @@ export function rpcParamLayoutConfig(layout: string | ParamTransformFn) {
 
 /**
  * TypeScript 5+ standard decorator for specifying the parameter layout of an RPC method.
- * This is the clean, modern version for TypeScript 5+ without legacy compatibility.
  *
- * This decorator attaches metadata to methods to configure how parameters should be arranged
- * when the method is called via RPC.
- *
- * @param config - Either a string identifier for built-in layouts or a transform function
- * @returns A method decorator
+ * This decorator defines how RPC parameters should be arranged when passed to the method.
  *
  * @example
  * ```typescript
- * class EthImpl {
- *   @rpcParamLayoutConfigStandard(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
- *   listening(): boolean {
- *     return false;
- *   }
+ * // Method that only needs requestDetails
+ * @rpcMethod
+ * @rpcParamSpecialLayout(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
+ * blockNumber(requestDetails: RequestDetails): Promise<string> {
+ *   // Implementation
+ * }
+ *
+ * // Method with specific parameter transformations
+ * @rpcMethod
+ * @rpcParamSpecialLayout(RPC_LAYOUT.custom(params => [params[0], params[1]]))
+ * estimateGas(transaction: IContractCallRequest, _blockParam: string | null, requestDetails: RequestDetails,): Promise<string | JsonRpcError> {
+ *   // Implementation
  * }
  * ```
+ *
+ * @param layout - Parameter layout specification
  */
-export function rpcParamLayoutConfigStandard(config: string | ParamTransformFn) {
+export function rpcParamLayoutConfigStandard(layout: string | ParamTransformFn) {
   return function (target: any, context: ClassMethodDecoratorContext): void {
     if (context.kind !== 'method') {
       throw new Error(`@rpcParamLayoutConfigStandard can only be applied to methods, received: ${context.kind}`);
     }
 
     // Attach parameter layout configuration to the method
-    (target as any)[RPC_PARAM_LAYOUT_KEY] = config;
+    (target as any)[RPC_PARAM_LAYOUT_KEY] = layout;
   };
 }

--- a/packages/relay/src/lib/decorators/rpcParamLayoutConfig.decorator.ts
+++ b/packages/relay/src/lib/decorators/rpcParamLayoutConfig.decorator.ts
@@ -28,7 +28,7 @@ export const RPC_LAYOUT = {
 };
 
 /**
- * Decorator for specifying the parameter layout of an RPC method which is different from the standard layout
+ * Legacy decorator for specifying the parameter layout of an RPC method which is different from the standard layout
  *
  * This decorator defines how RPC parameters should be arranged when passed to the method.
  *
@@ -55,5 +55,36 @@ export function rpcParamLayoutConfig(layout: string | ParamTransformFn) {
   return function (_target: any, _propertyKey: string, descriptor: PropertyDescriptor) {
     descriptor.value[RPC_PARAM_LAYOUT_KEY] = layout;
     return descriptor;
+  };
+}
+
+/**
+ * TypeScript 5+ standard decorator for specifying the parameter layout of an RPC method.
+ * This is the clean, modern version for TypeScript 5+ without legacy compatibility.
+ *
+ * This decorator attaches metadata to methods to configure how parameters should be arranged
+ * when the method is called via RPC.
+ *
+ * @param config - Either a string identifier for built-in layouts or a transform function
+ * @returns A method decorator
+ *
+ * @example
+ * ```typescript
+ * class EthImpl {
+ *   @rpcParamLayoutConfigStandard(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
+ *   listening(): boolean {
+ *     return false;
+ *   }
+ * }
+ * ```
+ */
+export function rpcParamLayoutConfigStandard(config: string | ParamTransformFn) {
+  return function (target: any, context: ClassMethodDecoratorContext): void {
+    if (context.kind !== 'method') {
+      throw new Error(`@rpcParamLayoutConfigStandard can only be applied to methods, received: ${context.kind}`);
+    }
+
+    // Attach parameter layout configuration to the method
+    (target as any)[RPC_PARAM_LAYOUT_KEY] = config;
   };
 }

--- a/packages/relay/src/lib/validators/index.ts
+++ b/packages/relay/src/lib/validators/index.ts
@@ -31,7 +31,7 @@ export interface IParamValidation {
 export const RPC_PARAM_VALIDATION_RULES_KEY = 'hedera-rpc-param-validation-rules';
 
 /**
- * Decorator that defines a schema for validating RPC method parameters
+ * Legacy decorator that defines a schema for validating RPC method parameters
  *
  * @example
  * ```typescript
@@ -53,6 +53,36 @@ export function rpcParamValidationRules(validationRules: Record<number, IParamVa
     // Store validation rules directly on the function as a property
     descriptor.value[RPC_PARAM_VALIDATION_RULES_KEY] = validationRules;
     return descriptor;
+  };
+}
+
+/**
+ * TypeScript 5+ standard decorator that defines a schema for validating RPC method parameters.
+ * This is the clean, modern version for TypeScript 5+ without legacy compatibility.
+ *
+ * @example
+ * ```typescript
+ * @rpcMethodStandard
+ * @rpcParamValidationRulesStandard({
+ *   0: { type: 'address', required: true },
+ *   1: { type: 'blockNumber', required: true }
+ * })
+ * getBalance(address: string, blockNumber: string, requestDetails: RequestDetails): Promise<string> {
+ *   // Implementation
+ * }
+ * ```
+ *
+ * @param validationRules - Validation rules for method parameters
+ * @returns Method decorator function
+ */
+export function rpcParamValidationRulesStandard(validationRules: Record<number, IParamValidation>) {
+  return function (target: any, context: ClassMethodDecoratorContext): void {
+    if (context.kind !== 'method') {
+      throw new Error(`@rpcParamValidationRulesStandard can only be applied to methods, received: ${context.kind}`);
+    }
+
+    // Store validation rules directly on the function as a property
+    (target as any)[RPC_PARAM_VALIDATION_RULES_KEY] = validationRules;
   };
 }
 


### PR DESCRIPTION
**Description**:
Adds new decorators with the same functionality as our existing ones following the typescript v5 standard. The new decorators are suffixed with `Standard`.  When we update the repo version, the old ones should be deleted (or suffixed with `Legacy` for example if we deem them to be necessary), and the new ones should be renamed e.g. `cacheStandard` -> `cache`. No further changes to the code will be required

**Related issue(s)**:

Fixes #3593 

**Notes for reviewer**:
It was tricky to set up typescript v5 for an automated test, but I have manually tested and verified the four new decorators work in a local mini sandbox environment that I have set up. 

There was one ugly way to achieve this task without creating new decorators. As of v4, the decorators take 3 params - `target`, `propertyKey`, `descriptor`. As of v5 it's only 2 `target` and `context`. So if we rename the 2nd param (which we don't use) to `context` and we check conditionally if it's a context object in order to execute the v5 logic. If not, we proceed with handling the `descriptor` object which would have been ignored in v5. However I decided against this approach since it would create confusion

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
