### PR TITLE
feat: increased k6 coverage for all RPC endpoints

### DIFF
--- a/k6/src/prepare/prep.js
+++ b/k6/src/prepare/prep.js
@@ -66,9 +66,7 @@ async function getSignedTxs(wallet, greeterContracts, gasPrice, gasLimit, chainI
   const mainWallet = new ethers.Wallet(mainPrivateKeyString, provider);
   console.log('RPC Server:  ' + process.env.RELAY_BASE_URL);
   console.log('Main Wallet Address: ' + mainWallet.address);
-  console.log(
-    'Main Wallet Initial Balance: ' + formatEther(await provider.getBalance(mainWallet.address)) + ' HBAR',
-  );
+  console.log('Main Wallet Initial Balance: ' + formatEther(await provider.getBalance(mainWallet.address)) + ' HBAR');
   const usersCount = process.env.WALLETS_AMOUNT ? process.env.WALLETS_AMOUNT : 1;
   const contractsCount = process.env.SMART_CONTRACTS_AMOUNT ? process.env.SMART_CONTRACTS_AMOUNT : 1;
   const smartContracts = [];
@@ -129,6 +127,26 @@ async function getSignedTxs(wallet, greeterContracts, gasPrice, gasLimit, chainI
   const latestBlock = await provider.getBlockNumber();
   console.log('Latest Block: ' + latestBlock);
 
+  // Create filters for testing filter endpoints
+  console.log('Creating filters for testing...');
+  const filters = {};
+
+  // Create a block filter
+  const blockFilterResponse = await provider.send('eth_newBlockFilter', []);
+  filters.blockFilterId = blockFilterResponse;
+  console.log('Block filter created:', blockFilterResponse);
+
+  // Create a log filter
+  const logFilterResponse = await provider.send('eth_newFilter', [
+    {
+      fromBlock: 'latest',
+      toBlock: 'latest',
+      address: smartContracts[0], // Use first contract address
+    },
+  ]);
+  filters.logFilterId = logFilterResponse;
+  console.log('Log filter created:', logFilterResponse);
+
   console.log('Creating smartContractParams.json file...');
 
   const output = {};
@@ -137,6 +155,7 @@ async function getSignedTxs(wallet, greeterContracts, gasPrice, gasLimit, chainI
   output['contractAddress'] = smartContracts[0];
   output['contractsAddresses'] = smartContracts;
   output['wallets'] = wallets;
+  output['filters'] = filters;
 
   fs.writeFileSync(path.resolve(__dirname) + '/.smartContractParams.json', JSON.stringify(output, null, 2));
 })();

--- a/k6/src/scenarios/test/debug_traceBlockByNumber.js
+++ b/k6/src/scenarios/test/debug_traceBlockByNumber.js
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
+
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
-import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { getPayLoad,httpParams, isNonErrorResponse } from './common.js';
 
 const methodName = 'debug_traceBlockByNumber';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/debug_traceBlockByNumber.js
+++ b/k6/src/scenarios/test/debug_traceBlockByNumber.js
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
-
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';

--- a/k6/src/scenarios/test/debug_traceBlockByNumber.js
+++ b/k6/src/scenarios/test/debug_traceBlockByNumber.js
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+
+import { TestScenarioBuilder } from '../../lib/common.js';
+import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
+
+const methodName = 'debug_traceBlockByNumber';
+const { options, run } = new TestScenarioBuilder()
+  .name(methodName) // use unique scenario name among all tests
+  .request((testParameters) => {
+    // Use 'latest' block for consistent testing
+    const blockNumber = 'latest';
+    return http.post(testParameters.RELAY_BASE_URL, getPayLoad(methodName, [blockNumber]), httpParams);
+  })
+  .check(methodName, (r) => isNonErrorResponse(r))
+  .maxDuration(5000) // Extended timeout for potentially slow debug responses
+  .testDuration('3s')
+  .build();
+
+export { options, run };
+
+export const setup = setupTestParameters;

--- a/k6/src/scenarios/test/debug_traceBlockByNumber.js
+++ b/k6/src/scenarios/test/debug_traceBlockByNumber.js
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
-import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 
 const methodName = 'debug_traceBlockByNumber';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/debug_traceTransaction.js
+++ b/k6/src/scenarios/test/debug_traceTransaction.js
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
-import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 
 const methodName = 'debug_traceTransaction';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/debug_traceTransaction.js
+++ b/k6/src/scenarios/test/debug_traceTransaction.js
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
-
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';

--- a/k6/src/scenarios/test/debug_traceTransaction.js
+++ b/k6/src/scenarios/test/debug_traceTransaction.js
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
+
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
-import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { getPayLoad,httpParams, isNonErrorResponse } from './common.js';
 
 const methodName = 'debug_traceTransaction';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/debug_traceTransaction.js
+++ b/k6/src/scenarios/test/debug_traceTransaction.js
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+
+import { TestScenarioBuilder } from '../../lib/common.js';
+import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
+
+const methodName = 'debug_traceTransaction';
+const { options, run } = new TestScenarioBuilder()
+  .name(methodName) // use unique scenario name among all tests
+  .request((testParameters) => {
+    // Use existing transaction hash from test parameters
+    const transactionHash = testParameters.DEFAULT_TRANSACTION_HASH;
+    return http.post(testParameters.RELAY_BASE_URL, getPayLoad(methodName, [transactionHash]), httpParams);
+  })
+  .check(methodName, (r) => isNonErrorResponse(r))
+  .maxDuration(5000) // Extended timeout for potentially slow debug responses
+  .testDuration('3s')
+  .build();
+
+export { options, run };
+
+export const setup = setupTestParameters;

--- a/k6/src/scenarios/test/eth_blobBaseFee.js
+++ b/k6/src/scenarios/test/eth_blobBaseFee.js
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import http from 'k6/http';
 
+
+import http from 'k6/http';
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { is400Status, httpParams, getPayLoad } from './common.js';
-
-const url = __ENV.RELAY_BASE_URL;
 
 const methodName = 'eth_blobBaseFee';
 const { options, run } = new TestScenarioBuilder()
   .name(methodName) // use unique scenario name among all tests
-  .request(() => http.post(url, getPayLoad(methodName), httpParams))
+  .request((testParameters) => http.post(testParameters.RELAY_BASE_URL, getPayLoad(methodName), httpParams))
   .check(methodName, (r) => is400Status(r))
   .build();
 

--- a/k6/src/scenarios/test/eth_blobBaseFee.js
+++ b/k6/src/scenarios/test/eth_blobBaseFee.js
@@ -3,8 +3,8 @@
 
 
 import http from 'k6/http';
-import { TestScenarioBuilder } from '../../lib/common.js';
 import { is400Status, httpParams, getPayLoad } from './common.js';
+import { TestScenarioBuilder } from '../../lib/common.js';
 
 const methodName = 'eth_blobBaseFee';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_blobBaseFee.js
+++ b/k6/src/scenarios/test/eth_blobBaseFee.js
@@ -3,8 +3,9 @@
 
 
 import http from 'k6/http';
-import { is400Status, httpParams, getPayLoad } from './common.js';
+
 import { TestScenarioBuilder } from '../../lib/common.js';
+import { getPayLoad,httpParams, is400Status } from './common.js';
 
 const methodName = 'eth_blobBaseFee';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_blobBaseFee.js
+++ b/k6/src/scenarios/test/eth_blobBaseFee.js
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+
+import { TestScenarioBuilder } from '../../lib/common.js';
+import { is400Status, httpParams, getPayLoad } from './common.js';
+
+const url = __ENV.RELAY_BASE_URL;
+
+const methodName = 'eth_blobBaseFee';
+const { options, run } = new TestScenarioBuilder()
+  .name(methodName) // use unique scenario name among all tests
+  .request(() => http.post(url, getPayLoad(methodName), httpParams))
+  .check(methodName, (r) => is400Status(r))
+  .build();
+
+export { options, run };

--- a/k6/src/scenarios/test/eth_createAccessList.js
+++ b/k6/src/scenarios/test/eth_createAccessList.js
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import http from 'k6/http';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+import http from 'k6/http';
+
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
-import { is400Status, httpParams, getPayLoad } from './common.js';
+import { getPayLoad,httpParams, is400Status } from './common.js';
 
 const methodName = 'eth_createAccessList';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_createAccessList.js
+++ b/k6/src/scenarios/test/eth_createAccessList.js
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+import { TestScenarioBuilder } from '../../lib/common.js';
+import { is400Status, httpParams, getPayLoad } from './common.js';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
+
+const methodName = 'eth_createAccessList';
+const { options, run } = new TestScenarioBuilder()
+  .name(methodName) // use unique scenario name among all tests
+  .request((testParameters) => {
+    // Select random wallet and contract addresses
+    const walletIndex = randomIntBetween(0, testParameters.wallets.length - 1);
+    const fromAddress = testParameters.wallets[walletIndex].address;
+
+    const contractIndex = randomIntBetween(0, testParameters.contractsAddresses.length - 1);
+    const toAddress = testParameters.contractsAddresses[contractIndex];
+
+    // Create transaction object for access list creation
+    const transactionObject = {
+      from: fromAddress,
+      to: toAddress,
+      data: '0xcfae3217', // Example function call data
+      gas: '0x5208', // 21000 in hex
+      gasPrice: '0x9184e72a000', // 10000000000000 in hex
+    };
+
+    const blockParameter = 'latest';
+
+    return http.post(
+      testParameters.RELAY_BASE_URL,
+      getPayLoad(methodName, [transactionObject, blockParameter]),
+      httpParams,
+    );
+  })
+  .check(methodName, (r) => is400Status(r))
+  .build();
+
+export { options, run };
+
+export const setup = setupTestParameters;

--- a/k6/src/scenarios/test/eth_createAccessList.js
+++ b/k6/src/scenarios/test/eth_createAccessList.js
@@ -2,7 +2,6 @@
 
 import http from 'k6/http';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
-
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { is400Status, httpParams, getPayLoad } from './common.js';
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';

--- a/k6/src/scenarios/test/eth_createAccessList.js
+++ b/k6/src/scenarios/test/eth_createAccessList.js
@@ -2,9 +2,9 @@
 
 import http from 'k6/http';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { is400Status, httpParams, getPayLoad } from './common.js';
-import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 
 const methodName = 'eth_createAccessList';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_getFilterChanges.js
+++ b/k6/src/scenarios/test/eth_getFilterChanges.js
@@ -3,19 +3,19 @@
 import http from 'k6/http';
 
 import { TestScenarioBuilder } from '../../lib/common.js';
-import { isNonErrorResponse, isErrorResponse, httpParams, getPayLoad } from './common.js';
-
-const url = __ENV.RELAY_BASE_URL;
+import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 
 const methodName = 'eth_getFilterChanges';
 const { options, run } = new TestScenarioBuilder()
   .name(methodName) // use unique scenario name among all tests
-  .request(() => {
-    // Use placeholder filter ID - may return error response which is acceptable for performance testing
-    const placeholderFilterId = '0x1';
-    return http.post(url, getPayLoad(methodName, [placeholderFilterId]), httpParams);
+  .request((testParameters) => {
+    const filterId = testParameters.filters.logFilterId;
+    return http.post(testParameters.RELAY_BASE_URL, getPayLoad(methodName, [filterId]), httpParams);
   })
-  .check(methodName, (r) => isNonErrorResponse(r) || isErrorResponse(r))
+  .check(methodName, (r) => isNonErrorResponse(r))
   .build();
 
 export { options, run };
+
+export const setup = setupTestParameters;

--- a/k6/src/scenarios/test/eth_getFilterChanges.js
+++ b/k6/src/scenarios/test/eth_getFilterChanges.js
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
-import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 
 const methodName = 'eth_getFilterChanges';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_getFilterChanges.js
+++ b/k6/src/scenarios/test/eth_getFilterChanges.js
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
+
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
-import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { getPayLoad,httpParams, isNonErrorResponse } from './common.js';
 
 const methodName = 'eth_getFilterChanges';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_getFilterChanges.js
+++ b/k6/src/scenarios/test/eth_getFilterChanges.js
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
-
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';

--- a/k6/src/scenarios/test/eth_getFilterChanges.js
+++ b/k6/src/scenarios/test/eth_getFilterChanges.js
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+
+import { TestScenarioBuilder } from '../../lib/common.js';
+import { isNonErrorResponse, isErrorResponse, httpParams, getPayLoad } from './common.js';
+
+const url = __ENV.RELAY_BASE_URL;
+
+const methodName = 'eth_getFilterChanges';
+const { options, run } = new TestScenarioBuilder()
+  .name(methodName) // use unique scenario name among all tests
+  .request(() => {
+    // Use placeholder filter ID - may return error response which is acceptable for performance testing
+    const placeholderFilterId = '0x1';
+    return http.post(url, getPayLoad(methodName, [placeholderFilterId]), httpParams);
+  })
+  .check(methodName, (r) => isNonErrorResponse(r) || isErrorResponse(r))
+  .build();
+
+export { options, run };

--- a/k6/src/scenarios/test/eth_getFilterLogs.js
+++ b/k6/src/scenarios/test/eth_getFilterLogs.js
@@ -3,19 +3,19 @@
 import http from 'k6/http';
 
 import { TestScenarioBuilder } from '../../lib/common.js';
-import { isNonErrorResponse, isErrorResponse, httpParams, getPayLoad } from './common.js';
-
-const url = __ENV.RELAY_BASE_URL;
+import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 
 const methodName = 'eth_getFilterLogs';
 const { options, run } = new TestScenarioBuilder()
   .name(methodName) // use unique scenario name among all tests
-  .request(() => {
-    // Use placeholder filter ID - may return error response which is acceptable for performance testing
-    const placeholderFilterId = '0x1';
-    return http.post(url, getPayLoad(methodName, [placeholderFilterId]), httpParams);
+  .request((testParameters) => {
+    const filterId = testParameters.filters.logFilterId;
+    return http.post(testParameters.RELAY_BASE_URL, getPayLoad(methodName, [filterId]), httpParams);
   })
-  .check(methodName, (r) => isNonErrorResponse(r) || isErrorResponse(r))
+  .check(methodName, (r) => isNonErrorResponse(r))
   .build();
 
 export { options, run };
+
+export const setup = setupTestParameters;

--- a/k6/src/scenarios/test/eth_getFilterLogs.js
+++ b/k6/src/scenarios/test/eth_getFilterLogs.js
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+
+import { TestScenarioBuilder } from '../../lib/common.js';
+import { isNonErrorResponse, isErrorResponse, httpParams, getPayLoad } from './common.js';
+
+const url = __ENV.RELAY_BASE_URL;
+
+const methodName = 'eth_getFilterLogs';
+const { options, run } = new TestScenarioBuilder()
+  .name(methodName) // use unique scenario name among all tests
+  .request(() => {
+    // Use placeholder filter ID - may return error response which is acceptable for performance testing
+    const placeholderFilterId = '0x1';
+    return http.post(url, getPayLoad(methodName, [placeholderFilterId]), httpParams);
+  })
+  .check(methodName, (r) => isNonErrorResponse(r) || isErrorResponse(r))
+  .build();
+
+export { options, run };

--- a/k6/src/scenarios/test/eth_getFilterLogs.js
+++ b/k6/src/scenarios/test/eth_getFilterLogs.js
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
-
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';

--- a/k6/src/scenarios/test/eth_getFilterLogs.js
+++ b/k6/src/scenarios/test/eth_getFilterLogs.js
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
+
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
-import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { getPayLoad,httpParams, isNonErrorResponse } from './common.js';
 
 const methodName = 'eth_getFilterLogs';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_getFilterLogs.js
+++ b/k6/src/scenarios/test/eth_getFilterLogs.js
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
-import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 
 const methodName = 'eth_getFilterLogs';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_getProof.js
+++ b/k6/src/scenarios/test/eth_getProof.js
@@ -2,9 +2,9 @@
 
 import http from 'k6/http';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { is400Status, httpParams, getPayLoad } from './common.js';
-import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 
 const methodName = 'eth_getProof';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_getProof.js
+++ b/k6/src/scenarios/test/eth_getProof.js
@@ -2,7 +2,6 @@
 
 import http from 'k6/http';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
-
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { is400Status, httpParams, getPayLoad } from './common.js';
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';

--- a/k6/src/scenarios/test/eth_getProof.js
+++ b/k6/src/scenarios/test/eth_getProof.js
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import http from 'k6/http';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+import http from 'k6/http';
+
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
-import { is400Status, httpParams, getPayLoad } from './common.js';
+import { getPayLoad,httpParams, is400Status } from './common.js';
 
 const methodName = 'eth_getProof';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_getProof.js
+++ b/k6/src/scenarios/test/eth_getProof.js
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+import { TestScenarioBuilder } from '../../lib/common.js';
+import { is400Status, httpParams, getPayLoad } from './common.js';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
+
+const methodName = 'eth_getProof';
+const { options, run } = new TestScenarioBuilder()
+  .name(methodName) // use unique scenario name among all tests
+  .request((testParameters) => {
+    // Select a random wallet address
+    const walletIndex = randomIntBetween(0, testParameters.wallets.length - 1);
+    const accountAddress = testParameters.wallets[walletIndex].address;
+
+    // Use static storage keys for testing
+    const storageKeys = [
+      '0x0000000000000000000000000000000000000000000000000000000000000000',
+      '0x0000000000000000000000000000000000000000000000000000000000000001',
+    ];
+
+    const blockParameter = 'latest';
+
+    return http.post(
+      testParameters.RELAY_BASE_URL,
+      getPayLoad(methodName, [accountAddress, storageKeys, blockParameter]),
+      httpParams,
+    );
+  })
+  .check(methodName, (r) => is400Status(r))
+  .build();
+
+export { options, run };
+
+export const setup = setupTestParameters;

--- a/k6/src/scenarios/test/eth_maxPriorityFeePerGas.js
+++ b/k6/src/scenarios/test/eth_maxPriorityFeePerGas.js
@@ -3,8 +3,9 @@
 
 
 import http from 'k6/http';
-import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+
 import { TestScenarioBuilder } from '../../lib/common.js';
+import { getPayLoad,httpParams, isNonErrorResponse } from './common.js';
 
 const methodName = 'eth_maxPriorityFeePerGas';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_maxPriorityFeePerGas.js
+++ b/k6/src/scenarios/test/eth_maxPriorityFeePerGas.js
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import http from 'k6/http';
 
+
+import http from 'k6/http';
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
-
-const url = __ENV.RELAY_BASE_URL;
 
 const methodName = 'eth_maxPriorityFeePerGas';
 const { options, run } = new TestScenarioBuilder()
   .name(methodName) // use unique scenario name among all tests
-  .request(() => http.post(url, getPayLoad(methodName), httpParams))
+  .request((testParameters) => http.post(testParameters.RELAY_BASE_URL, getPayLoad(methodName), httpParams))
   .check(methodName, (r) => isNonErrorResponse(r))
   .build();
 

--- a/k6/src/scenarios/test/eth_maxPriorityFeePerGas.js
+++ b/k6/src/scenarios/test/eth_maxPriorityFeePerGas.js
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+
+import { TestScenarioBuilder } from '../../lib/common.js';
+import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+
+const url = __ENV.RELAY_BASE_URL;
+
+const methodName = 'eth_maxPriorityFeePerGas';
+const { options, run } = new TestScenarioBuilder()
+  .name(methodName) // use unique scenario name among all tests
+  .request(() => http.post(url, getPayLoad(methodName), httpParams))
+  .check(methodName, (r) => isNonErrorResponse(r))
+  .build();
+
+export { options, run };

--- a/k6/src/scenarios/test/eth_maxPriorityFeePerGas.js
+++ b/k6/src/scenarios/test/eth_maxPriorityFeePerGas.js
@@ -3,8 +3,8 @@
 
 
 import http from 'k6/http';
-import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { TestScenarioBuilder } from '../../lib/common.js';
 
 const methodName = 'eth_maxPriorityFeePerGas';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_newBlockFilter.js
+++ b/k6/src/scenarios/test/eth_newBlockFilter.js
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+
+import { TestScenarioBuilder } from '../../lib/common.js';
+import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+
+const url = __ENV.RELAY_BASE_URL;
+
+const methodName = 'eth_newBlockFilter';
+const { options, run } = new TestScenarioBuilder()
+  .name(methodName) // use unique scenario name among all tests
+  .request(() => http.post(url, getPayLoad(methodName), httpParams))
+  .check(methodName, (r) => isNonErrorResponse(r))
+  .build();
+
+export { options, run };

--- a/k6/src/scenarios/test/eth_newBlockFilter.js
+++ b/k6/src/scenarios/test/eth_newBlockFilter.js
@@ -3,8 +3,8 @@
 
 
 import http from 'k6/http';
-import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { TestScenarioBuilder } from '../../lib/common.js';
 
 const methodName = 'eth_newBlockFilter';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_newBlockFilter.js
+++ b/k6/src/scenarios/test/eth_newBlockFilter.js
@@ -3,8 +3,9 @@
 
 
 import http from 'k6/http';
-import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+
 import { TestScenarioBuilder } from '../../lib/common.js';
+import { getPayLoad,httpParams, isNonErrorResponse } from './common.js';
 
 const methodName = 'eth_newBlockFilter';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_newBlockFilter.js
+++ b/k6/src/scenarios/test/eth_newBlockFilter.js
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import http from 'k6/http';
 
+
+import http from 'k6/http';
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
-
-const url = __ENV.RELAY_BASE_URL;
 
 const methodName = 'eth_newBlockFilter';
 const { options, run } = new TestScenarioBuilder()
   .name(methodName) // use unique scenario name among all tests
-  .request(() => http.post(url, getPayLoad(methodName), httpParams))
+  .request((testParameters) => http.post(testParameters.RELAY_BASE_URL, getPayLoad(methodName), httpParams))
   .check(methodName, (r) => isNonErrorResponse(r))
   .build();
 

--- a/k6/src/scenarios/test/eth_newFilter.js
+++ b/k6/src/scenarios/test/eth_newFilter.js
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+
+import { TestScenarioBuilder } from '../../lib/common.js';
+import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
+
+const url = __ENV.RELAY_BASE_URL;
+
+const methodName = 'eth_newFilter';
+const { options, run } = new TestScenarioBuilder()
+  .name(methodName) // use unique scenario name among all tests
+  .request((testParameters) => {
+    // Create filter object with basic parameters
+    const filterObject = {
+      fromBlock: 'latest',
+      toBlock: 'latest',
+    };
+
+    // Add contract address if available
+    if (testParameters && testParameters.contractsAddresses && testParameters.contractsAddresses.length > 0) {
+      const contractIndex = randomIntBetween(0, testParameters.contractsAddresses.length - 1);
+      filterObject.address = testParameters.contractsAddresses[contractIndex];
+    }
+
+    return http.post(url, getPayLoad(methodName, [filterObject]), httpParams);
+  })
+  .check(methodName, (r) => isNonErrorResponse(r))
+  .build();
+
+export { options, run };
+
+export const setup = setupTestParameters;

--- a/k6/src/scenarios/test/eth_newFilter.js
+++ b/k6/src/scenarios/test/eth_newFilter.js
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
+
 import http from 'k6/http';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
-
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
-
-const url = __ENV.RELAY_BASE_URL;
 
 const methodName = 'eth_newFilter';
 const { options, run } = new TestScenarioBuilder()
@@ -25,7 +23,7 @@ const { options, run } = new TestScenarioBuilder()
       filterObject.address = testParameters.contractsAddresses[contractIndex];
     }
 
-    return http.post(url, getPayLoad(methodName, [filterObject]), httpParams);
+    return http.post(testParameters.RELAY_BASE_URL, getPayLoad(methodName, [filterObject]), httpParams);
   })
   .check(methodName, (r) => isNonErrorResponse(r))
   .build();

--- a/k6/src/scenarios/test/eth_newFilter.js
+++ b/k6/src/scenarios/test/eth_newFilter.js
@@ -3,9 +3,9 @@
 
 import http from 'k6/http';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
-import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 
 const methodName = 'eth_newFilter';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_newFilter.js
+++ b/k6/src/scenarios/test/eth_newFilter.js
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 
-import http from 'k6/http';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.4.0/index.js';
+import http from 'k6/http';
+
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
-import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { getPayLoad,httpParams, isNonErrorResponse } from './common.js';
 
 const methodName = 'eth_newFilter';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_newPendingTransactionFilter.js
+++ b/k6/src/scenarios/test/eth_newPendingTransactionFilter.js
@@ -3,8 +3,9 @@
 
 
 import http from 'k6/http';
-import { is400Status, httpParams, getPayLoad } from './common.js';
+
 import { TestScenarioBuilder } from '../../lib/common.js';
+import { getPayLoad,httpParams, is400Status } from './common.js';
 
 const methodName = 'eth_newPendingTransactionFilter';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_newPendingTransactionFilter.js
+++ b/k6/src/scenarios/test/eth_newPendingTransactionFilter.js
@@ -3,8 +3,8 @@
 
 
 import http from 'k6/http';
-import { TestScenarioBuilder } from '../../lib/common.js';
 import { is400Status, httpParams, getPayLoad } from './common.js';
+import { TestScenarioBuilder } from '../../lib/common.js';
 
 const methodName = 'eth_newPendingTransactionFilter';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_newPendingTransactionFilter.js
+++ b/k6/src/scenarios/test/eth_newPendingTransactionFilter.js
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+
+import { TestScenarioBuilder } from '../../lib/common.js';
+import { is400Status, httpParams, getPayLoad } from './common.js';
+
+const url = __ENV.RELAY_BASE_URL;
+
+const methodName = 'eth_newPendingTransactionFilter';
+const { options, run } = new TestScenarioBuilder()
+  .name(methodName) // use unique scenario name among all tests
+  .request(() => http.post(url, getPayLoad(methodName), httpParams))
+  .check(methodName, (r) => is400Status(r))
+  .build();
+
+export { options, run };

--- a/k6/src/scenarios/test/eth_newPendingTransactionFilter.js
+++ b/k6/src/scenarios/test/eth_newPendingTransactionFilter.js
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import http from 'k6/http';
 
+
+import http from 'k6/http';
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { is400Status, httpParams, getPayLoad } from './common.js';
-
-const url = __ENV.RELAY_BASE_URL;
 
 const methodName = 'eth_newPendingTransactionFilter';
 const { options, run } = new TestScenarioBuilder()
   .name(methodName) // use unique scenario name among all tests
-  .request(() => http.post(url, getPayLoad(methodName), httpParams))
+  .request((testParameters) => http.post(testParameters.RELAY_BASE_URL, getPayLoad(methodName), httpParams))
   .check(methodName, (r) => is400Status(r))
   .build();
 

--- a/k6/src/scenarios/test/eth_uninstallFilter.js
+++ b/k6/src/scenarios/test/eth_uninstallFilter.js
@@ -3,19 +3,19 @@
 import http from 'k6/http';
 
 import { TestScenarioBuilder } from '../../lib/common.js';
-import { isNonErrorResponse, isErrorResponse, httpParams, getPayLoad } from './common.js';
-
-const url = __ENV.RELAY_BASE_URL;
+import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 
 const methodName = 'eth_uninstallFilter';
 const { options, run } = new TestScenarioBuilder()
   .name(methodName) // use unique scenario name among all tests
-  .request(() => {
-    // Use placeholder filter ID - may return error response which is acceptable for performance testing
-    const placeholderFilterId = '0x1';
-    return http.post(url, getPayLoad(methodName, [placeholderFilterId]), httpParams);
+  .request((testParameters) => {
+    const filterId = testParameters.filters.blockFilterId;
+    return http.post(testParameters.RELAY_BASE_URL, getPayLoad(methodName, [filterId]), httpParams);
   })
-  .check(methodName, (r) => isNonErrorResponse(r) || isErrorResponse(r))
+  .check(methodName, (r) => isNonErrorResponse(r))
   .build();
 
 export { options, run };
+
+export const setup = setupTestParameters;

--- a/k6/src/scenarios/test/eth_uninstallFilter.js
+++ b/k6/src/scenarios/test/eth_uninstallFilter.js
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
+import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
-import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 
 const methodName = 'eth_uninstallFilter';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_uninstallFilter.js
+++ b/k6/src/scenarios/test/eth_uninstallFilter.js
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
-
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';

--- a/k6/src/scenarios/test/eth_uninstallFilter.js
+++ b/k6/src/scenarios/test/eth_uninstallFilter.js
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import http from 'k6/http';
+
 import { setupTestParameters } from '../../lib/bootstrapEnvParameters.js';
 import { TestScenarioBuilder } from '../../lib/common.js';
-import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { getPayLoad,httpParams, isNonErrorResponse } from './common.js';
 
 const methodName = 'eth_uninstallFilter';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/eth_uninstallFilter.js
+++ b/k6/src/scenarios/test/eth_uninstallFilter.js
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+
+import { TestScenarioBuilder } from '../../lib/common.js';
+import { isNonErrorResponse, isErrorResponse, httpParams, getPayLoad } from './common.js';
+
+const url = __ENV.RELAY_BASE_URL;
+
+const methodName = 'eth_uninstallFilter';
+const { options, run } = new TestScenarioBuilder()
+  .name(methodName) // use unique scenario name among all tests
+  .request(() => {
+    // Use placeholder filter ID - may return error response which is acceptable for performance testing
+    const placeholderFilterId = '0x1';
+    return http.post(url, getPayLoad(methodName, [placeholderFilterId]), httpParams);
+  })
+  .check(methodName, (r) => isNonErrorResponse(r) || isErrorResponse(r))
+  .build();
+
+export { options, run };

--- a/k6/src/scenarios/test/index.js
+++ b/k6/src/scenarios/test/index.js
@@ -3,11 +3,15 @@
 import { getSequentialTestScenarios } from '../../lib/common.js';
 
 // import test modules
+import * as debug_traceBlockByNumber from './debug_traceBlockByNumber.js';
+import * as debug_traceTransaction from './debug_traceTransaction.js';
 import * as eth_accounts from './eth_accounts.js';
+import * as eth_blobBaseFee from './eth_blobBaseFee.js';
 import * as eth_blockNumber from './eth_blockNumber.js';
 import * as eth_call from './eth_call.js';
 import * as eth_chainId from './eth_chainId.js';
 import * as eth_coinbase from './eth_coinbase.js';
+import * as eth_createAccessList from './eth_createAccessList.js';
 import * as eth_estimateGas from './eth_estimateGas.js';
 import * as eth_feeHistory from './eth_feeHistory.js';
 import * as eth_gasPrice from './eth_gasPrice.js';
@@ -18,7 +22,10 @@ import * as eth_getBlockTransactionCountByHash from './eth_getBlockTransactionCo
 import * as eth_getBlockTransactionCountByNumber from './eth_getBlockTransactionCountByNumber.js';
 import * as eth_getBlockReceipts from './eth_getBlockReceipts.js';
 import * as eth_getCode from './eth_getCode.js';
+import * as eth_getFilterChanges from './eth_getFilterChanges.js';
+import * as eth_getFilterLogs from './eth_getFilterLogs.js';
 import * as eth_getLogs from './eth_getLogs.js';
+import * as eth_getProof from './eth_getProof.js';
 import * as eth_getStorageAt from './eth_getStorageAt.js';
 import * as eth_getTransactionByBlockHashAndIndex from './eth_getTransactionByBlockHashAndIndex.js';
 import * as eth_getTransactionByBlockNumberAndIndex from './eth_getTransactionByBlockNumberAndIndex.js';
@@ -31,7 +38,11 @@ import * as eth_getUncleCountByBlockHash from './eth_getUncleCountByBlockHash.js
 import * as eth_getUncleCountByBlockNumber from './eth_getUncleCountByBlockNumber.js';
 import * as eth_getWork from './eth_getWork.js';
 import * as eth_hashrate from './eth_hashrate.js';
+import * as eth_maxPriorityFeePerGas from './eth_maxPriorityFeePerGas.js';
 import * as eth_mining from './eth_mining.js';
+import * as eth_newBlockFilter from './eth_newBlockFilter.js';
+import * as eth_newFilter from './eth_newFilter.js';
+import * as eth_newPendingTransactionFilter from './eth_newPendingTransactionFilter.js';
 import * as eth_protocolVersion from './eth_protocolVersion.js';
 import * as eth_sendRawTransaction from './eth_sendRawTransaction.js';
 import * as eth_sendTransaction from './eth_sendTransaction.js';
@@ -40,17 +51,24 @@ import * as eth_signTransaction from './eth_signTransaction.js';
 import * as eth_submitHashrate from './eth_submitHashrate.js';
 import * as eth_submitWork from './eth_submitWork.js';
 import * as eth_syncing from './eth_syncing.js';
+import * as eth_uninstallFilter from './eth_uninstallFilter.js';
 import * as net_listening from './net_listening.js';
+import * as net_peerCount from './net_peerCount.js';
 import * as net_version from './net_version.js';
 import * as web3_clientVersion from './web3_clientVersion.js';
+import * as web3_sha3 from './web3_sha3.js';
 
 // add test modules here
 const tests = {
+  debug_traceBlockByNumber,
+  debug_traceTransaction,
   eth_accounts,
+  eth_blobBaseFee,
   eth_blockNumber,
   eth_call,
   eth_chainId,
   eth_coinbase,
+  eth_createAccessList,
   eth_estimateGas,
   eth_feeHistory,
   eth_gasPrice,
@@ -61,7 +79,10 @@ const tests = {
   eth_getBlockTransactionCountByNumber,
   eth_getBlockReceipts,
   eth_getCode,
+  eth_getFilterChanges,
+  eth_getFilterLogs,
   eth_getLogs,
+  eth_getProof,
   eth_getStorageAt,
   eth_getTransactionByBlockHashAndIndex,
   eth_getTransactionByBlockNumberAndIndex,
@@ -74,7 +95,11 @@ const tests = {
   eth_getUncleCountByBlockNumber,
   eth_getWork,
   eth_hashrate,
+  eth_maxPriorityFeePerGas,
   eth_mining,
+  eth_newBlockFilter,
+  eth_newFilter,
+  eth_newPendingTransactionFilter,
   eth_protocolVersion,
   eth_sendRawTransaction,
   eth_sendTransaction,
@@ -83,9 +108,12 @@ const tests = {
   eth_submitHashrate,
   eth_submitWork,
   eth_syncing,
+  eth_uninstallFilter,
   net_listening,
+  net_peerCount,
   net_version,
   web3_clientVersion,
+  web3_sha3,
 };
 
 const { funcs, options, scenarioDurationGauge } = getSequentialTestScenarios(tests);

--- a/k6/src/scenarios/test/net_peerCount.js
+++ b/k6/src/scenarios/test/net_peerCount.js
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+
+import { TestScenarioBuilder } from '../../lib/common.js';
+import { is400Status, httpParams, getPayLoad } from './common.js';
+
+const url = __ENV.RELAY_BASE_URL;
+
+const methodName = 'net_peerCount';
+const { options, run } = new TestScenarioBuilder()
+  .name(methodName) // use unique scenario name among all tests
+  .request(() => http.post(url, getPayLoad(methodName), httpParams))
+  .check(methodName, (r) => is400Status(r))
+  .build();
+
+export { options, run };

--- a/k6/src/scenarios/test/net_peerCount.js
+++ b/k6/src/scenarios/test/net_peerCount.js
@@ -3,8 +3,9 @@
 
 
 import http from 'k6/http';
-import { is400Status, httpParams, getPayLoad } from './common.js';
+
 import { TestScenarioBuilder } from '../../lib/common.js';
+import { getPayLoad,httpParams, is400Status } from './common.js';
 
 const methodName = 'net_peerCount';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/net_peerCount.js
+++ b/k6/src/scenarios/test/net_peerCount.js
@@ -3,8 +3,8 @@
 
 
 import http from 'k6/http';
-import { TestScenarioBuilder } from '../../lib/common.js';
 import { is400Status, httpParams, getPayLoad } from './common.js';
+import { TestScenarioBuilder } from '../../lib/common.js';
 
 const methodName = 'net_peerCount';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/net_peerCount.js
+++ b/k6/src/scenarios/test/net_peerCount.js
@@ -1,16 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import http from 'k6/http';
 
+
+import http from 'k6/http';
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { is400Status, httpParams, getPayLoad } from './common.js';
-
-const url = __ENV.RELAY_BASE_URL;
 
 const methodName = 'net_peerCount';
 const { options, run } = new TestScenarioBuilder()
   .name(methodName) // use unique scenario name among all tests
-  .request(() => http.post(url, getPayLoad(methodName), httpParams))
+  .request((testParameters) => http.post(testParameters.RELAY_BASE_URL, getPayLoad(methodName), httpParams))
   .check(methodName, (r) => is400Status(r))
   .build();
 

--- a/k6/src/scenarios/test/web3_sha3.js
+++ b/k6/src/scenarios/test/web3_sha3.js
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import http from 'k6/http';
+
+import { TestScenarioBuilder } from '../../lib/common.js';
+import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+
+const url = __ENV.RELAY_BASE_URL;
+
+const methodName = 'web3_sha3';
+const { options, run } = new TestScenarioBuilder()
+  .name(methodName) // use unique scenario name among all tests
+  .request(() => {
+    // Use static hex-encoded data for testing
+    const testData = '0x68656c6c6f20776f726c64'; // "hello world" in hex
+    return http.post(url, getPayLoad(methodName, [testData]), httpParams);
+  })
+  .check(methodName, (r) => isNonErrorResponse(r))
+  .build();
+
+export { options, run };

--- a/k6/src/scenarios/test/web3_sha3.js
+++ b/k6/src/scenarios/test/web3_sha3.js
@@ -1,19 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import http from 'k6/http';
 
+
+import http from 'k6/http';
 import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
-
-const url = __ENV.RELAY_BASE_URL;
 
 const methodName = 'web3_sha3';
 const { options, run } = new TestScenarioBuilder()
   .name(methodName) // use unique scenario name among all tests
-  .request(() => {
+  .request((testParameters) => {
     // Use static hex-encoded data for testing
     const testData = '0x68656c6c6f20776f726c64'; // "hello world" in hex
-    return http.post(url, getPayLoad(methodName, [testData]), httpParams);
+    return http.post(testParameters.RELAY_BASE_URL, getPayLoad(methodName, [testData]), httpParams);
   })
   .check(methodName, (r) => isNonErrorResponse(r))
   .build();

--- a/k6/src/scenarios/test/web3_sha3.js
+++ b/k6/src/scenarios/test/web3_sha3.js
@@ -3,8 +3,8 @@
 
 
 import http from 'k6/http';
-import { TestScenarioBuilder } from '../../lib/common.js';
 import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+import { TestScenarioBuilder } from '../../lib/common.js';
 
 const methodName = 'web3_sha3';
 const { options, run } = new TestScenarioBuilder()

--- a/k6/src/scenarios/test/web3_sha3.js
+++ b/k6/src/scenarios/test/web3_sha3.js
@@ -3,8 +3,9 @@
 
 
 import http from 'k6/http';
-import { isNonErrorResponse, httpParams, getPayLoad } from './common.js';
+
 import { TestScenarioBuilder } from '../../lib/common.js';
+import { getPayLoad,httpParams, isNonErrorResponse } from './common.js';
 
 const methodName = 'web3_sha3';
 const { options, run } = new TestScenarioBuilder()


### PR DESCRIPTION
### Description

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

This PR addresses the test coverage gap by implementing K6 performance tests for the **14 missing JSON-RPC endpoints** in the Hedera JSON RPC Relay test suite.

- eth_blobBaseFee
- eth_maxPriorityFeePerGas
- eth_newBlockFilter
- eth_newFilter
- eth_uninstallFilter
- eth_newPendingTransactionFilter
- eth_getFilterLogs
- eth_getFilterChanges
- net_peerCount
- web3_sha3
- debug_traceTransaction
- debug_traceBlockByNumber
- eth_getProof
- eth_createAccessList

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #3966 

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1. Spin up local-node network. Stop the relay instance from the local-node network, then run a new Relay instance from this project, remember to set `RATE_LIMIT_DISABLED` to `true` to disable IP rate limiting.
2. Use this .env file
```
PRIVATE_KEY=0x105d050185ccb907fba04dd92d8de9e32c18305e097ab41dadda21489a211524
MIRROR_BASE_URL=http://127.0.0.1:5551
RELAY_BASE_URL=http://127.0.0.1:7546
DEFAULT_DURATION=1s
DEFAULT_VUS=1
DEFAULT_LIMIT=800
DEFAULT_PASS_RATE=0.95
DEFAULT_MAX_DURATION=800
DEFAULT_GRACEFUL_STOP=5s
FILTER_TEST=debug_traceBlockByNumber,debug_traceTransaction,eth_blobBaseFee,eth_createAccessList,eth_getFilterChanges,eth_getFilterLogs,eth_getProof,eth_maxPriorityFeePerGas,eth_newBlockFilter,eth_newFilter,eth_newPendingTransactionFilter,eth_uninstallFilter,net_peerCount,web3_sha3
DEBUG_MODE=false
SIGNED_TXS=50
```

Which narrows down to run the tests only on the 14 new tests.

3. Eventually, a `report.md` file will be created after the test finishes running. The file should report the result of the test and supposed to showcase all the new tests are running as expected.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
