### PR TITLE
feat: removes duration from rpc_relay_client_service metric

### DIFF
--- a/packages/relay/src/lib/services/hapiService/hapiService.ts
+++ b/packages/relay/src/lib/services/hapiService/hapiService.ts
@@ -189,7 +189,7 @@ export default class HAPIService {
       name: metricCounterName,
       help: 'Relay Client Service',
       registers: [register],
-      labelNames: ['transactions', 'duration', 'errors'],
+      labelNames: ['transactions', 'errors'],
     });
   }
 

--- a/packages/relay/src/lib/services/hapiService/hapiService.ts
+++ b/packages/relay/src/lib/services/hapiService/hapiService.ts
@@ -234,9 +234,7 @@ export default class HAPIService {
    * Reset the SDK Client and all counters.
    */
   private resetClient() {
-    this.clientResetCounter
-      .labels(this.transactionCount.toString(), this.resetDuration.toString(), this.errorCodes.toString())
-      .inc(1);
+    this.clientResetCounter.labels(this.transactionCount.toString(), this.errorCodes.toString()).inc(1);
 
     this.clientMain = this.initClient(this.logger, this.hederaNetwork);
     this.client = this.initSDKClient(this.logger);

--- a/packages/relay/tests/lib/hapiService.spec.ts
+++ b/packages/relay/tests/lib/hapiService.spec.ts
@@ -56,7 +56,7 @@ describe('HAPI Service', async function () {
   });
 
   it('should be able to initialize SDK instance', async function () {
-    hapiService = new HAPIService(logger, registry, cacheService, eventEmitter, hbarLimitService);
+    hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
     const client = hapiService.getMainClientInstance();
     const sdkClient = hapiService.getSDKClient();
 
@@ -68,7 +68,7 @@ describe('HAPI Service', async function () {
     it('should be able to reinitialise SDK instance upon reaching transaction limit', async function () {
       const hapiClientTransactionReset = Number(ConfigService.get('HAPI_CLIENT_TRANSACTION_RESET'));
 
-      hapiService = new HAPIService(logger, registry, cacheService, eventEmitter, hbarLimitService);
+      hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
       expect(hapiService.getTransactionCount()).to.eq(hapiClientTransactionReset);
 
       const oldClientInstance = hapiService.getMainClientInstance();
@@ -88,7 +88,7 @@ describe('HAPI Service', async function () {
     it('should be able to reinitialise SDK instance upon reaching time limit', async function () {
       const hapiClientDurationReset = Number(ConfigService.get('HAPI_CLIENT_DURATION_RESET'));
 
-      hapiService = new HAPIService(logger, registry, cacheService, eventEmitter, hbarLimitService);
+      hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
       expect(hapiService.getTimeUntilReset()).to.be.approximately(hapiClientDurationReset, 10); // 10 ms tolerance
 
       const oldClientInstance = hapiService.getMainClientInstance();
@@ -107,7 +107,7 @@ describe('HAPI Service', async function () {
     it('should be able to reinitialise SDK instance upon error status code encounter', async function () {
       const hapiClientErrorReset = ConfigService.get('HAPI_CLIENT_ERROR_RESET');
 
-      hapiService = new HAPIService(logger, registry, cacheService, eventEmitter, hbarLimitService);
+      hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
       expect(hapiService.getErrorCodes()[0]).to.eq(hapiClientErrorReset[0]);
 
       const oldClientInstance = hapiService.getMainClientInstance();
@@ -133,7 +133,7 @@ describe('HAPI Service', async function () {
         const hapiClientTransactionReset = Number(ConfigService.get('HAPI_CLIENT_TRANSACTION_RESET'));
         const hapiClientDurationReset = Number(ConfigService.get('HAPI_CLIENT_DURATION_RESET'));
 
-        hapiService = new HAPIService(logger, registry, cacheService, eventEmitter, hbarLimitService);
+        hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
 
         const oldClientInstance = hapiService.getMainClientInstance();
         const oldSDKInstance = hapiService.getSDKClient();
@@ -158,7 +158,7 @@ describe('HAPI Service', async function () {
     () => {
       it('should keep the same instance of hbar limiter and not reset the budget', async function () {
         const costAmount = 10000;
-        hapiService = new HAPIService(logger, registry, cacheService, eventEmitter, hbarLimitService);
+        hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
 
         const hbarLimiterBudgetBefore = await hbarLimitService['getRemainingBudget'](requestDetails);
         const oldClientInstance = hapiService.getMainClientInstance();
@@ -188,7 +188,7 @@ describe('HAPI Service', async function () {
     },
     () => {
       it('should not be able to reinitialise and decrement counters, if it is disabled', async function () {
-        hapiService = new HAPIService(logger, registry, cacheService, eventEmitter, hbarLimitService);
+        hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
         expect(hapiService.getTransactionCount()).to.eq(Number(ConfigService.get('HAPI_CLIENT_TRANSACTION_RESET')));
 
         const oldClientInstance = hapiService.getMainClientInstance();


### PR DESCRIPTION
### Description

The rpc_relay_client_service metric currently includes a duration label that is unnecessary and contributes to increased metric cardinality.

### Related issue(s)

Closes #4084

### Testing Guide

1. Verify duration has been removed in the code everywhere `rpc_relay_client_service` is referenced.
2. Once merged, verify through the dashboard

### Changes from original design (optional)

I got a warning that we still pass cacheService to the HAPIService inside the tests, so I've decided to remove it. This doesn't affect the tests and functionality.

### Additional work needed (optional)
N/A

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
