### PR TITLE
feat: fix CI after simplifying the config object

### DIFF
--- a/packages/config-service/src/services/globalConfig.ts
+++ b/packages/config-service/src/services/globalConfig.ts
@@ -504,13 +504,11 @@ const _CONFIG = {
     defaultValue: null,
   },
   PAYMASTER_ENABLED: {
-    envName: 'PAYMASTER_ENABLED',
     type: 'boolean',
     required: false,
     defaultValue: false,
   },
   PAYMASTER_WHITELIST: {
-    envName: 'PAYMASTER_WHITELIST',
     type: 'strArray',
     required: false,
     defaultValue: [],


### PR DESCRIPTION
### Description

Due to not pulling the latest main into https://github.com/hiero-ledger/hiero-json-rpc-relay/pull/3979, two env variables are left with `envName` that breaks the `ConfigProperty` interface and the project build afterwards.

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

### Solution:
- remove `envName` from `PAYMASTER_ENABLED` and `PAYMASTER_WHITELIST`

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #3895 

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1.
2.
3.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
