### PR TITLE
refactor: split event emitters and listeners

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -59,15 +59,6 @@ export class SDKClient {
   private readonly fileAppendChunkSize: number;
 
   /**
-   * An instance of EventEmitter used for emitting and handling events within the class.
-   *
-   * @private
-   * @readonly
-   * @type {EventEmitter}
-   */
-  private readonly eventEmitter: CustomEventEmitter;
-
-  /**
    * An instance of the HbarLimitService that tracks hbar expenses and limits.
    * @private
    * @readonly
@@ -86,7 +77,7 @@ export class SDKClient {
   constructor(
     clientMain: Client,
     logger: Logger,
-    eventEmitter: CustomEventEmitter,
+    readonly eventEmitter: CustomEventEmitter,
     hbarLimitService: HbarLimitService,
   ) {
     this.clientMain = clientMain;
@@ -96,7 +87,6 @@ export class SDKClient {
     this.clientMain = clientMain.setMaxExecutionTime(ConfigService.get('CONSENSUS_MAX_EXECUTION_TIME'));
 
     this.logger = logger;
-    this.eventEmitter = eventEmitter;
     this.hbarLimitService = hbarLimitService;
     this.maxChunks = ConfigService.get('FILE_APPEND_MAX_CHUNKS');
     this.fileAppendChunkSize = ConfigService.get('FILE_APPEND_CHUNK_SIZE');

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import { EventEmitter } from 'events';
 import { Logger } from 'pino';
 
 import { Eth } from '../index';
@@ -33,6 +34,7 @@ import {
   INewFilterParams,
   ITransactionReceipt,
   RequestDetails,
+  TypedEvents,
 } from './types';
 import { rpcParamValidationRules } from './validators';
 
@@ -80,7 +82,7 @@ export class EthImpl implements Eth {
    * Event emitter for publishing and subscribing to events.
    * @private
    */
-  private readonly eventEmitter: CustomEventEmitter;
+  readonly eventEmitter: CustomEventEmitter;
 
   /**
    * The Fee Service implementation that takes care of all fee API operations.
@@ -123,7 +125,6 @@ export class EthImpl implements Eth {
     logger: Logger,
     chain: string,
     public readonly cacheService: CacheService,
-    eventEmitter: CustomEventEmitter,
   ) {
     this.chain = chain;
     this.logger = logger;
@@ -133,12 +134,12 @@ export class EthImpl implements Eth {
     this.contractService = new ContractService(cacheService, this.common, hapiService, logger, mirrorNodeClient);
     this.accountService = new AccountService(cacheService, this.common, logger, mirrorNodeClient);
     this.blockService = new BlockService(cacheService, chain, this.common, mirrorNodeClient, logger);
-    this.eventEmitter = eventEmitter;
+    this.eventEmitter = new EventEmitter<TypedEvents>();
     this.transactionService = new TransactionService(
       cacheService,
       chain,
       this.common,
-      eventEmitter,
+      this.eventEmitter,
       hapiService,
       logger,
       mirrorNodeClient,

--- a/packages/relay/src/lib/relay.ts
+++ b/packages/relay/src/lib/relay.ts
@@ -2,7 +2,6 @@
 
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
 import { Client } from '@hashgraph/sdk';
-import EventEmitter from 'events';
 import { Logger } from 'pino';
 import { Gauge, Registry } from 'prom-client';
 
@@ -24,7 +23,14 @@ import HAPIService from './services/hapiService/hapiService';
 import { HbarLimitService } from './services/hbarLimitService';
 import MetricService from './services/metricService/metricService';
 import { registerRpcMethods } from './services/registryService/rpcMethodRegistryService';
-import { CustomEventEmitter, RequestDetails, RpcMethodRegistry, RpcNamespaceRegistry, TypedEvents } from './types';
+import {
+  IEthExecutionEventPayload,
+  IExecuteQueryEventPayload,
+  IExecuteTransactionEventPayload,
+  RequestDetails,
+  RpcMethodRegistry,
+  RpcNamespaceRegistry,
+} from './types';
 import { Web3Impl } from './web3';
 
 export class Relay {
@@ -92,15 +98,6 @@ export class Relay {
   private readonly metricService: MetricService;
 
   /**
-   * An instance of EventEmitter used for emitting and handling events within the class.
-   *
-   * @private
-   * @readonly
-   * @type {EventEmitter}
-   */
-  private readonly eventEmitter: CustomEventEmitter;
-
-  /**
    * The Debug Service implementation that takes care of all filter API operations.
    */
   private readonly debugImpl: DebugImpl;
@@ -135,8 +132,6 @@ export class Relay {
 
     const chainId = ConfigService.get('CHAIN_ID');
     const duration = constants.HBAR_RATE_LIMIT_DURATION;
-
-    this.eventEmitter = new EventEmitter<TypedEvents>();
     const reservedKeys = HbarSpendingPlanConfigService.getPreconfiguredSpendingPlanKeys(logger);
     this.cacheService = new CacheService(logger.child({ name: 'cache-service' }), register, reservedKeys);
 
@@ -161,7 +156,7 @@ export class Relay {
       duration,
     );
 
-    const hapiService = new HAPIService(logger, register, this.eventEmitter, hbarLimitService);
+    const hapiService = new HAPIService(logger, register, hbarLimitService);
 
     this.clientMain = hapiService.getMainClientInstance();
 
@@ -182,7 +177,6 @@ export class Relay {
       hapiService.getSDKClient(),
       this.mirrorNodeClient,
       register,
-      this.eventEmitter,
       hbarLimitService,
     );
 
@@ -192,8 +186,19 @@ export class Relay {
       logger.child({ name: 'relay-eth' }),
       chainId,
       this.cacheService,
-      this.eventEmitter,
     );
+
+    (this.ethImpl as EthImpl).eventEmitter.on(constants.EVENTS.ETH_EXECUTION, (args: IEthExecutionEventPayload) => {
+      this.metricService.ethExecutionsCounter.labels(args.method).inc();
+    });
+
+    hapiService.eventEmitter.on(constants.EVENTS.EXECUTE_TRANSACTION, (args: IExecuteTransactionEventPayload) => {
+      this.metricService.captureTransactionMetrics(args).then();
+    });
+
+    hapiService.eventEmitter.on(constants.EVENTS.EXECUTE_QUERY, (args: IExecuteQueryEventPayload) => {
+      this.metricService.addExpenseAndCaptureMetrics(args);
+    });
 
     this.debugImpl = new DebugImpl(this.mirrorNodeClient, logger, this.cacheService);
     this.adminImpl = new AdminImpl(this.cacheService);

--- a/packages/relay/src/lib/services/ethService/transactionService/TransactionService.ts
+++ b/packages/relay/src/lib/services/ethService/transactionService/TransactionService.ts
@@ -41,15 +41,6 @@ export class TransactionService implements ITransactionService {
   private readonly common: ICommonService;
 
   /**
-   * An instance of EventEmitter used for emitting and handling events within the class.
-   *
-   * @private
-   * @readonly
-   * @type {EventEmitter}
-   */
-  private readonly eventEmitter: CustomEventEmitter;
-
-  /**
    * The HAPI service for interacting with Hedera API.
    * @private
    * @readonly
@@ -89,7 +80,7 @@ export class TransactionService implements ITransactionService {
     cacheService: CacheService,
     chain: string,
     common: ICommonService,
-    eventEmitter: CustomEventEmitter,
+    private readonly eventEmitter: CustomEventEmitter,
     hapiService: HAPIService,
     logger: Logger,
     mirrorNodeClient: MirrorNodeClient,
@@ -333,16 +324,6 @@ export class TransactionService implements ITransactionService {
   }
 
   /**
-   * Emits an Ethereum execution event with transaction details
-   * @param requestDetails The request details for logging and tracking
-   */
-  private emitEthExecutionEvent(requestDetails: RequestDetails): void {
-    this.eventEmitter.emit(constants.EVENTS.ETH_EXECUTION, {
-      method: constants.ETH_SEND_RAW_TRANSACTION,
-    });
-  }
-
-  /**
    * Retrieves the current network exchange rate of HBAR to USD in cents.
    * @param requestDetails The request details for logging and tracking
    * @returns {Promise<number>} A promise that resolves to the current exchange rate in cents
@@ -553,7 +534,9 @@ export class TransactionService implements ITransactionService {
     const requestIdPrefix = requestDetails.formattedRequestId;
     const originalCallerAddress = parsedTx.from?.toString() || '';
 
-    this.emitEthExecutionEvent(requestDetails);
+    this.eventEmitter.emit(constants.EVENTS.ETH_EXECUTION, {
+      method: constants.ETH_SEND_RAW_TRANSACTION,
+    });
 
     const { txSubmitted, submittedTransactionId, error } = await this.submitTransaction(
       transactionBuffer,

--- a/packages/relay/src/lib/services/hapiService/hapiService.ts
+++ b/packages/relay/src/lib/services/hapiService/hapiService.ts
@@ -2,13 +2,14 @@
 
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
 import { Client } from '@hashgraph/sdk';
+import { EventEmitter } from 'events';
 import { Logger } from 'pino';
 import { Counter, Registry } from 'prom-client';
 
 import { Utils } from '../../../utils';
 import { SDKClient } from '../../clients';
 import constants from '../../constants';
-import { CustomEventEmitter } from '../../types';
+import { CustomEventEmitter, TypedEvents } from '../../types';
 import { HbarLimitService } from '../hbarLimitService';
 
 export default class HAPIService {
@@ -125,7 +126,7 @@ export default class HAPIService {
    * @readonly
    * @type {EventEmitter}
    */
-  private readonly eventEmitter: CustomEventEmitter;
+  readonly eventEmitter: CustomEventEmitter;
 
   /**
    * A registry used within the class.
@@ -151,15 +152,10 @@ export default class HAPIService {
    * @param {EventEmitter} eventEmitter - The event emitter instance used for emitting events.
    * @param {HbarLimitService} hbarLimitService - An HBAR Rate Limit service that tracks hbar expenses and limits.
    */
-  constructor(
-    logger: Logger,
-    register: Registry,
-    eventEmitter: CustomEventEmitter,
-    hbarLimitService: HbarLimitService,
-  ) {
+  constructor(logger: Logger, register: Registry, hbarLimitService: HbarLimitService) {
     this.logger = logger;
     this.hbarLimitService = hbarLimitService;
-    this.eventEmitter = eventEmitter;
+    this.eventEmitter = new EventEmitter<TypedEvents>();
     this.hederaNetwork = ConfigService.get('HEDERA_NETWORK').toLowerCase();
     this.clientMain = this.initClient(logger, this.hederaNetwork);
 

--- a/packages/relay/tests/lib/debug.spec.ts
+++ b/packages/relay/tests/lib/debug.spec.ts
@@ -4,12 +4,10 @@ import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services'
 import MockAdapter from 'axios-mock-adapter';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { EventEmitter } from 'events';
 import pino from 'pino';
 import { register, Registry } from 'prom-client';
 import sinon from 'sinon';
 
-import { TypedEvents } from '../../dist/lib/types';
 import { predefined } from '../../src';
 import { strip0x } from '../../src/formatters';
 import { MirrorNodeClient } from '../../src/lib/clients';
@@ -263,7 +261,6 @@ describe('Debug API Test Suite', async function () {
       cacheService,
     );
     const duration = constants.HBAR_RATE_LIMIT_DURATION;
-    const eventEmitter = new EventEmitter<TypedEvents>();
 
     const hbarSpendingPlanRepository = new HbarSpendingPlanRepository(cacheService, logger);
     const evmAddressHbarSpendingPlanRepository = new EvmAddressHbarSpendingPlanRepository(cacheService, logger);
@@ -276,7 +273,7 @@ describe('Debug API Test Suite', async function () {
       register,
       duration,
     );
-    new HAPIService(logger, registry, eventEmitter, hbarLimitService);
+    new HAPIService(logger, registry, hbarLimitService);
 
     restMock = new MockAdapter(mirrorNodeInstance.getMirrorNodeRestInstance(), { onNoMatch: 'throwException' });
 

--- a/packages/relay/tests/lib/eth/eth-helpers.ts
+++ b/packages/relay/tests/lib/eth/eth-helpers.ts
@@ -2,12 +2,10 @@
 
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
 import MockAdapter from 'axios-mock-adapter';
-import { EventEmitter } from 'events';
 import pino from 'pino';
 import { register, Registry } from 'prom-client';
 
 import { ConfigServiceTestHelper } from '../../../../config-service/tests/configServiceTestHelper';
-import { TypedEvents } from '../../../dist/lib/types';
 import { MirrorNodeClient } from '../../../src/lib/clients/mirrorNodeClient';
 import constants from '../../../src/lib/constants';
 import { EvmAddressHbarSpendingPlanRepository } from '../../../src/lib/db/repositories/hbarLimiter/evmAddressHbarSpendingPlanRepository';
@@ -48,7 +46,6 @@ export function generateEthTestEnv(fixedFeeHistory = false) {
   const web3Mock = new MockAdapter(mirrorNodeInstance.getMirrorNodeWeb3Instance(), { onNoMatch: 'throwException' });
 
   const duration = constants.HBAR_RATE_LIMIT_DURATION;
-  const eventEmitter = new EventEmitter<TypedEvents>();
 
   const hbarSpendingPlanRepository = new HbarSpendingPlanRepository(cacheService, logger);
   const evmAddressHbarSpendingPlanRepository = new EvmAddressHbarSpendingPlanRepository(cacheService, logger);
@@ -62,11 +59,11 @@ export function generateEthTestEnv(fixedFeeHistory = false) {
     duration,
   );
 
-  const hapiServiceInstance = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
+  const hapiServiceInstance = new HAPIService(logger, registry, hbarLimitService);
 
   const commonService = new CommonService(mirrorNodeInstance, logger, cacheService);
 
-  const ethImpl = new EthImpl(hapiServiceInstance, mirrorNodeInstance, logger, '0x12a', cacheService, eventEmitter);
+  const ethImpl = new EthImpl(hapiServiceInstance, mirrorNodeInstance, logger, '0x12a', cacheService);
 
   return {
     cacheService,

--- a/packages/relay/tests/lib/eth/eth_estimateGas.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_estimateGas.spec.ts
@@ -3,11 +3,9 @@
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { AbiCoder, keccak256 } from 'ethers';
-import { EventEmitter } from 'events';
 import { createStubInstance, SinonStub, SinonStubbedInstance, stub } from 'sinon';
 import { v4 as uuid } from 'uuid';
 
-import { TypedEvents } from '../../../dist/lib/types';
 import { Eth, JsonRpcError } from '../../../src';
 import { numberTo0x } from '../../../src/formatters';
 import { SDKClient } from '../../../src/lib/clients';
@@ -31,7 +29,6 @@ use(chaiAsPromised);
 let sdkClientStub: SinonStubbedInstance<SDKClient>;
 let getSdkClientStub: SinonStub<[], SDKClient>;
 let ethImplOverridden: Eth;
-let eventEmitter: EventEmitter;
 const gasTxBaseCost = numberTo0x(constants.TX_BASE_COST);
 describe('@ethEstimateGas Estimate Gas spec', async function () {
   this.timeout(10000);
@@ -40,7 +37,6 @@ describe('@ethEstimateGas Estimate Gas spec', async function () {
 
   const contractService = ethImpl['contractService'];
   const requestDetails = new RequestDetails({ requestId: 'eth_estimateGasTest', ipAddress: '0.0.0.0' });
-  eventEmitter = new EventEmitter<TypedEvents>();
   async function mockContractCall(
     callData: IContractCallRequest,
     estimate: boolean,
@@ -77,14 +73,7 @@ describe('@ethEstimateGas Estimate Gas spec', async function () {
     restMock.reset();
     sdkClientStub = createStubInstance(SDKClient);
     getSdkClientStub = stub(hapiServiceInstance, 'getSDKClient').returns(sdkClientStub);
-    ethImplOverridden = new EthImpl(
-      hapiServiceInstance,
-      mirrorNodeInstance,
-      logger,
-      '0x12a',
-      cacheService,
-      eventEmitter,
-    );
+    ethImplOverridden = new EthImpl(hapiServiceInstance, mirrorNodeInstance, logger, '0x12a', cacheService);
     restMock.onGet('network/fees').reply(200, JSON.stringify(DEFAULT_NETWORK_FEES));
     restMock.onGet(`accounts/undefined${NO_TRANSACTIONS}`).reply(404);
     mockGetAccount(hapiServiceInstance.getMainClientInstance().operatorAccountId!.toString(), 200, {

--- a/packages/relay/tests/lib/eth/eth_getBlockByHash.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getBlockByHash.spec.ts
@@ -2,11 +2,9 @@
 
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { EventEmitter } from 'events';
 import sinon from 'sinon';
 
 import { ASCIIToHex, numberTo0x, prepend0x } from '../../../dist/formatters';
-import { TypedEvents } from '../../../dist/lib/types';
 import { MirrorNodeClientError, predefined } from '../../../src';
 import { SDKClient } from '../../../src/lib/clients';
 import { EthImpl } from '../../../src/lib/eth';
@@ -56,7 +54,6 @@ let ethImplLowTransactionCount: EthImpl;
 describe('@ethGetBlockByHash using MirrorNode', async function () {
   this.timeout(10000);
   const { restMock, hapiServiceInstance, ethImpl, cacheService, mirrorNodeInstance, logger } = generateEthTestEnv(true);
-  const eventEmitter = new EventEmitter<TypedEvents>();
   const results = defaultContractResults.results;
   const TOTAL_GAS_USED = numberTo0x(results[0].gas_used + results[1].gas_used);
 
@@ -79,14 +76,7 @@ describe('@ethGetBlockByHash using MirrorNode', async function () {
       .onGet(contractByEvmAddress(CONTRACT_ADDRESS_2))
       .reply(200, JSON.stringify({ ...DEFAULT_CONTRACT, evmAddress: CONTRACT_ADDRESS_2 }));
 
-    ethImplLowTransactionCount = new EthImpl(
-      hapiServiceInstance,
-      mirrorNodeInstance,
-      logger,
-      '0x12a',
-      cacheService,
-      eventEmitter,
-    );
+    ethImplLowTransactionCount = new EthImpl(hapiServiceInstance, mirrorNodeInstance, logger, '0x12a', cacheService);
   });
 
   this.afterEach(() => {

--- a/packages/relay/tests/lib/eth/eth_getBlockByNumber.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getBlockByNumber.spec.ts
@@ -4,12 +4,10 @@ import { fail } from 'assert';
 import MockAdapter from 'axios-mock-adapter';
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { EventEmitter } from 'events';
 import { Logger } from 'pino';
 import sinon from 'sinon';
 
 import { ASCIIToHex, hashNumber, numberTo0x, prepend0x } from '../../../dist/formatters';
-import { TypedEvents } from '../../../dist/lib/types';
 import { predefined } from '../../../src';
 import { MirrorNodeClient, SDKClient } from '../../../src/lib/clients';
 import constants from '../../../src/lib/constants';
@@ -91,7 +89,6 @@ describe('@ethGetBlockByNumber using MirrorNode', async function () {
     mirrorNodeInstance: MirrorNodeClient;
     logger: Logger;
   } = generateEthTestEnv(true);
-  const eventEmitter = new EventEmitter<TypedEvents>();
   const results = defaultContractResults.results;
   const TOTAL_GAS_USED = numberTo0x(results[0].gas_used + results[1].gas_used);
 
@@ -125,14 +122,7 @@ describe('@ethGetBlockByNumber using MirrorNode', async function () {
     sdkClientStub = sinon.createStubInstance(SDKClient);
     getSdkClientStub = sinon.stub(hapiServiceInstance, 'getSDKClient').returns(sdkClientStub);
     restMock.onGet('network/fees').reply(200, JSON.stringify(DEFAULT_NETWORK_FEES));
-    ethImplLowTransactionCount = new EthImpl(
-      hapiServiceInstance,
-      mirrorNodeInstance,
-      logger,
-      '0x12a',
-      cacheService,
-      eventEmitter,
-    );
+    ethImplLowTransactionCount = new EthImpl(hapiServiceInstance, mirrorNodeInstance, logger, '0x12a', cacheService);
     restMock.onGet('network/fees').reply(200, JSON.stringify(DEFAULT_NETWORK_FEES));
     restMock.onGet(`accounts/${defaultContractResults.results[0].from}?transactions=false`).reply(200);
     restMock.onGet(`accounts/${defaultContractResults.results[1].from}?transactions=false`).reply(200);

--- a/packages/relay/tests/lib/ethGetBlockBy.spec.ts
+++ b/packages/relay/tests/lib/ethGetBlockBy.spec.ts
@@ -4,23 +4,16 @@ import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services'
 import MockAdapter from 'axios-mock-adapter';
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
-import { EventEmitter } from 'events';
 import pino from 'pino';
 import { register, Registry } from 'prom-client';
 
-import { TypedEvents } from '../../dist/lib/types';
 import { nanOrNumberTo0x, nullableNumberTo0x, numberTo0x, toHash32 } from '../../src/formatters';
 import { MirrorNodeClient } from '../../src/lib/clients';
 import constants from '../../src/lib/constants';
-import { EvmAddressHbarSpendingPlanRepository } from '../../src/lib/db/repositories/hbarLimiter/evmAddressHbarSpendingPlanRepository';
-import { HbarSpendingPlanRepository } from '../../src/lib/db/repositories/hbarLimiter/hbarSpendingPlanRepository';
-import { IPAddressHbarSpendingPlanRepository } from '../../src/lib/db/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository';
 import { EthImpl } from '../../src/lib/eth';
 import { Log, Transaction } from '../../src/lib/model';
 import { BlockService, CommonService } from '../../src/lib/services';
 import { CacheService } from '../../src/lib/services/cacheService/cacheService';
-import HAPIService from '../../src/lib/services/hapiService/hapiService';
-import { HbarLimitService } from '../../src/lib/services/hbarLimitService';
 import { RequestDetails } from '../../src/lib/types';
 import { defaultDetailedContractResults, overrideEnvsInMochaDescribe, useInMemoryRedisServer } from '../helpers';
 
@@ -31,7 +24,6 @@ const registry = new Registry();
 
 let restMock: MockAdapter;
 let mirrorNodeInstance: MirrorNodeClient;
-let hapiServiceInstance: HAPIService;
 let cacheService: CacheService;
 
 const blockHashTrimmed = '0x3c08bbbee74d287b1dcd3f0ca6d1d2cb92c90883c4acf9747de9f3f3162ad25b';
@@ -122,25 +114,6 @@ describe('eth_getBlockBy', async function () {
     // @ts-ignore
     restMock = new MockAdapter(mirrorNodeInstance.getMirrorNodeRestInstance(), { onNoMatch: 'throwException' });
 
-    const duration = constants.HBAR_RATE_LIMIT_DURATION;
-    const eventEmitter = new EventEmitter<TypedEvents>();
-
-    const hbarSpendingPlanRepository = new HbarSpendingPlanRepository(cacheService, logger);
-    const evmAddressHbarSpendingPlanRepository = new EvmAddressHbarSpendingPlanRepository(cacheService, logger);
-    const ipAddressHbarSpendingPlanRepository = new IPAddressHbarSpendingPlanRepository(cacheService, logger);
-    const hbarLimitService = new HbarLimitService(
-      hbarSpendingPlanRepository,
-      evmAddressHbarSpendingPlanRepository,
-      ipAddressHbarSpendingPlanRepository,
-      logger,
-      register,
-      duration,
-    );
-
-    hapiServiceInstance = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
-
-    // @ts-ignore
-    ethImpl = new EthImpl(hapiServiceInstance, mirrorNodeInstance, logger, '0x12a', cacheService, eventEmitter);
     const common = new CommonService(mirrorNodeInstance, logger, cacheService);
     blockService = new BlockService(cacheService, '0x12a', common, mirrorNodeInstance, logger);
   });

--- a/packages/relay/tests/lib/hapiService.spec.ts
+++ b/packages/relay/tests/lib/hapiService.spec.ts
@@ -3,11 +3,9 @@
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
 import { Client } from '@hashgraph/sdk';
 import { expect } from 'chai';
-import { EventEmitter } from 'events';
 import pino from 'pino';
 import { register, Registry } from 'prom-client';
 
-import { TypedEvents } from '../../dist/lib/types';
 import { SDKClient } from '../../src/lib/clients';
 import constants from '../../src/lib/constants';
 import { EvmAddressHbarSpendingPlanRepository } from '../../src/lib/db/repositories/hbarLimiter/evmAddressHbarSpendingPlanRepository';
@@ -25,7 +23,6 @@ const logger = pino({ level: 'silent' });
 describe('HAPI Service', async function () {
   this.timeout(20000);
   let cacheService: CacheService;
-  let eventEmitter: EventEmitter;
   let hapiService: HAPIService;
   let hbarLimitService: HbarLimitService;
 
@@ -34,7 +31,6 @@ describe('HAPI Service', async function () {
 
   this.beforeAll(() => {
     const duration = constants.HBAR_RATE_LIMIT_DURATION;
-    eventEmitter = new EventEmitter<TypedEvents>();
     cacheService = new CacheService(logger, registry);
 
     const hbarSpendingPlanRepository = new HbarSpendingPlanRepository(cacheService, logger);
@@ -57,7 +53,7 @@ describe('HAPI Service', async function () {
   });
 
   it('should be able to initialize SDK instance', async function () {
-    hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
+    hapiService = new HAPIService(logger, registry, hbarLimitService);
     const client = hapiService.getMainClientInstance();
     const sdkClient = hapiService.getSDKClient();
 
@@ -69,7 +65,7 @@ describe('HAPI Service', async function () {
     it('should be able to reinitialise SDK instance upon reaching transaction limit', async function () {
       const hapiClientTransactionReset = Number(ConfigService.get('HAPI_CLIENT_TRANSACTION_RESET'));
 
-      hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
+      hapiService = new HAPIService(logger, registry, hbarLimitService);
       expect(hapiService.getTransactionCount()).to.eq(hapiClientTransactionReset);
 
       const oldClientInstance = hapiService.getMainClientInstance();
@@ -89,7 +85,7 @@ describe('HAPI Service', async function () {
     it('should be able to reinitialise SDK instance upon reaching time limit', async function () {
       const hapiClientDurationReset = Number(ConfigService.get('HAPI_CLIENT_DURATION_RESET'));
 
-      hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
+      hapiService = new HAPIService(logger, registry, hbarLimitService);
       expect(hapiService.getTimeUntilReset()).to.be.approximately(hapiClientDurationReset, 10); // 10 ms tolerance
 
       const oldClientInstance = hapiService.getMainClientInstance();
@@ -108,7 +104,7 @@ describe('HAPI Service', async function () {
     it('should be able to reinitialise SDK instance upon error status code encounter', async function () {
       const hapiClientErrorReset = ConfigService.get('HAPI_CLIENT_ERROR_RESET');
 
-      hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
+      hapiService = new HAPIService(logger, registry, hbarLimitService);
       expect(hapiService.getErrorCodes()[0]).to.eq(hapiClientErrorReset[0]);
 
       const oldClientInstance = hapiService.getMainClientInstance();
@@ -134,7 +130,7 @@ describe('HAPI Service', async function () {
         const hapiClientTransactionReset = Number(ConfigService.get('HAPI_CLIENT_TRANSACTION_RESET'));
         const hapiClientDurationReset = Number(ConfigService.get('HAPI_CLIENT_DURATION_RESET'));
 
-        hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
+        hapiService = new HAPIService(logger, registry, hbarLimitService);
 
         const oldClientInstance = hapiService.getMainClientInstance();
         const oldSDKInstance = hapiService.getSDKClient();
@@ -159,7 +155,7 @@ describe('HAPI Service', async function () {
     () => {
       it('should keep the same instance of hbar limiter and not reset the budget', async function () {
         const costAmount = 10000;
-        hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
+        hapiService = new HAPIService(logger, registry, hbarLimitService);
 
         const hbarLimiterBudgetBefore = await hbarLimitService['getRemainingBudget'](requestDetails);
         const oldClientInstance = hapiService.getMainClientInstance();
@@ -189,7 +185,7 @@ describe('HAPI Service', async function () {
     },
     () => {
       it('should not be able to reinitialise and decrement counters, if it is disabled', async function () {
-        hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
+        hapiService = new HAPIService(logger, registry, hbarLimitService);
         expect(hapiService.getTransactionCount()).to.eq(Number(ConfigService.get('HAPI_CLIENT_TRANSACTION_RESET')));
 
         const oldClientInstance = hapiService.getMainClientInstance();

--- a/packages/relay/tests/lib/openrpc.spec.ts
+++ b/packages/relay/tests/lib/openrpc.spec.ts
@@ -6,13 +6,11 @@ import Ajv from 'ajv';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { expect } from 'chai';
-import { EventEmitter } from 'events';
 import pino from 'pino';
 import { register, Registry } from 'prom-client';
 import sinon from 'sinon';
 
 import openRpcSchema from '../../../../docs/openrpc.json';
-import { TypedEvents } from '../../dist/lib/types';
 import { Relay } from '../../src';
 import { numberTo0x } from '../../src/formatters';
 import { SDKClient } from '../../src/lib/clients';
@@ -108,7 +106,6 @@ describe('Open RPC Specification', function () {
       instance,
     );
     const duration = constants.HBAR_RATE_LIMIT_DURATION;
-    const eventEmitter = new EventEmitter<TypedEvents>();
 
     const hbarSpendingPlanRepository = new HbarSpendingPlanRepository(cacheService, logger);
     const evmAddressHbarSpendingPlanRepository = new EvmAddressHbarSpendingPlanRepository(cacheService, logger);
@@ -122,11 +119,11 @@ describe('Open RPC Specification', function () {
       duration,
     );
 
-    clientServiceInstance = new ClientService(logger, registry, eventEmitter, hbarLimitService);
+    clientServiceInstance = new ClientService(logger, registry, hbarLimitService);
     sdkClientStub = sinon.createStubInstance(SDKClient);
     sinon.stub(clientServiceInstance, 'getSDKClient').returns(sdkClientStub);
     // @ts-ignore
-    ethImpl = new EthImpl(clientServiceInstance, mirrorNodeInstance, logger, '0x12a', cacheService, eventEmitter);
+    ethImpl = new EthImpl(clientServiceInstance, mirrorNodeInstance, logger, '0x12a', cacheService);
 
     // mocked data
     mock.onGet('blocks?limit=1&order=desc').reply(200, JSON.stringify({ blocks: [defaultBlock] }));

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -27,7 +27,12 @@ import pino from 'pino';
 import { register, Registry } from 'prom-client';
 import * as sinon from 'sinon';
 
-import { CustomEventEmitter, TypedEvents } from '../../dist/lib/types';
+import {
+  CustomEventEmitter,
+  IExecuteQueryEventPayload,
+  IExecuteTransactionEventPayload,
+  TypedEvents,
+} from '../../dist/lib/types';
 import { formatTransactionId } from '../../src/formatters';
 import { MirrorNodeClient, SDKClient } from '../../src/lib/clients';
 import constants from '../../src/lib/constants';
@@ -35,7 +40,7 @@ import { EvmAddressHbarSpendingPlanRepository } from '../../src/lib/db/repositor
 import { HbarSpendingPlanRepository } from '../../src/lib/db/repositories/hbarLimiter/hbarSpendingPlanRepository';
 import { IPAddressHbarSpendingPlanRepository } from '../../src/lib/db/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository';
 import { SDKClientError } from '../../src/lib/errors/SDKClientError';
-import { CACHE_LEVEL, CacheService } from '../../src/lib/services/cacheService/cacheService';
+import { CacheService } from '../../src/lib/services/cacheService/cacheService';
 import HAPIService from '../../src/lib/services/hapiService/hapiService';
 import { HbarLimitService } from '../../src/lib/services/hbarLimitService';
 import MetricService from '../../src/lib/services/metricService/metricService';
@@ -97,6 +102,7 @@ describe('SdkClient', async function () {
       duration,
     );
 
+    // @ts-ignore
     sdkClient = new SDKClient(client, logger, eventEmitter, hbarLimitService);
 
     instance = axios.create({
@@ -119,7 +125,13 @@ describe('SdkClient', async function () {
 
     // Note: Since the main capturing metric logic of the `MetricService` class works by listening to specific events,
     //       this class does not need an instance but must still be initiated.
-    new MetricService(logger, sdkClient, mirrorNodeClient, registry, eventEmitter, hbarLimitService);
+    const metricService = new MetricService(logger, sdkClient, mirrorNodeClient, registry, hbarLimitService);
+    eventEmitter.on(constants.EVENTS.EXECUTE_TRANSACTION, (args: IExecuteTransactionEventPayload) => {
+      metricService.captureTransactionMetrics(args).then();
+    });
+    eventEmitter.on(constants.EVENTS.EXECUTE_QUERY, (args: IExecuteQueryEventPayload) => {
+      metricService.addExpenseAndCaptureMetrics(args);
+    });
   });
 
   beforeEach(() => {
@@ -141,7 +153,7 @@ describe('SdkClient', async function () {
 
     this.beforeEach(() => {
       if (ConfigService.get('OPERATOR_KEY_FORMAT') !== 'BAD_FORMAT') {
-        hapiService = new HAPIService(logger, registry, eventEmitter, hbarLimitService);
+        hapiService = new HAPIService(logger, registry, hbarLimitService);
       }
     });
 
@@ -181,7 +193,7 @@ describe('SdkClient', async function () {
     withOverriddenEnvsInMochaTest({ OPERATOR_KEY_FORMAT: 'BAD_FORMAT' }, () => {
       it('It should throw an Error when an unexpected string is set', async () => {
         try {
-          new HAPIService(logger, registry, eventEmitter, hbarLimitService);
+          new HAPIService(logger, registry, hbarLimitService);
           expect.fail(`Expected an error but nothing was thrown`);
         } catch (e: any) {
           expect(e.message).to.eq('Invalid OPERATOR_KEY_FORMAT provided: BAD_FORMAT');


### PR DESCRIPTION
### Description

Currently, we pass around one instance of the eventEmitter in classes that need it. We shouldn't do this, but instead create a new instance in the different classes.

The PoC branch and more description can be found [here](https://github.com/hiero-ledger/hiero-json-rpc-relay/pull/4112).

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes 

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1.
2.
3.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
