### PR TITLE
feat: gracefully handle HTML error responses from remote Mirror Node server

### DIFF
--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -378,19 +378,16 @@ export class MirrorNodeClient {
             (data) => {
               // if the data is not valid, just return it to stick to the current behaviour
               if (data) {
-                if (
-                  typeof data === 'string' &&
-                  (data.trim().startsWith('<html') ||
-                    data.trim().startsWith('<!DOCTYPE html') ||
-                    data.trim().startsWith('<'))
-                ) {
-                  // Most likely HTML error response from the remote server.
-                  // Return raw data so response can be processed properly by subsequent operations.
-                  return data;
+                try {
+                  return JSONBigInt.parse(data);
+                } catch (error) {
+                  this.logger.warn(
+                    `${requestDetails.formattedRequestId} Failed to parse response data from Mirror Node: ${error}`,
+                  );
                 }
-                return JSONBigInt.parse(data);
               }
 
+              // Return raw data so response can be processed properly by subsequent operations.
               return data;
             },
           ];

--- a/packages/relay/tests/lib/mirrorNodeClient.spec.ts
+++ b/packages/relay/tests/lib/mirrorNodeClient.spec.ts
@@ -217,6 +217,14 @@ describe('MirrorNodeClient', async function () {
         .to.eventually.be.rejectedWith('Request failed with status code 502')
         .and.have.property('statusCode', 502);
     });
+
+    it('should gracefully handle empty error responses', async () => {
+      // Simulate Mirror Node returning HTML error page
+      mock.onGet('accounts').reply(503, ``);
+      await expect(mirrorNodeInstance.get('accounts', 'accounts', requestDetails))
+        .to.eventually.be.rejectedWith('Request failed with status code 503')
+        .and.have.property('statusCode', 503);
+    });
   });
 
   it('Can extract the account number out of an account pagination next link url', async () => {


### PR DESCRIPTION
### Description

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->
This PR adds an HTML error response checker to the MirrorNodeClient class, enabling it to detect when a response is HTML rather than a valid JSON object. This prevents parsing errors in the transformResponse interceptor. If the response is identified as HTML, the interceptor returns the raw data, allowing the MirrorNodeClient to handle the response appropriately.

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #3711 

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1. New unit test was added in mirrorNodeClient.spec.ts, under `should gracefully handle HTML error responses` unit
2. Run Relay unit test
3. Observe the test passing indicating the new logic works as expected.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
