### PR TITLE
refactor: update logging to use Pino's interpolation values

### DIFF
--- a/packages/relay/src/lib/clients/cache/localLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/localLRUCache.ts
@@ -105,9 +105,7 @@ export class LocalLRUCache implements ICacheClient {
     if (value !== undefined) {
       const censoredKey = key.replace(Utils.IP_ADDRESS_REGEX, '<REDACTED>');
       const censoredValue = JSON.stringify(value).replace(/"ipAddress":"[^"]+"/, '"ipAddress":"<REDACTED>"');
-      if (this.logger.isLevelEnabled('trace')) {
-        this.logger.trace('Returning cached value %s:%s on %s call', censoredKey, censoredValue, callingMethod);
-      }
+      this.logger.trace('Returning cached value %s:%s on %s call', censoredKey, censoredValue, callingMethod);
       return value;
     }
 

--- a/packages/relay/src/lib/clients/cache/localLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/localLRUCache.ts
@@ -105,7 +105,9 @@ export class LocalLRUCache implements ICacheClient {
     if (value !== undefined) {
       const censoredKey = key.replace(Utils.IP_ADDRESS_REGEX, '<REDACTED>');
       const censoredValue = JSON.stringify(value).replace(/"ipAddress":"[^"]+"/, '"ipAddress":"<REDACTED>"');
+      if (this.logger.isLevelEnabled('trace')) {
         this.logger.trace('Returning cached value %s:%s on %s call', censoredKey, censoredValue, callingMethod);
+      }
       return value;
     }
 
@@ -121,7 +123,7 @@ export class LocalLRUCache implements ICacheClient {
   public async getRemainingTtl(key: string, callingMethod: string): Promise<number> {
     const cache = this.getCacheInstance(key);
     const remainingTtl = cache.getRemainingTTL(key); // in milliseconds
-      this.logger.trace('returning remaining TTL %s:%d on %s call', key, remainingTtl, callingMethod);
+    this.logger.trace('returning remaining TTL %s:%d on %s call', key, remainingTtl, callingMethod);
     return remainingTtl;
   }
 
@@ -141,14 +143,21 @@ export class LocalLRUCache implements ICacheClient {
     } else {
       cache.set(key, value, { ttl: 0 }); // 0 means indefinite time
     }
-      const censoredKey = key.replace(Utils.IP_ADDRESS_REGEX, '<REDACTED>');
-      const censoredValue = JSON.stringify(value).replace(/"ipAddress":"[^"]+"/, '"ipAddress":"<REDACTED>"');
-      const message = 'Caching %s:%s on %s for %s';
-      this.logger.trace('%s (cache size: %d, max: %d)', 
-        message.replace('%s', censoredKey).replace('%s', censoredValue).replace('%s', callingMethod).replace('%s', resolvedTtl > 0 ? `${resolvedTtl} ms` : 'indefinite time'),
-        this.cache.size, 
-        this.options.max
+    const censoredKey = key.replace(Utils.IP_ADDRESS_REGEX, '<REDACTED>');
+    const censoredValue = JSON.stringify(value).replace(/"ipAddress":"[^"]+"/, '"ipAddress":"<REDACTED>"');
+    const message = 'Caching %s:%s on %s for %s';
+    if (this.logger.isLevelEnabled('trace')) {
+      this.logger.trace(
+        '%s (cache size: %d, max: %d)',
+        message
+          .replace('%s', censoredKey)
+          .replace('%s', censoredValue)
+          .replace('%s', callingMethod)
+          .replace('%s', resolvedTtl > 0 ? `${resolvedTtl} ms` : 'indefinite time'),
+        this.cache.size,
+        this.options.max,
       );
+    }
   }
 
   /**

--- a/packages/relay/src/lib/clients/cache/localLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/localLRUCache.ts
@@ -145,18 +145,11 @@ export class LocalLRUCache implements ICacheClient {
     }
     const censoredKey = key.replace(Utils.IP_ADDRESS_REGEX, '<REDACTED>');
     const censoredValue = JSON.stringify(value).replace(/"ipAddress":"[^"]+"/, '"ipAddress":"<REDACTED>"');
-    const message = 'Caching %s:%s on %s for %s';
+    const message = `Caching ${censoredKey}:${censoredValue} on ${callingMethod} for ${
+      resolvedTtl > 0 ? `${resolvedTtl} ms` : 'indefinite time'
+    }`;
     if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(
-        '%s (cache size: %d, max: %d)',
-        message
-          .replace('%s', censoredKey)
-          .replace('%s', censoredValue)
-          .replace('%s', callingMethod)
-          .replace('%s', resolvedTtl > 0 ? `${resolvedTtl} ms` : 'indefinite time'),
-        this.cache.size,
-        this.options.max,
-      );
+      this.logger.trace('%s (cache size: %d, max: %d)', message, this.cache.size, this.options.max);
     }
   }
 
@@ -253,7 +246,8 @@ export class LocalLRUCache implements ICacheClient {
 
     const matchingKeys = keys.filter((key) => regex.test(key));
 
-    this.logger.trace(`retrieving keys matching ${pattern} on ${callingMethod} call`);
+    this.logger.trace('retrieving keys matching %s on %s call', pattern, callingMethod);
+
     return matchingKeys;
   }
 

--- a/packages/relay/src/lib/clients/cache/localLRUCache.ts
+++ b/packages/relay/src/lib/clients/cache/localLRUCache.ts
@@ -105,9 +105,7 @@ export class LocalLRUCache implements ICacheClient {
     if (value !== undefined) {
       const censoredKey = key.replace(Utils.IP_ADDRESS_REGEX, '<REDACTED>');
       const censoredValue = JSON.stringify(value).replace(/"ipAddress":"[^"]+"/, '"ipAddress":"<REDACTED>"');
-      if (this.logger.isLevelEnabled('trace')) {
-        this.logger.trace(`Returning cached value ${censoredKey}:${censoredValue} on ${callingMethod} call`);
-      }
+        this.logger.trace('Returning cached value %s:%s on %s call', censoredKey, censoredValue, callingMethod);
       return value;
     }
 
@@ -123,9 +121,7 @@ export class LocalLRUCache implements ICacheClient {
   public async getRemainingTtl(key: string, callingMethod: string): Promise<number> {
     const cache = this.getCacheInstance(key);
     const remainingTtl = cache.getRemainingTTL(key); // in milliseconds
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`returning remaining TTL ${key}:${remainingTtl} on ${callingMethod} call`);
-    }
+      this.logger.trace('returning remaining TTL %s:%d on %s call', key, remainingTtl, callingMethod);
     return remainingTtl;
   }
 
@@ -145,14 +141,14 @@ export class LocalLRUCache implements ICacheClient {
     } else {
       cache.set(key, value, { ttl: 0 }); // 0 means indefinite time
     }
-    if (this.logger.isLevelEnabled('trace')) {
       const censoredKey = key.replace(Utils.IP_ADDRESS_REGEX, '<REDACTED>');
       const censoredValue = JSON.stringify(value).replace(/"ipAddress":"[^"]+"/, '"ipAddress":"<REDACTED>"');
-      const message = `Caching ${censoredKey}:${censoredValue} on ${callingMethod} for ${
-        resolvedTtl > 0 ? `${resolvedTtl} ms` : 'indefinite time'
-      }`;
-      this.logger.trace(`${message} (cache size: ${this.cache.size}, max: ${this.options.max})`);
-    }
+      const message = 'Caching %s:%s on %s for %s';
+      this.logger.trace('%s (cache size: %d, max: %d)', 
+        message.replace('%s', censoredKey).replace('%s', censoredValue).replace('%s', callingMethod).replace('%s', resolvedTtl > 0 ? `${resolvedTtl} ms` : 'indefinite time'),
+        this.cache.size, 
+        this.options.max
+      );
   }
 
   /**
@@ -191,9 +187,7 @@ export class LocalLRUCache implements ICacheClient {
    * @param callingMethod - The name of the method calling the cache.
    */
   public async delete(key: string, callingMethod: string): Promise<void> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`delete cache for ${key} on ${callingMethod} call`);
-    }
+    this.logger.trace('delete cache for %s on %s call', key, callingMethod);
     const cache = this.getCacheInstance(key);
     cache.delete(key);
   }
@@ -250,9 +244,7 @@ export class LocalLRUCache implements ICacheClient {
 
     const matchingKeys = keys.filter((key) => regex.test(key));
 
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`retrieving keys matching ${pattern} on ${callingMethod} call`);
-    }
+    this.logger.trace(`retrieving keys matching ${pattern} on ${callingMethod} call`);
     return matchingKeys;
   }
 

--- a/packages/relay/src/lib/clients/cache/redisCache.ts
+++ b/packages/relay/src/lib/clients/cache/redisCache.ts
@@ -114,11 +114,9 @@ export class RedisCache implements IRedisCacheClient {
     const client = await this.getConnectedClient();
     const result = await client.get(key);
     if (result) {
-      if (this.logger.isLevelEnabled('trace')) {
         const censoredKey = key.replace(Utils.IP_ADDRESS_REGEX, '<REDACTED>');
         const censoredValue = result.replace(/"ipAddress":"[^"]+"/, '"ipAddress":"<REDACTED>"');
-        this.logger.trace(`Returning cached value ${censoredKey}:${censoredValue} on ${callingMethod} call`);
-      }
+        this.logger.trace('Returning cached value %s:%s on %s call', censoredKey, censoredValue, callingMethod);
       // TODO: add metrics
       return JSON.parse(result);
     }
@@ -146,12 +144,10 @@ export class RedisCache implements IRedisCacheClient {
 
     const censoredKey = key.replace(Utils.IP_ADDRESS_REGEX, '<REDACTED>');
     const censoredValue = serializedValue.replace(/"ipAddress":"[^"]+"/, '"ipAddress":"<REDACTED>"');
-    const message = `Caching ${censoredKey}:${censoredValue} on ${callingMethod} for ${
-      resolvedTtl > 0 ? `${resolvedTtl} ms` : 'indefinite time'
-    }`;
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`${message}`);
-    }
+    const message = 'Caching %s:%s on %s for %s';
+    this.logger.trace('%s',
+      message.replace('%s', censoredKey).replace('%s', censoredValue).replace('%s', callingMethod).replace('%s', resolvedTtl > 0 ? `${resolvedTtl} ms` : 'indefinite time')
+    );
     // TODO: add metrics
   }
 
@@ -175,9 +171,7 @@ export class RedisCache implements IRedisCacheClient {
 
     // Log the operation
     const entriesLength = Object.keys(keyValuePairs).length;
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`caching multiple keys via ${callingMethod}, total keys: ${entriesLength}`);
-    }
+    this.logger.trace('caching multiple keys via %s, total keys: %d', callingMethod, entriesLength);
   }
 
   /**
@@ -202,11 +196,9 @@ export class RedisCache implements IRedisCacheClient {
     // Execute pipeline operation
     await pipeline.execAsPipeline();
 
-    if (this.logger.isLevelEnabled('trace')) {
-      // Log the operation
-      const entriesLength = Object.keys(keyValuePairs).length;
-      this.logger.trace(`caching multiple keys via ${callingMethod}, total keys: ${entriesLength}`);
-    }
+    // Log the operation
+    const entriesLength = Object.keys(keyValuePairs).length;
+    this.logger.trace('caching multiple keys via %s, total keys: %d', callingMethod, entriesLength);
   }
 
   /**
@@ -219,9 +211,7 @@ export class RedisCache implements IRedisCacheClient {
   async delete(key: string, callingMethod: string): Promise<void> {
     const client = await this.getConnectedClient();
     await client.del(key);
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`delete cache for ${key} on ${callingMethod} call`);
-    }
+    this.logger.trace(`delete cache for ${key} on ${callingMethod} call`);
     // TODO: add metrics
   }
 
@@ -288,9 +278,7 @@ export class RedisCache implements IRedisCacheClient {
   async incrBy(key: string, amount: number, callingMethod: string): Promise<number> {
     const client = await this.getConnectedClient();
     const result = await client.incrBy(key, amount);
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`incrementing ${key} by ${amount} on ${callingMethod} call`);
-    }
+    this.logger.trace(`incrementing ${key} by ${amount} on ${callingMethod} call`);
     return result;
   }
 
@@ -306,9 +294,7 @@ export class RedisCache implements IRedisCacheClient {
   async lRange(key: string, start: number, end: number, callingMethod: string): Promise<any[]> {
     const client = await this.getConnectedClient();
     const result = await client.lRange(key, start, end);
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`retrieving range [${start}:${end}] from ${key} on ${callingMethod} call`);
-    }
+    this.logger.trace(`retrieving range [${start}:${end}] from ${key} on ${callingMethod} call`);
     return result.map((item) => JSON.parse(item));
   }
 
@@ -324,9 +310,7 @@ export class RedisCache implements IRedisCacheClient {
     const client = await this.getConnectedClient();
     const serializedValue = JSON.stringify(value);
     const result = await client.rPush(key, serializedValue);
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`pushing ${serializedValue} to ${key} on ${callingMethod} call`);
-    }
+    this.logger.trace(`pushing ${serializedValue} to ${key} on ${callingMethod} call`);
     return result;
   }
 
@@ -339,9 +323,7 @@ export class RedisCache implements IRedisCacheClient {
   async keys(pattern: string, callingMethod: string): Promise<string[]> {
     const client = await this.getConnectedClient();
     const result = await client.keys(pattern);
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`retrieving keys matching ${pattern} on ${callingMethod} call`);
-    }
+    this.logger.trace(`retrieving keys matching ${pattern} on ${callingMethod} call`);
     return result;
   }
 }

--- a/packages/relay/src/lib/clients/cache/redisCache.ts
+++ b/packages/relay/src/lib/clients/cache/redisCache.ts
@@ -328,7 +328,7 @@ export class RedisCache implements IRedisCacheClient {
   async keys(pattern: string, callingMethod: string): Promise<string[]> {
     const client = await this.getConnectedClient();
     const result = await client.keys(pattern);
-    this.logger.trace(`retrieving keys matching ${pattern} on ${callingMethod} call`);
+    this.logger.trace('retrieving keys matching %s on %s call', pattern, callingMethod);
     return result;
   }
 }

--- a/packages/relay/src/lib/clients/cache/redisCache.ts
+++ b/packages/relay/src/lib/clients/cache/redisCache.ts
@@ -64,7 +64,7 @@ export class RedisCache implements IRedisCacheClient {
       socket: {
         reconnectStrategy: (retries: number) => {
           const delay = retries * reconnectDelay;
-          logger.warn(`Trying to reconnect with Redis, retry #${retries}. Delay is ${delay} ms...`);
+          logger.warn('Trying to reconnect with Redis, retry #%d. Delay is %d ms...', retries, delay);
           return delay;
         },
       },
@@ -82,7 +82,7 @@ export class RedisCache implements IRedisCacheClient {
         this.logger.error(error);
         return 0;
       });
-      logger.info(`Connected to Redis server (${redisUrl}) successfully! Number of connections: ${connections}`);
+      logger.info('Connected to Redis server (%s) successfully! Number of connections: %s', redisUrl, connections);
     });
     this.client.on('end', () => {
       this.connected = Promise.resolve(false);
@@ -92,9 +92,9 @@ export class RedisCache implements IRedisCacheClient {
       this.connected = Promise.resolve(false);
       const redisError = new RedisCacheError(error);
       if (redisError.isSocketClosed()) {
-        logger.error(`Error occurred with Redis Connection when closing socket: ${redisError.message}`);
+        logger.error('Error occurred with Redis Connection when closing socket: %s', redisError.message);
       } else {
-        logger.error(`Error occurred with Redis Connection: ${redisError.fullError}`);
+        logger.error('Error occurred with Redis Connection: %s', redisError.fullError);
       }
     });
   }
@@ -114,9 +114,9 @@ export class RedisCache implements IRedisCacheClient {
     const client = await this.getConnectedClient();
     const result = await client.get(key);
     if (result) {
-        const censoredKey = key.replace(Utils.IP_ADDRESS_REGEX, '<REDACTED>');
-        const censoredValue = result.replace(/"ipAddress":"[^"]+"/, '"ipAddress":"<REDACTED>"');
-        this.logger.trace('Returning cached value %s:%s on %s call', censoredKey, censoredValue, callingMethod);
+      const censoredKey = key.replace(Utils.IP_ADDRESS_REGEX, '<REDACTED>');
+      const censoredValue = result.replace(/"ipAddress":"[^"]+"/, '"ipAddress":"<REDACTED>"');
+      this.logger.trace('Returning cached value %s:%s on %s call', censoredKey, censoredValue, callingMethod);
       // TODO: add metrics
       return JSON.parse(result);
     }
@@ -145,8 +145,13 @@ export class RedisCache implements IRedisCacheClient {
     const censoredKey = key.replace(Utils.IP_ADDRESS_REGEX, '<REDACTED>');
     const censoredValue = serializedValue.replace(/"ipAddress":"[^"]+"/, '"ipAddress":"<REDACTED>"');
     const message = 'Caching %s:%s on %s for %s';
-    this.logger.trace('%s',
-      message.replace('%s', censoredKey).replace('%s', censoredValue).replace('%s', callingMethod).replace('%s', resolvedTtl > 0 ? `${resolvedTtl} ms` : 'indefinite time')
+    this.logger.trace(
+      '%s',
+      message
+        .replace('%s', censoredKey)
+        .replace('%s', censoredValue)
+        .replace('%s', callingMethod)
+        .replace('%s', resolvedTtl > 0 ? `${resolvedTtl} ms` : 'indefinite time'),
     );
     // TODO: add metrics
   }
@@ -211,7 +216,7 @@ export class RedisCache implements IRedisCacheClient {
   async delete(key: string, callingMethod: string): Promise<void> {
     const client = await this.getConnectedClient();
     await client.del(key);
-    this.logger.trace(`delete cache for ${key} on ${callingMethod} call`);
+    this.logger.trace('delete cache for %s on %s call', key, callingMethod);
     // TODO: add metrics
   }
 
@@ -278,7 +283,7 @@ export class RedisCache implements IRedisCacheClient {
   async incrBy(key: string, amount: number, callingMethod: string): Promise<number> {
     const client = await this.getConnectedClient();
     const result = await client.incrBy(key, amount);
-    this.logger.trace(`incrementing ${key} by ${amount} on ${callingMethod} call`);
+    this.logger.trace('incrementing %s by %d on %s call', key, amount, callingMethod);
     return result;
   }
 
@@ -294,7 +299,7 @@ export class RedisCache implements IRedisCacheClient {
   async lRange(key: string, start: number, end: number, callingMethod: string): Promise<any[]> {
     const client = await this.getConnectedClient();
     const result = await client.lRange(key, start, end);
-    this.logger.trace(`retrieving range [${start}:${end}] from ${key} on ${callingMethod} call`);
+    this.logger.trace('retrieving range [%d:%d] from %s on %s call', start, end, key, callingMethod);
     return result.map((item) => JSON.parse(item));
   }
 
@@ -310,7 +315,7 @@ export class RedisCache implements IRedisCacheClient {
     const client = await this.getConnectedClient();
     const serializedValue = JSON.stringify(value);
     const result = await client.rPush(key, serializedValue);
-    this.logger.trace(`pushing ${serializedValue} to ${key} on ${callingMethod} call`);
+    this.logger.trace('pushing %s to %s on %s call', serializedValue, key, callingMethod);
     return result;
   }
 

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -218,11 +218,14 @@ export class SDKClient {
         throw predefined.REQUEST_TIMEOUT;
       }
 
-      if (this.logger.isLevelEnabled('debug')) {
-        this.logger.debug(
-          `Fail to execute ${queryConstructorName} callerName=${callerName}, status=${sdkClientError.status}(${sdkClientError.status._code}), cost=${queryCost} tinybars`,
-        );
-      }
+      this.logger.debug(
+        'Fail to execute %s callerName=%s, status=%s(%s), cost=%d tinybars',
+        queryConstructorName,
+        callerName,
+        sdkClientError.status,
+        sdkClientError.status._code,
+        queryCost,
+      );
 
       throw sdkClientError;
     } finally {
@@ -283,7 +286,7 @@ export class SDKClient {
     }
 
     try {
-      this.logger.info(`Execute ${txConstructorName} transaction`);
+      this.logger.info('Execute %s transaction', txConstructorName);
       transactionResponse = await transaction.execute(this.clientMain);
 
       transactionId = transactionResponse.transactionId.toString();
@@ -292,13 +295,21 @@ export class SDKClient {
       const transactionReceipt = await transactionResponse.getReceipt(this.clientMain);
 
       this.logger.info(
-        `Successfully execute ${txConstructorName} transaction: transactionId=${transactionResponse.transactionId}, callerName=${callerName}, status=${transactionReceipt.status}(${transactionReceipt.status._code})`,
+        'Successfully execute %s transaction: transactionId=%s, callerName=%s, status=%s(%s)',
+        txConstructorName,
+        transactionResponse.transactionId,
+        callerName,
+        transactionReceipt.status,
+        transactionReceipt.status._code,
       );
       return transactionResponse;
     } catch (e: any) {
       this.logger.warn(
         e,
-        `Transaction failed while executing transaction via the SDK: transactionId=${transaction.transactionId}, callerName=${callerName}, txConstructorName=${txConstructorName}`,
+        'Transaction failed while executing transaction via the SDK: transactionId=%s, callerName=%s, txConstructorName=%s',
+        transaction.transactionId,
+        callerName,
+        txConstructorName,
       );
 
       if (e instanceof JsonRpcError) {
@@ -493,12 +504,10 @@ export class SDKClient {
       );
 
       if (fileInfo.size.isZero()) {
-        this.logger.warn(`File ${fileId} is empty.`);
+        this.logger.warn('File %s is empty.', fileId);
         throw new SDKClientError({}, 'Created file is empty.');
       }
-      if (this.logger.isLevelEnabled('trace')) {
-        this.logger.trace(`Created file with fileId: ${fileId} and file size ${fileInfo.size}`);
-      }
+      this.logger.trace('Created file with fileId: %s and file size %s', fileId, fileInfo.size);
     }
 
     return fileId;
@@ -546,11 +555,9 @@ export class SDKClient {
       );
 
       if (fileInfo.isDeleted) {
-        if (this.logger.isLevelEnabled('trace')) {
-          this.logger.trace(`Deleted file with fileId: ${fileId}`);
-        }
+        this.logger.trace('Deleted file with fileId: %s', fileId);
       } else {
-        this.logger.warn(`Fail to delete file with fileId: ${fileId} `);
+        this.logger.warn('Fail to delete file with fileId: %s ', fileId);
       }
     } catch (error: any) {
       this.logger.warn(`${error['message']} `);
@@ -577,11 +584,11 @@ export class SDKClient {
     let transactionFee: number = 0;
     let txRecordChargeAmount: number = 0;
     try {
-      if (this.logger.isLevelEnabled('debug')) {
         this.logger.debug(
-          `Get transaction record via consensus node: transactionId=${transactionId}, txConstructorName=${txConstructorName}`,
+          'Get transaction record via consensus node: transactionId=%s, txConstructorName=%s',
+          transactionId,
+          txConstructorName,
         );
-      }
 
       const transactionRecord = await new TransactionRecordQuery()
         .setTransactionId(transactionId)
@@ -601,7 +608,13 @@ export class SDKClient {
       const sdkClientError = new SDKClientError(e, e.message);
       this.logger.warn(
         e,
-        `Error raised during TransactionRecordQuery: transactionId=${transactionId}, txConstructorName=${txConstructorName}, recordStatus=${sdkClientError.status} (${sdkClientError.status._code}), cost=${transactionFee}, gasUsed=${gasUsed}`,
+        'Error raised during TransactionRecordQuery: transactionId=%s, txConstructorName=%s, recordStatus=%s (%s), cost=%d, gasUsed=%d',
+        transactionId,
+        txConstructorName,
+        sdkClientError.status,
+        sdkClientError.status._code,
+        transactionFee,
+        gasUsed,
       );
       throw sdkClientError;
     }

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -198,14 +198,17 @@ export class SDKClient {
     let queryCost: number | undefined = undefined;
     let status: string = '';
 
-    this.logger.info(`Execute ${queryConstructorName} query.`);
+    this.logger.info('Execute %s query.', queryConstructorName);
 
     try {
       queryResponse = await query.execute(client);
       queryCost = query._queryPayment?.toTinybars().toNumber();
       status = Status.Success.toString();
       this.logger.info(
-        `Successfully execute ${queryConstructorName} query: callerName=${callerName}, cost=${queryCost} tinybars`,
+        'Successfully execute %s query: callerName=%s, cost=%d tinybars',
+        queryConstructorName,
+        callerName,
+        queryCost,
       );
       return queryResponse;
     } catch (e: any) {
@@ -560,7 +563,7 @@ export class SDKClient {
         this.logger.warn('Fail to delete file with fileId: %s ', fileId);
       }
     } catch (error: any) {
-      this.logger.warn(`${error['message']} `);
+      this.logger.warn('%s', error['message']);
     }
   }
 
@@ -584,11 +587,11 @@ export class SDKClient {
     let transactionFee: number = 0;
     let txRecordChargeAmount: number = 0;
     try {
-        this.logger.debug(
-          'Get transaction record via consensus node: transactionId=%s, txConstructorName=%s',
-          transactionId,
-          txConstructorName,
-        );
+      this.logger.debug(
+        'Get transaction record via consensus node: transactionId=%s, txConstructorName=%s',
+        transactionId,
+        txConstructorName,
+      );
 
       const transactionRecord = await new TransactionRecordQuery()
         .setTransactionId(transactionId)

--- a/packages/relay/src/lib/db/repositories/hbarLimiter/evmAddressHbarSpendingPlanRepository.ts
+++ b/packages/relay/src/lib/db/repositories/hbarLimiter/evmAddressHbarSpendingPlanRepository.ts
@@ -69,9 +69,7 @@ export class EvmAddressHbarSpendingPlanRepository {
     for (const key of keys) {
       const addressPlan = await this.cache.getAsync<IEvmAddressHbarSpendingPlan>(key, callingMethod);
       if (addressPlan?.planId === planId) {
-        if (this.logger.isLevelEnabled('trace')) {
-          this.logger.trace(`Removing EVM address ${addressPlan.evmAddress} from HbarSpendingPlan with ID ${planId}`);
-        }
+          this.logger.trace('Removing EVM address %s from HbarSpendingPlan with ID %s', addressPlan.evmAddress, planId);
         await this.cache.delete(key, callingMethod);
       }
     }
@@ -89,11 +87,11 @@ export class EvmAddressHbarSpendingPlanRepository {
     if (!addressPlan) {
       throw new EvmAddressHbarSpendingPlanNotFoundError(evmAddress);
     }
-    if (this.logger.isLevelEnabled('debug')) {
       this.logger.debug(
-        `Retrieved link between EVM address ${evmAddress} and HbarSpendingPlan with ID ${addressPlan.planId}`,
+        'Retrieved link between EVM address %s and HbarSpendingPlan with ID %s',
+        evmAddress,
+        addressPlan.planId,
       );
-    }
     return new EvmAddressHbarSpendingPlan(addressPlan);
   }
 
@@ -107,11 +105,11 @@ export class EvmAddressHbarSpendingPlanRepository {
   async save(addressPlan: IEvmAddressHbarSpendingPlan, ttl: number): Promise<void> {
     const key = this.getKey(addressPlan.evmAddress);
     await this.cache.set(key, addressPlan, 'save', ttl);
-    if (this.logger.isLevelEnabled('debug')) {
-      this.logger.debug(
-        `Linked EVM address ${addressPlan.evmAddress} to HbarSpendingPlan with ID ${addressPlan.planId}`,
-      );
-    }
+    this.logger.debug(
+      'Linked EVM address %s to HbarSpendingPlan with ID %s',
+      addressPlan.evmAddress,
+      addressPlan.planId,
+    );
   }
 
   /**
@@ -127,9 +125,7 @@ export class EvmAddressHbarSpendingPlanRepository {
     const errorMessage = evmAddressPlan
       ? `Removed EVM address ${evmAddress} from HbarSpendingPlan with ID ${evmAddressPlan.planId}`
       : `Trying to remove EVM address ${evmAddress}, which is not linked to a spending plan`;
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`${errorMessage}`);
-    }
+      this.logger.trace('%s', errorMessage);
   }
 
   /**

--- a/packages/relay/src/lib/db/repositories/hbarLimiter/hbarSpendingPlanRepository.ts
+++ b/packages/relay/src/lib/db/repositories/hbarLimiter/hbarSpendingPlanRepository.ts
@@ -42,9 +42,7 @@ export class HbarSpendingPlanRepository {
     if (!plan) {
       throw new HbarSpendingPlanNotFoundError(id);
     }
-    if (this.logger.isLevelEnabled('debug')) {
-      this.logger.debug(`Retrieved subscription with ID ${id}`);
-    }
+    this.logger.debug('Retrieved subscription with ID %s', id);
     return {
       ...plan,
       createdAt: new Date(plan.createdAt),
@@ -81,18 +79,14 @@ export class HbarSpendingPlanRepository {
       spendingHistory: [],
       amountSpent: 0,
     };
-    if (this.logger.isLevelEnabled('debug')) {
-      this.logger.debug(`Creating HbarSpendingPlan with ID ${plan.id}...`);
-    }
+    this.logger.debug('Creating HbarSpendingPlan with ID %s...', plan.id);
     const key = this.getKey(plan.id);
     await this.cache.set(key, plan, 'create', ttl);
     return new HbarSpendingPlan(plan);
   }
 
   async delete(id: string): Promise<void> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`Deleting HbarSpendingPlan with ID ${id}...`);
-    }
+    this.logger.trace('Deleting HbarSpendingPlan with ID %s...', id);
     const key = this.getKey(id);
     await this.cache.delete(key, 'delete');
   }
@@ -117,9 +111,7 @@ export class HbarSpendingPlanRepository {
   async getSpendingHistory(id: string): Promise<IHbarSpendingRecord[]> {
     await this.checkExistsAndActive(id);
 
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`Retrieving spending history for HbarSpendingPlan with ID ${id}...`);
-    }
+    this.logger.trace('Retrieving spending history for HbarSpendingPlan with ID %s...', id);
     const key = this.getSpendingHistoryKey(id);
     const spendingHistory = await this.cache.lRange<IHbarSpendingRecord>(key, 0, -1, 'getSpendingHistory');
     return spendingHistory.map((entry) => new HbarSpendingRecord(entry));
@@ -134,9 +126,7 @@ export class HbarSpendingPlanRepository {
   async addAmountToSpendingHistory(id: string, amount: number): Promise<number> {
     await this.checkExistsAndActive(id);
 
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`Adding ${amount} to spending history for HbarSpendingPlan with ID ${id}...`);
-    }
+    this.logger.trace('Adding %d to spending history for HbarSpendingPlan with ID %s...', amount, id);
     const key = this.getSpendingHistoryKey(id);
     const entry: IHbarSpendingRecord = { amount, timestamp: new Date() };
     return this.cache.rPush(key, entry, 'addAmountToSpendingHistory');
@@ -150,9 +140,7 @@ export class HbarSpendingPlanRepository {
   async getAmountSpent(id: string): Promise<number> {
     await this.checkExistsAndActive(id);
 
-    if (this.logger.isLevelEnabled('debug')) {
-      this.logger.debug(`Retrieving amountSpent for HbarSpendingPlan with ID ${id}...`);
-    }
+    this.logger.debug('Retrieving amountSpent for HbarSpendingPlan with ID %s...', id);
     const key = this.getAmountSpentKey(id);
     return this.cache.getAsync(key, 'getAmountSpent').then((amountSpent) => parseInt(amountSpent ?? '0'));
   }
@@ -162,15 +150,11 @@ export class HbarSpendingPlanRepository {
    * @returns - A promise that resolves when the operation is complete.
    */
   async resetAmountSpentOfAllPlans(): Promise<void> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`Resetting the \`amountSpent\` entries for all HbarSpendingPlans...`);
-    }
+    this.logger.trace('Resetting the `amountSpent` entries for all HbarSpendingPlans...');
     const callerMethod = this.resetAmountSpentOfAllPlans.name;
     const keys = await this.cache.keys(this.getAmountSpentKey('*'), callerMethod);
     await Promise.all(keys.map((key) => this.cache.delete(key, callerMethod)));
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`Successfully reset ${keys.length} "amountSpent" entries for HbarSpendingPlans.`);
-    }
+    this.logger.trace('Successfully reset %d "amountSpent" entries for HbarSpendingPlans.', keys.length);
   }
 
   /**
@@ -185,14 +169,10 @@ export class HbarSpendingPlanRepository {
 
     const key = this.getAmountSpentKey(id);
     if (!(await this.cache.getAsync(key, 'addToAmountSpent'))) {
-      if (this.logger.isLevelEnabled('trace')) {
-        this.logger.trace(`No spending yet for HbarSpendingPlan with ID ${id}, setting amountSpent to ${amount}...`);
-      }
+      this.logger.trace('No spending yet for HbarSpendingPlan with ID %s, setting amountSpent to %d...', id, amount);
       await this.cache.set(key, amount, 'addToAmountSpent', ttl);
     } else {
-      if (this.logger.isLevelEnabled('debug')) {
-        this.logger.debug(`Adding ${amount} to amountSpent for HbarSpendingPlan with ID ${id}...`);
-      }
+        this.logger.debug('Adding %d to amountSpent for HbarSpendingPlan with ID %s...', amount, id);
       await this.cache.incrBy(key, amount, 'addToAmountSpent');
     }
   }

--- a/packages/relay/src/lib/db/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository.ts
+++ b/packages/relay/src/lib/db/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository.ts
@@ -69,9 +69,7 @@ export class IPAddressHbarSpendingPlanRepository {
     for (const key of keys) {
       const addressPlan = await this.cache.getAsync<IIPAddressHbarSpendingPlan>(key, callingMethod);
       if (addressPlan?.planId === planId) {
-        if (this.logger.isLevelEnabled('trace')) {
           this.logger.trace(`Removing IP address from HbarSpendingPlan with ID ${planId}`);
-        }
         await this.cache.delete(key, callingMethod);
       }
     }
@@ -89,9 +87,7 @@ export class IPAddressHbarSpendingPlanRepository {
     if (!addressPlan) {
       throw new IPAddressHbarSpendingPlanNotFoundError(ipAddress);
     }
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`Retrieved link between IP address and HbarSpendingPlan with ID ${addressPlan.planId}`);
-    }
+    this.logger.trace(`Retrieved link between IP address and HbarSpendingPlan with ID ${addressPlan.planId}`);
     return new IPAddressHbarSpendingPlan(addressPlan);
   }
 
@@ -121,9 +117,7 @@ export class IPAddressHbarSpendingPlanRepository {
     const errorMessage = ipAddressSpendingPlan
       ? `Removed IP address from HbarSpendingPlan with ID ${ipAddressSpendingPlan.planId}`
       : `Trying to remove an IP address, which is not linked to a spending plan`;
-    if (this.logger.isLevelEnabled('trace')) {
       this.logger.trace(`${errorMessage}`);
-    }
   }
 
   /**

--- a/packages/relay/src/lib/db/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository.ts
+++ b/packages/relay/src/lib/db/repositories/hbarLimiter/ipAddressHbarSpendingPlanRepository.ts
@@ -69,7 +69,7 @@ export class IPAddressHbarSpendingPlanRepository {
     for (const key of keys) {
       const addressPlan = await this.cache.getAsync<IIPAddressHbarSpendingPlan>(key, callingMethod);
       if (addressPlan?.planId === planId) {
-          this.logger.trace(`Removing IP address from HbarSpendingPlan with ID ${planId}`);
+        this.logger.trace('Removing IP address from HbarSpendingPlan with ID %s', planId);
         await this.cache.delete(key, callingMethod);
       }
     }
@@ -87,7 +87,7 @@ export class IPAddressHbarSpendingPlanRepository {
     if (!addressPlan) {
       throw new IPAddressHbarSpendingPlanNotFoundError(ipAddress);
     }
-    this.logger.trace(`Retrieved link between IP address and HbarSpendingPlan with ID ${addressPlan.planId}`);
+    this.logger.trace('Retrieved link between IP address and HbarSpendingPlan with ID %s', addressPlan.planId);
     return new IPAddressHbarSpendingPlan(addressPlan);
   }
 
@@ -101,7 +101,7 @@ export class IPAddressHbarSpendingPlanRepository {
   async save(addressPlan: IIPAddressHbarSpendingPlan, ttl: number): Promise<void> {
     const key = this.getKey(addressPlan.ipAddress);
     await this.cache.set(key, addressPlan, 'save', ttl);
-    this.logger.trace(`Linked new IP address to HbarSpendingPlan with ID ${addressPlan.planId}`);
+    this.logger.trace('Linked new IP address to HbarSpendingPlan with ID %s', addressPlan.planId);
   }
 
   /**
@@ -117,7 +117,7 @@ export class IPAddressHbarSpendingPlanRepository {
     const errorMessage = ipAddressSpendingPlan
       ? `Removed IP address from HbarSpendingPlan with ID ${ipAddressSpendingPlan.planId}`
       : `Trying to remove an IP address, which is not linked to a spending plan`;
-      this.logger.trace(`${errorMessage}`);
+    this.logger.trace('%s', errorMessage);
   }
 
   /**

--- a/packages/relay/src/lib/debug.ts
+++ b/packages/relay/src/lib/debug.ts
@@ -115,9 +115,7 @@ export class DebugImpl implements Debug {
     tracerObject: TransactionTracerConfig,
     requestDetails: RequestDetails,
   ): Promise<any> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`traceTransaction(${transactionIdOrHash})`);
-    }
+    this.logger.trace('traceTransaction(%s)', transactionIdOrHash);
 
     //we use a wrapper since we accept a transaction where a second param with tracer/tracerConfig may not be provided
     //and we will still default to opcodeLogger
@@ -174,9 +172,7 @@ export class DebugImpl implements Debug {
     tracerObject: BlockTracerConfig,
     requestDetails: RequestDetails,
   ): Promise<TraceBlockByNumberTxResult[]> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`traceBlockByNumber(blockNumber=${blockNumber}, tracerObject=${JSON.stringify(tracerObject)})`);
-    }
+    this.logger.trace('traceBlockByNumber(blockNumber=%s, tracerObject=%o)', blockNumber, tracerObject);
 
     try {
       DebugImpl.requireDebugAPIEnabled();

--- a/packages/relay/src/lib/dispatcher/rpcMethodDispatcher.ts
+++ b/packages/relay/src/lib/dispatcher/rpcMethodDispatcher.ts
@@ -79,9 +79,7 @@ export class RpcMethodDispatcher {
     const operationHandler = this.methodRegistry.get(rpcMethodName);
 
     if (!operationHandler) {
-      if (this.logger.isLevelEnabled('debug')) {
-        this.logger.debug(`RPC method not found in registry: rpcMethodName=${rpcMethodName}`);
-      }
+      this.logger.debug('RPC method not found in registry: rpcMethodName=%s', rpcMethodName);
 
       throw this.throwUnregisteredRpcMethods(rpcMethodName);
     }
@@ -90,11 +88,11 @@ export class RpcMethodDispatcher {
     const methodParamSchemas = operationHandler[RPC_PARAM_VALIDATION_RULES_KEY];
 
     if (methodParamSchemas) {
-      if (this.logger.isLevelEnabled('info')) {
-        this.logger.info(
-          `Validating method parameters for ${rpcMethodName}, params: ${JSON.stringify(rpcMethodParams)}`,
-        );
-      }
+      this.logger.info(
+        'Validating method parameters for %s, params: %o',
+        rpcMethodName,
+        rpcMethodParams,
+      );
       validateParams(rpcMethodParams, methodParamSchemas);
     }
 
@@ -152,7 +150,7 @@ export class RpcMethodDispatcher {
    */
   private handleRpcMethodError(error: any, rpcMethodName: string): JsonRpcError {
     const errorMessage = error?.message?.toString() || 'Unknown error';
-    this.logger.error(`Error executing method: rpcMethodName=${rpcMethodName}, error=${errorMessage}`);
+    this.logger.error('Error executing method: rpcMethodName=%s, error=%s', rpcMethodName, errorMessage);
 
     // If error is already a JsonRpcError, use it directly
     if (error instanceof JsonRpcError) {

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -204,9 +204,7 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   async blockNumber(requestDetails: RequestDetails): Promise<string> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`blockNumber()`);
-    }
+    this.logger.trace(`blockNumber()`);
     return await this.common.getLatestBlockNumber(requestDetails);
   }
 
@@ -223,9 +221,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   chainId(): string {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`chainId()`);
-    }
     return this.chain;
   }
 
@@ -296,9 +291,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   async mining(): Promise<boolean> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('mining()');
-    }
     return false;
   }
 
@@ -318,9 +310,7 @@ export class EthImpl implements Eth {
     0: { type: 'filter', required: true },
   })
   async newFilter(params: INewFilterParams, requestDetails: RequestDetails): Promise<string> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`newFilter(params=${JSON.stringify(params)})`);
-    }
+    this.logger.trace('newFilter(params=%o)', params);
     return this.filterService.newFilter(params, requestDetails);
   }
 
@@ -339,9 +329,7 @@ export class EthImpl implements Eth {
     0: { type: 'hex', required: true },
   })
   async getFilterLogs(filterId: string, requestDetails: RequestDetails): Promise<Log[]> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`getFilterLogs(${filterId})`);
-    }
+    this.logger.trace('getFilterLogs(%s)', filterId);
     return this.filterService.getFilterLogs(filterId, requestDetails);
   }
 
@@ -360,9 +348,7 @@ export class EthImpl implements Eth {
     0: { type: 'hex', required: true },
   })
   async getFilterChanges(filterId: string, requestDetails: RequestDetails): Promise<string[] | Log[]> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`getFilterChanges(${filterId})`);
-    }
+    this.logger.trace('getFilterChanges(%s)', filterId);
     return this.filterService.getFilterChanges(filterId, requestDetails);
   }
 
@@ -378,9 +364,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   async newBlockFilter(requestDetails: RequestDetails): Promise<string> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('newBlockFilter()');
-    }
     return this.filterService.newBlockFilter(requestDetails);
   }
 
@@ -398,9 +381,7 @@ export class EthImpl implements Eth {
     0: { type: 'hex', required: true },
   })
   async uninstallFilter(filterId: string): Promise<boolean> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`uninstallFilter(${filterId})`);
-    }
+    this.logger.trace('uninstallFilter(%s)', filterId);
     return this.filterService.uninstallFilter(filterId);
   }
 
@@ -415,11 +396,9 @@ export class EthImpl implements Eth {
    */
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
-  newPendingTransactionFilter(): JsonRpcError {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('newPendingTransactionFilter()');
-    }
-    return predefined.UNSUPPORTED_METHOD;
+  async newPendingTransactionFilter(): Promise<JsonRpcError> {
+    this.logger.trace('newPendingTransactionFilter()');
+    return this.filterService.newPendingTransactionFilter();
   }
 
   /**
@@ -428,9 +407,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   async submitWork(): Promise<boolean> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('submitWork()');
-    }
     return false;
   }
 
@@ -440,9 +416,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   async syncing(): Promise<boolean> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('syncing()');
-    }
     return false;
   }
 
@@ -512,9 +485,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   async hashrate(): Promise<string> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('hashrate()');
-    }
     return constants.ZERO_HEX;
   }
 
@@ -529,9 +499,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   getWork(): JsonRpcError {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('getWork()');
-    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
@@ -546,9 +513,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   submitHashrate(): JsonRpcError {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('submitHashrate()');
-    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
@@ -605,9 +569,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   protocolVersion(): JsonRpcError {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('protocolVersion()');
-    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
@@ -622,9 +583,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   coinbase(): JsonRpcError {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('coinbase()');
-    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
@@ -639,9 +597,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   blobBaseFee(): JsonRpcError {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('blobBaseFee()');
-    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
@@ -954,9 +909,8 @@ export class EthImpl implements Eth {
     );
     // log request info and increment metrics counter
     const callDataSize = callData ? callData.length : 0;
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`call data size: ${callDataSize}`);
-    }
+
+    this.logger.trace('call data size: %d', callDataSize);
 
     this.eventEmitter.emit('eth_execution', {
       method: constants.ETH_CALL,
@@ -1063,9 +1017,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   async maxPriorityFeePerGas(): Promise<string> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('maxPriorityFeePerGas()');
-    }
     return constants.ZERO_HEX;
   }
 
@@ -1104,9 +1055,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   getProof(): JsonRpcError {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('getProof()');
-    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
@@ -1122,9 +1070,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   createAccessList(): JsonRpcError {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('createAccessList()');
-    }
     return predefined.UNSUPPORTED_METHOD;
   }
 }

--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -204,7 +204,6 @@ export class EthImpl implements Eth {
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
   async blockNumber(requestDetails: RequestDetails): Promise<string> {
-    this.logger.trace(`blockNumber()`);
     return await this.common.getLatestBlockNumber(requestDetails);
   }
 
@@ -310,7 +309,6 @@ export class EthImpl implements Eth {
     0: { type: 'filter', required: true },
   })
   async newFilter(params: INewFilterParams, requestDetails: RequestDetails): Promise<string> {
-    this.logger.trace('newFilter(params=%o)', params);
     return this.filterService.newFilter(params, requestDetails);
   }
 

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -87,15 +87,11 @@ export class Precheck {
   async verifyAccount(tx: Transaction, requestDetails: RequestDetails): Promise<any> {
     const accountInfo = await this.mirrorNodeClient.getAccount(tx.from!, requestDetails);
     if (accountInfo == null) {
-      if (this.logger.isLevelEnabled('trace')) {
         this.logger.trace(
-          `Failed to retrieve address '${
-            tx.from
-          }' account details from mirror node on verify account precheck for sendRawTransaction(transaction=${JSON.stringify(
-            tx,
-          )})`,
+          'Failed to retrieve address \'%s\' account details from mirror node on verify account precheck for sendRawTransaction(transaction=%o)',
+          tx.from,
+          tx,
         );
-      }
       throw predefined.RESOURCE_NOT_FOUND(`address '${tx.from}'.`);
     }
 
@@ -108,11 +104,11 @@ export class Precheck {
    * @param accountInfoNonce - The nonce of the account.
    */
   nonce(tx: Transaction, accountInfoNonce: number): void {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(
-        `Nonce precheck for sendRawTransaction(tx.nonce=${tx.nonce}, accountInfoNonce=${accountInfoNonce})`,
-      );
-    }
+    this.logger.trace(
+      'Nonce precheck for sendRawTransaction(tx.nonce=%d, accountInfoNonce=%d)',
+      tx.nonce,
+      accountInfoNonce,
+    );
 
     if (accountInfoNonce > tx.nonce) {
       throw predefined.NONCE_TOO_LOW(tx.nonce, accountInfoNonce);
@@ -127,13 +123,11 @@ export class Precheck {
     const txChainId = prepend0x(Number(tx.chainId).toString(16));
     const passes = this.isLegacyUnprotectedEtx(tx) || txChainId === this.chain;
     if (!passes) {
-      if (this.logger.isLevelEnabled('trace')) {
         this.logger.trace(
-          `Failed chainId precheck for sendRawTransaction(transaction=%s, chainId=%s)`,
-          JSON.stringify(tx),
+          'Failed chainId precheck for sendRawTransaction(transaction=%o, chainId=%s)',
+          tx,
           txChainId,
         );
-      }
       throw predefined.UNSUPPORTED_CHAIN_ID(txChainId, this.chain);
     }
   }
@@ -180,15 +174,12 @@ export class Precheck {
           return;
         }
       }
-
-      if (this.logger.isLevelEnabled('trace')) {
-        this.logger.trace(
-          `Failed gas price precheck for sendRawTransaction(transaction=%s, gasPrice=%s, requiredGasPrice=%s)`,
-          JSON.stringify(tx),
-          txGasPrice,
-          networkGasPrice,
-        );
-      }
+      this.logger.trace(
+        'Failed gas price precheck for sendRawTransaction(transaction=%s, gasPrice=%s, requiredGasPrice=%s)',
+        JSON.stringify(tx),
+        txGasPrice,
+        networkGasPrice,
+      );
       throw predefined.GAS_PRICE_TOO_LOW(txGasPrice, networkGasPrice);
     }
   }
@@ -217,13 +208,11 @@ export class Precheck {
     const txTotalValue = tx.value + txGasPrice * tx.gasLimit;
 
     if (account == null) {
-      if (this.logger.isLevelEnabled('trace')) {
         this.logger.trace(
-          `Failed to retrieve account details from mirror node on balance precheck for sendRawTransaction(transaction=${JSON.stringify(
-            tx,
-          )}, totalValue=${txTotalValue})`,
+          'Failed to retrieve account details from mirror node on balance precheck for sendRawTransaction(transaction=%s, totalValue=%s)',
+          JSON.stringify(tx),
+          txTotalValue,
         );
-      }
       throw predefined.RESOURCE_NOT_FOUND(`tx.from '${tx.from}'.`);
     }
 
@@ -232,9 +221,8 @@ export class Precheck {
       tinybars = BigInt(account.balance.balance.toString()) * BigInt(constants.TINYBAR_TO_WEIBAR_COEF);
       result.passes = tinybars >= txTotalValue;
     } catch (error: any) {
-      if (this.logger.isLevelEnabled('trace')) {
-        this.logger.trace(
-          `Error on balance precheck for sendRawTransaction(transaction=%s, totalValue=%s, error=%s)`,
+      this.logger.trace(
+        'Error on balance precheck for sendRawTransaction(transaction=%s, totalValue=%s, error=%s)',
           JSON.stringify(tx),
           txTotalValue,
           error.message,
@@ -249,14 +237,12 @@ export class Precheck {
     }
 
     if (!result.passes) {
-      if (this.logger.isLevelEnabled('trace')) {
         this.logger.trace(
-          `Failed balance precheck for sendRawTransaction(transaction=%s, totalValue=%s, accountTinyBarBalance=%s)`,
+          'Failed balance precheck for sendRawTransaction(transaction=%s, totalValue=%s, accountTinyBarBalance=%s)',
           JSON.stringify(tx),
           txTotalValue,
           tinybars,
         );
-      }
       throw predefined.INSUFFICIENT_ACCOUNT_BALANCE;
     }
   }
@@ -272,24 +258,20 @@ export class Precheck {
     const intrinsicGasCost = Precheck.transactionIntrinsicGasCost(tx.data);
 
     if (gasLimit > constants.MAX_TRANSACTION_FEE_THRESHOLD) {
-      if (this.logger.isLevelEnabled('trace')) {
-        this.logger.trace(
-          `${failBaseLog} Gas Limit was too high: %s, block gas limit: %s`,
+      this.logger.trace(
+        `${failBaseLog} Gas Limit was too high: %s, block gas limit: %s`,
           JSON.stringify(tx),
           gasLimit,
           constants.MAX_TRANSACTION_FEE_THRESHOLD,
         );
-      }
       throw predefined.GAS_LIMIT_TOO_HIGH(gasLimit, constants.MAX_TRANSACTION_FEE_THRESHOLD);
     } else if (gasLimit < intrinsicGasCost) {
-      if (this.logger.isLevelEnabled('trace')) {
         this.logger.trace(
           `${failBaseLog} Gas Limit was too low: %s, intrinsic gas cost: %s`,
           JSON.stringify(tx),
           gasLimit,
           intrinsicGasCost,
         );
-      }
       throw predefined.GAS_LIMIT_TOO_LOW(gasLimit, intrinsicGasCost);
     }
   }
@@ -356,11 +338,9 @@ export class Precheck {
   transactionType(tx: Transaction) {
     // Blob transactions are not supported as per HIP 866
     if (tx.type === 3) {
-      if (this.logger.isLevelEnabled('trace')) {
         this.logger.trace(
           `Transaction with type=${tx.type} is unsupported for sendRawTransaction(transaction=${JSON.stringify(tx)})`,
         );
-      }
       throw predefined.UNSUPPORTED_TRANSACTION_TYPE;
     }
   }

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -87,11 +87,11 @@ export class Precheck {
   async verifyAccount(tx: Transaction, requestDetails: RequestDetails): Promise<any> {
     const accountInfo = await this.mirrorNodeClient.getAccount(tx.from!, requestDetails);
     if (accountInfo == null) {
-        this.logger.trace(
-          'Failed to retrieve address \'%s\' account details from mirror node on verify account precheck for sendRawTransaction(transaction=%o)',
-          tx.from,
-          tx,
-        );
+      this.logger.trace(
+        "Failed to retrieve address '%s' account details from mirror node on verify account precheck for sendRawTransaction(transaction=%o)",
+        tx.from,
+        tx,
+      );
       throw predefined.RESOURCE_NOT_FOUND(`address '${tx.from}'.`);
     }
 
@@ -123,11 +123,7 @@ export class Precheck {
     const txChainId = prepend0x(Number(tx.chainId).toString(16));
     const passes = this.isLegacyUnprotectedEtx(tx) || txChainId === this.chain;
     if (!passes) {
-        this.logger.trace(
-          'Failed chainId precheck for sendRawTransaction(transaction=%o, chainId=%s)',
-          tx,
-          txChainId,
-        );
+      this.logger.trace('Failed chainId precheck for sendRawTransaction(transaction=%o, chainId=%s)', tx, txChainId);
       throw predefined.UNSUPPORTED_CHAIN_ID(txChainId, this.chain);
     }
   }
@@ -208,11 +204,11 @@ export class Precheck {
     const txTotalValue = tx.value + txGasPrice * tx.gasLimit;
 
     if (account == null) {
-        this.logger.trace(
-          'Failed to retrieve account details from mirror node on balance precheck for sendRawTransaction(transaction=%s, totalValue=%s)',
-          JSON.stringify(tx),
-          txTotalValue,
-        );
+      this.logger.trace(
+        'Failed to retrieve account details from mirror node on balance precheck for sendRawTransaction(transaction=%s, totalValue=%s)',
+        JSON.stringify(tx),
+        txTotalValue,
+      );
       throw predefined.RESOURCE_NOT_FOUND(`tx.from '${tx.from}'.`);
     }
 
@@ -223,11 +219,10 @@ export class Precheck {
     } catch (error: any) {
       this.logger.trace(
         'Error on balance precheck for sendRawTransaction(transaction=%s, totalValue=%s, error=%s)',
-          JSON.stringify(tx),
-          txTotalValue,
-          error.message,
-        );
-      }
+        JSON.stringify(tx),
+        txTotalValue,
+        error.message,
+      );
       if (error instanceof JsonRpcError) {
         // preserve original error
         throw error;
@@ -237,12 +232,12 @@ export class Precheck {
     }
 
     if (!result.passes) {
-        this.logger.trace(
-          'Failed balance precheck for sendRawTransaction(transaction=%s, totalValue=%s, accountTinyBarBalance=%s)',
-          JSON.stringify(tx),
-          txTotalValue,
-          tinybars,
-        );
+      this.logger.trace(
+        'Failed balance precheck for sendRawTransaction(transaction=%s, totalValue=%s, accountTinyBarBalance=%s)',
+        JSON.stringify(tx),
+        txTotalValue,
+        tinybars,
+      );
       throw predefined.INSUFFICIENT_ACCOUNT_BALANCE;
     }
   }
@@ -259,19 +254,19 @@ export class Precheck {
 
     if (gasLimit > constants.MAX_TRANSACTION_FEE_THRESHOLD) {
       this.logger.trace(
-        `${failBaseLog} Gas Limit was too high: %s, block gas limit: %s`,
-          JSON.stringify(tx),
-          gasLimit,
-          constants.MAX_TRANSACTION_FEE_THRESHOLD,
-        );
+        failBaseLog + ' Gas Limit was too high: %s, block gas limit: %s',
+        JSON.stringify(tx),
+        gasLimit,
+        constants.MAX_TRANSACTION_FEE_THRESHOLD,
+      );
       throw predefined.GAS_LIMIT_TOO_HIGH(gasLimit, constants.MAX_TRANSACTION_FEE_THRESHOLD);
     } else if (gasLimit < intrinsicGasCost) {
-        this.logger.trace(
-          `${failBaseLog} Gas Limit was too low: %s, intrinsic gas cost: %s`,
-          JSON.stringify(tx),
-          gasLimit,
-          intrinsicGasCost,
-        );
+      this.logger.trace(
+        failBaseLog + ' Gas Limit was too low: %s, intrinsic gas cost: %s',
+        JSON.stringify(tx),
+        gasLimit,
+        intrinsicGasCost,
+      );
       throw predefined.GAS_LIMIT_TOO_LOW(gasLimit, intrinsicGasCost);
     }
   }
@@ -338,9 +333,11 @@ export class Precheck {
   transactionType(tx: Transaction) {
     // Blob transactions are not supported as per HIP 866
     if (tx.type === 3) {
-        this.logger.trace(
-          `Transaction with type=${tx.type} is unsupported for sendRawTransaction(transaction=${JSON.stringify(tx)})`,
-        );
+      this.logger.trace(
+        'Transaction with type=%s is unsupported for sendRawTransaction(transaction=%s)',
+        tx.type,
+        JSON.stringify(tx),
+      );
       throw predefined.UNSUPPORTED_TRANSACTION_TYPE;
     }
   }

--- a/packages/relay/src/lib/relay.ts
+++ b/packages/relay/src/lib/relay.ts
@@ -260,7 +260,7 @@ export class Relay {
           this.logger.info('Pre-configured spending plans populated successfully');
         }
       })
-      .catch((e) => this.logger.warn(`Failed to load pre-configured spending plans: ${e.message}`));
+      .catch((e) => this.logger.warn('Failed to load pre-configured spending plans: %s', e.message));
   }
 
   /**
@@ -343,7 +343,7 @@ export class Relay {
     if (balance === BigInt(0)) {
       throw new Error(`Operator account '${operator}' has no balance`);
     } else {
-      this.logger.info(`Operator account '${operator}' has balance: ${balance}`);
+      this.logger.info("Operator account '%s' has balance: %s", operator, balance);
     }
   }
 }

--- a/packages/relay/src/lib/services/cacheService/cacheService.ts
+++ b/packages/relay/src/lib/services/cacheService/cacheService.ts
@@ -133,7 +133,7 @@ export class CacheService {
         await this.sharedCache.connect();
       } catch (e) {
         const redisError = new RedisCacheError(e);
-        this.logger.error(`Error occurred when connecting to Redis. ${redisError}`);
+        this.logger.error('Error occurred when connecting to Redis. %s', redisError);
       }
     }
   }
@@ -152,7 +152,7 @@ export class CacheService {
         await this.sharedCache.disconnect();
       } catch (e) {
         const redisError = new RedisCacheError(e);
-        this.logger.error(`Error occurred when disconnecting from Redis. ${redisError}`);
+        this.logger.error('Error occurred when disconnecting from Redis. %s', redisError);
       }
     }
   }
@@ -168,7 +168,7 @@ export class CacheService {
         return await this.sharedCache.getNumberOfConnections();
       } catch (e) {
         const redisError = new RedisCacheError(e);
-        this.logger.error(`Error occurred when getting the number of Redis connections. ${redisError}`);
+        this.logger.error('Error occurred when getting the number of Redis connections. %s', redisError);
       }
     }
     return 0;
@@ -199,7 +199,7 @@ export class CacheService {
       return await this.sharedCache.get(key, callingMethod);
     } catch (error) {
       const redisError = new RedisCacheError(error);
-      this.logger.error(redisError, 'Error occurred while getting the cache from Redis. Fallback to internal cache.');
+      this.logger.error('Error occurred while getting the cache from Redis. Fallback to internal cache. %s', redisError);
 
       // fallback to internal cache in case of Redis error
       return await this.getFromInternalCache(key, callingMethod);
@@ -252,7 +252,7 @@ export class CacheService {
         return;
       } catch (error) {
         const redisError = new RedisCacheError(error);
-        this.logger.error(redisError, 'Error occurred while setting the cache to Redis. Fallback to internal cache.');
+        this.logger.error('Error occurred while setting the cache to Redis. Fallback to internal cache. %s', redisError);
       }
     }
 
@@ -284,7 +284,7 @@ export class CacheService {
         return;
       } catch (error) {
         const redisError = new RedisCacheError(error);
-        this.logger.error(redisError, 'Error occurred while setting the cache to Redis. Fallback to internal cache.');
+        this.logger.error('Error occurred while setting the cache to Redis. Fallback to internal cache. %s', redisError);
       }
     }
 
@@ -311,7 +311,7 @@ export class CacheService {
         return;
       } catch (error) {
         const redisError = new RedisCacheError(error);
-        this.logger.error(redisError, `Error occurred while deleting cache from Redis.`);
+        this.logger.error('Error occurred while deleting cache from Redis. %s', redisError);
       }
     }
 
@@ -332,7 +332,7 @@ export class CacheService {
         return;
       } catch (error) {
         const redisError = new RedisCacheError(error);
-        this.logger.error(redisError, `Error occurred while clearing Redis cache.`);
+        this.logger.error('Error occurred while clearing Redis cache. %s', redisError);
       }
     }
 
@@ -357,7 +357,7 @@ export class CacheService {
         return await this.sharedCache.incrBy(key, amount, callingMethod);
       } catch (error) {
         const redisError = new RedisCacheError(error);
-        this.logger.error(redisError, `Error occurred while incrementing cache in Redis.`);
+        this.logger.error('Error occurred while incrementing cache in Redis. %s', redisError);
       }
     }
 
@@ -392,7 +392,7 @@ export class CacheService {
         return await this.sharedCache.rPush(key, value, callingMethod);
       } catch (error) {
         const redisError = new RedisCacheError(error);
-        this.logger.error(redisError, `Error occurred while pushing cache in Redis.`);
+        this.logger.error('Error occurred while pushing cache in Redis. %s', redisError);
       }
     }
 
@@ -432,7 +432,7 @@ export class CacheService {
         return await this.sharedCache.lRange(key, start, end, callingMethod);
       } catch (error) {
         const redisError = new RedisCacheError(error);
-        this.logger.error(redisError, `Error occurred while getting cache in Redis.`);
+        this.logger.error('Error occurred while getting cache in Redis. %s', redisError);
       }
     }
 
@@ -459,7 +459,7 @@ export class CacheService {
         return await this.sharedCache.keys(pattern, callingMethod);
       } catch (error) {
         const redisError = new RedisCacheError(error);
-        this.logger.error(redisError, `Error occurred while getting keys from Redis.`);
+        this.logger.error('Error occurred while getting keys from Redis. %s', redisError);
       }
     }
 

--- a/packages/relay/src/lib/services/ethService/accountService/AccountService.ts
+++ b/packages/relay/src/lib/services/ethService/accountService/AccountService.ts
@@ -99,9 +99,7 @@ export class AccountService implements IAccountService {
     blockNumberOrTagOrHash: string,
     requestDetails: RequestDetails,
   ): Promise<string> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`getBalance(account=${account}, blockNumberOrTag=${blockNumberOrTagOrHash})`);
-    }
+    this.logger.trace('getBalance(account=%s, blockNumberOrTag=%s)', account, blockNumberOrTagOrHash);
 
     let latestBlock: LatestBlockNumberTimestamp | null | undefined;
     // this check is required, because some tools like Metamask pass for parameter latest block, with a number (ex 0x30ea)
@@ -147,13 +145,12 @@ export class AccountService implements IAccountService {
       }
 
       if (!balanceFound) {
-        if (this.logger.isLevelEnabled('debug')) {
-          this.logger.debug(
-            `Unable to find account ${account} in block ${JSON.stringify(
-              blockNumber,
-            )}(${blockNumberOrTagOrHash}), returning 0x0 balance`,
-          );
-        }
+        this.logger.debug(
+          'Unable to find account %s in block %o(%s), returning 0x0 balance',
+          account,
+          blockNumber,
+          blockNumberOrTagOrHash,
+        );
         return constants.ZERO_HEX;
       }
 
@@ -176,9 +173,7 @@ export class AccountService implements IAccountService {
     const blockNumberCached = await this.cacheService.getAsync(cacheKey, constants.ETH_GET_BALANCE);
 
     if (blockNumberCached) {
-      if (this.logger.isLevelEnabled('trace')) {
-        this.logger.trace(`returning cached value ${cacheKey}:${JSON.stringify(blockNumberCached)}`);
-      }
+      this.logger.trace('returning cached value %s:%o', cacheKey, blockNumberCached);
       latestBlock = { blockNumber: blockNumberCached, timeStampTo: '0' };
     } else {
       latestBlock = await this.blockNumberTimestamp(constants.ETH_GET_BALANCE, requestDetails);
@@ -296,17 +291,13 @@ export class AccountService implements IAccountService {
     blockNumOrTag: string,
     requestDetails: RequestDetails,
   ): Promise<string | JsonRpcError> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`getTransactionCount(address=${address}, blockNumOrTag=${blockNumOrTag})`);
-    }
+    this.logger.trace('getTransactionCount(address=%s, blockNumOrTag=%s)', address, blockNumOrTag);
 
     // cache considerations for high load
     const cacheKey = `eth_getTransactionCount_${address}_${blockNumOrTag}`;
     let nonceCount = await this.cacheService.getAsync(cacheKey, constants.ETH_GET_TRANSACTION_COUNT);
     if (nonceCount) {
-      if (this.logger.isLevelEnabled('trace')) {
-        this.logger.trace(`returning cached value ${cacheKey}:${JSON.stringify(nonceCount)}`);
-      }
+      this.logger.trace('returning cached value %s:%o', cacheKey, nonceCount);
       return nonceCount;
     }
 
@@ -344,9 +335,7 @@ export class AccountService implements IAccountService {
     caller: string,
     requestDetails: RequestDetails,
   ): Promise<LatestBlockNumberTimestamp> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`blockNumber()`);
-    }
+    this.logger.trace('blockNumber()');
 
     const cacheKey = `${constants.CACHE_KEY.ETH_BLOCK_NUMBER}`;
 

--- a/packages/relay/src/lib/services/ethService/blockService/BlockService.ts
+++ b/packages/relay/src/lib/services/ethService/blockService/BlockService.ts
@@ -84,7 +84,7 @@ export class BlockService implements IBlockService {
     showDetails: boolean,
     requestDetails: RequestDetails,
   ): Promise<Block | null> {
-    this.logger.trace(`getBlockByHash(hash=${hash}, showDetails=${showDetails})`);
+    this.logger.trace('getBlockByHash(hash=%s, showDetails=%s)', hash, showDetails);
 
     return this.getBlock(hash, showDetails, requestDetails).catch((e: any) => {
       throw this.common.genericErrorHandler(e, `Failed to retrieve block for hash ${hash}`);
@@ -104,7 +104,7 @@ export class BlockService implements IBlockService {
     showDetails: boolean,
     requestDetails: RequestDetails,
   ): Promise<Block | null> {
-    this.logger.trace(`getBlockByNumber(blockNumber=${blockNumber}, showDetails=${showDetails})`);
+    this.logger.trace('getBlockByNumber(blockNumber=%s, showDetails=%s)', blockNumber, showDetails);
 
     return this.getBlock(blockNumber, showDetails, requestDetails).catch((e: any) => {
       throw this.common.genericErrorHandler(e, `Failed to retrieve block for blockNumber ${blockNumber}`);
@@ -122,9 +122,7 @@ export class BlockService implements IBlockService {
     blockHashOrBlockNumber: string,
     requestDetails: RequestDetails,
   ): Promise<ITransactionReceipt[] | null> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`getBlockReceipt(${JSON.stringify(blockHashOrBlockNumber)})`);
-    }
+    this.logger.trace('getBlockReceipt(%o)', blockHashOrBlockNumber);
 
     const block = await this.common.getHistoricalBlockResponse(requestDetails, blockHashOrBlockNumber);
 
@@ -155,11 +153,9 @@ export class BlockService implements IBlockService {
 
     const receiptPromises = contractResults.map(async (contractResult) => {
       if (Utils.isRevertedDueToHederaSpecificValidation(contractResult)) {
-        if (this.logger.isLevelEnabled('debug')) {
-          this.logger.debug(
-            `Transaction with hash ${contractResult.hash} is skipped due to hedera-specific validation failure (${contractResult.result})`,
-          );
-        }
+        this.logger.debug(
+          `Transaction with hash ${contractResult.hash} is skipped due to hedera-specific validation failure (${contractResult.result})`,
+        );
         return null;
       }
 
@@ -206,7 +202,7 @@ export class BlockService implements IBlockService {
    * @returns {Promise<string | null>} The transaction count
    */
   async getBlockTransactionCountByHash(hash: string, requestDetails: RequestDetails): Promise<string | null> {
-    this.logger.trace(`getBlockTransactionCountByHash(hash=${hash}, showDetails=%o)`);
+    this.logger.trace('getBlockTransactionCountByHash(hash=%s, showDetails=%o)', hash);
 
     try {
       const block = await this.mirrorNodeClient.getBlock(hash, requestDetails);
@@ -226,9 +222,7 @@ export class BlockService implements IBlockService {
     blockNumOrTag: string,
     requestDetails: RequestDetails,
   ): Promise<string | null> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`getBlockTransactionCountByNumber(blockNum=${blockNumOrTag}, showDetails=%o)`);
-    }
+    this.logger.trace('getBlockTransactionCountByNumber(blockNum=%s, showDetails=%o)', blockNumOrTag);
 
     const blockNum = await this.common.translateBlockTag(blockNumOrTag, requestDetails);
     try {
@@ -244,9 +238,6 @@ export class BlockService implements IBlockService {
    * @returns null
    */
   async getUncleByBlockHashAndIndex(): Promise<null> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('getUncleByBlockHashAndIndex()');
-    }
     return null;
   }
 
@@ -255,9 +246,6 @@ export class BlockService implements IBlockService {
    * @returns null
    */
   async getUncleByBlockNumberAndIndex(): Promise<null> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('getUncleByBlockNumberAndIndex()');
-    }
     return null;
   }
 
@@ -266,9 +254,6 @@ export class BlockService implements IBlockService {
    * @returns '0x0'
    */
   async getUncleCountByBlockHash(): Promise<string> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('getUncleCountByBlockHash()');
-    }
     return constants.ZERO_HEX;
   }
 
@@ -277,9 +262,6 @@ export class BlockService implements IBlockService {
    * @returns '0x0'
    */
   async getUncleCountByBlockNumber(): Promise<string> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('getUncleCountByBlockNumber()');
-    }
     return constants.ZERO_HEX;
   }
 
@@ -416,10 +398,7 @@ export class BlockService implements IBlockService {
         (transactionsArray as string[]).push(log.transactionHash);
       });
     }
-
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`Synthetic transaction hashes will be populated in the block response`);
-    }
+    this.logger.trace('Synthetic transaction hashes will be populated in the block response');
 
     transactionsArray = _.uniqWith(transactionsArray as string[], _.isEqual);
     return transactionsArray;
@@ -442,11 +421,11 @@ export class BlockService implements IBlockService {
       // there are several hedera-specific validations that occur right before entering the evm
       // if a transaction has reverted there, we should not include that tx in the block response
       if (Utils.isRevertedDueToHederaSpecificValidation(contractResult)) {
-        if (this.logger.isLevelEnabled('debug')) {
           this.logger.debug(
-            `Transaction with hash ${contractResult.hash} is skipped due to hedera-specific validation failure (${contractResult.result})`,
+            'Transaction with hash %s is skipped due to hedera-specific validation failure (%s)',
+            contractResult.hash,
+            contractResult.result,
           );
-        }
         continue;
       }
 

--- a/packages/relay/src/lib/services/ethService/contractService/ContractService.ts
+++ b/packages/relay/src/lib/services/ethService/contractService/ContractService.ts
@@ -161,14 +161,14 @@ export class ContractService implements IContractService {
       const response = await this.estimateGasFromMirrorNode(transaction, requestDetails);
 
       if (response?.result) {
-        this.logger.info(`Returning gas: ${response.result}`);
+        this.logger.info('Returning gas: %s', response.result);
         return prepend0x(trimPrecedingZeros(response.result));
       } else {
-        this.logger.error(`No gas estimate returned from mirror-node: ${JSON.stringify(response)}`);
+        this.logger.error('No gas estimate returned from mirror-node: %o', response);
         return this.predefinedGasForTransaction(transaction, requestDetails);
       }
     } catch (e: any) {
-      this.logger.error(`Error raised while fetching estimateGas from mirror-node: ${JSON.stringify(e)}`);
+      this.logger.error('Error raised while fetching estimateGas from mirror-node: %o', e);
       // in case of contract revert, we don't want to return a predefined gas but the actual error with the reason
       if (
         ConfigService.get('ESTIMATE_GAS_THROWS') &&
@@ -271,12 +271,12 @@ export class ContractService implements IContractService {
     blockNumberOrTagOrHash: string,
     requestDetails: RequestDetails,
   ): Promise<string> {
-      this.logger.trace(
-        'getStorageAt(address=%s, slot=%s, blockNumberOrOrHashTag=%s)',
-        address,
-        slot,
-        blockNumberOrTagOrHash,
-      );
+    this.logger.trace(
+      'getStorageAt(address=%s, slot=%s, blockNumberOrOrHashTag=%s)',
+      address,
+      slot,
+      blockNumberOrTagOrHash,
+    );
 
     let result = constants.ZERO_HEX_32_BYTE; // if contract or slot not found then return 32 byte 0
 
@@ -324,14 +324,14 @@ export class ContractService implements IContractService {
     requestDetails: RequestDetails,
   ): Promise<string | JsonRpcError> {
     try {
-        this.logger.debug(
-          'Making eth_call on contract %s with gas %d and call data "%s" from "%s" at blockBlockNumberOrTag: "%s" using mirror-node.',
-          call.to,
-          gas,
-          call.data,
-          call.from,
-          block,
-        );
+      this.logger.debug(
+        'Making eth_call on contract %s with gas %d and call data "%s" from "%s" at blockBlockNumberOrTag: "%s" using mirror-node.',
+        call.to,
+        gas,
+        call.data,
+        call.from,
+        block,
+      );
       const callData = this.prepareMirrorNodeCallData(call, gas, value, block);
       return await this.executeMirrorNodeCall(callData, requestDetails);
     } catch (e: any) {
@@ -511,12 +511,12 @@ export class ContractService implements IContractService {
     }
 
     if (e.isContractReverted()) {
-        this.logger.trace(
-          'mirror node eth_call request encountered contract revert. message: %s, details: %s, data: %s',
-          e.message,
-          e.detail,
-          e.data,
-        );
+      this.logger.trace(
+        'mirror node eth_call request encountered contract revert. message: %s, details: %s, data: %s',
+        e.message,
+        e.detail,
+        e.data,
+      );
       return predefined.CONTRACT_REVERT(e.detail || e.message, e.data);
     }
     // for any other Mirror Node upstream server errors (429, 500, 502, 503, 504, etc.), preserve the original error and re-throw to the upper layer

--- a/packages/relay/src/lib/services/ethService/ethCommonService/CommonService.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/CommonService.ts
@@ -237,20 +237,19 @@ export class CommonService implements ICommonService {
     returnLatest: boolean = true,
   ): Promise<any> {
     if (!returnLatest && this.blockTagIsLatestOrPending(blockNumberOrTagOrHash)) {
-      if (this.logger.isLevelEnabled('debug')) {
-        this.logger.debug(
-          `Detected a contradiction between blockNumberOrTagOrHash and returnLatest. The request does not target the latest block, yet blockNumberOrTagOrHash representing latest or pending: returnLatest=${returnLatest}, blockNumberOrTagOrHash=${blockNumberOrTagOrHash}`,
-        );
-      }
+      this.logger.debug(
+        'Detected a contradiction between blockNumberOrTagOrHash and returnLatest. The request does not target the latest block, yet blockNumberOrTagOrHash representing latest or pending: returnLatest=%s, blockNumberOrTagOrHash=%s',
+        returnLatest,
+        blockNumberOrTagOrHash,
+      );
       return null;
     }
 
     if (blockNumberOrTagOrHash === constants.EMPTY_HEX) {
-      if (this.logger.isLevelEnabled('debug')) {
-        this.logger.debug(
-          `Invalid input detected in getHistoricalBlockResponse(): blockNumberOrTagOrHash=${blockNumberOrTagOrHash}.`,
-        );
-      }
+      this.logger.debug(
+        'Invalid input detected in getHistoricalBlockResponse(): blockNumberOrTagOrHash=%s.',
+        blockNumberOrTagOrHash,
+      );
       return null;
     }
 
@@ -480,10 +479,6 @@ export class CommonService implements ICommonService {
    * @param requestDetails
    */
   public async gasPrice(requestDetails: RequestDetails): Promise<string> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`eth_gasPrice`);
-    }
-
     try {
       const gasPrice = Utils.addPercentageBufferToGasPrice(await this.getGasPriceInWeibars(requestDetails));
 

--- a/packages/relay/src/lib/services/ethService/ethFilterService/FilterService.ts
+++ b/packages/relay/src/lib/services/ethService/ethFilterService/FilterService.ts
@@ -109,9 +109,8 @@ export class FilterService implements IFilterService {
     const filterId = generateRandomHex();
     await this.updateFilterCache(filterId, type, params, null, this.ethNewFilter);
 
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`created filter with TYPE=${type}, params: ${JSON.stringify(params)}`);
-    }
+    this.logger.trace('created filter with TYPE=%s, params: %o', type, params);
+
     return filterId;
   }
 

--- a/packages/relay/src/lib/services/ethService/feeService/FeeService.ts
+++ b/packages/relay/src/lib/services/ethService/feeService/FeeService.ts
@@ -67,11 +67,12 @@ export class FeeService implements IFeeService {
       : Number(ConfigService.get('FEE_HISTORY_MAX_RESULTS'));
     const maxRewardPercentilesSize = constants.FEE_HISTORY_REWARD_PERCENTILES_MAX_SIZE;
 
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(
-        `feeHistory(blockCount=${blockCount}, newestBlock=${newestBlock}, rewardPercentiles=${rewardPercentiles})`,
-      );
-    }
+    this.logger.trace(
+      'feeHistory(blockCount=%d, newestBlock=%s, rewardPercentiles=%o)',
+      blockCount,
+      newestBlock,
+      rewardPercentiles,
+    );
 
     if (rewardPercentiles && rewardPercentiles.length > maxRewardPercentilesSize) {
       throw predefined.INVALID_PARAMETER(
@@ -139,10 +140,6 @@ export class FeeService implements IFeeService {
    * @param requestDetails
    */
   public async maxPriorityFeePerGas(): Promise<string> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('maxPriorityFeePerGas()');
-    }
-
     return constants.ZERO_HEX;
   }
 

--- a/packages/relay/src/lib/services/ethService/transactionService/TransactionService.ts
+++ b/packages/relay/src/lib/services/ethService/transactionService/TransactionService.ts
@@ -108,9 +108,7 @@ export class TransactionService implements ITransactionService {
     transactionIndex: string,
     requestDetails: RequestDetails,
   ): Promise<Transaction | null> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`getTransactionByBlockHashAndIndex(hash=${blockHash}, index=${transactionIndex})`);
-    }
+    this.logger.trace('getTransactionByBlockHashAndIndex(hash=%s, index=%s)', blockHash, transactionIndex);
 
     try {
       return await this.getTransactionByBlockHashOrBlockNumAndIndex(
@@ -138,9 +136,7 @@ export class TransactionService implements ITransactionService {
     transactionIndex: string,
     requestDetails: RequestDetails,
   ): Promise<Transaction | null> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`getTransactionByBlockNumberAndIndex(blockNum=${blockNumOrTag}, index=${transactionIndex})`);
-    }
+    this.logger.trace('getTransactionByBlockNumberAndIndex(blockNum=%s, index=%s)', blockNumOrTag, transactionIndex);
     const blockNum = await this.common.translateBlockTag(blockNumOrTag, requestDetails);
 
     try {
@@ -164,9 +160,7 @@ export class TransactionService implements ITransactionService {
    * @returns {Promise<Transaction | null>} A promise that resolves to a Transaction object or null if not found
    */
   async getTransactionByHash(hash: string, requestDetails: RequestDetails): Promise<Transaction | null> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`getTransactionByHash(hash=${hash})`, hash);
-    }
+    this.logger.trace('getTransactionByHash(hash=%s)', hash);
 
     const contractResult = await this.mirrorNodeClient.getContractResultWithRetry(
       this.mirrorNodeClient.getContractResult.name,
@@ -185,9 +179,7 @@ export class TransactionService implements ITransactionService {
 
       // no tx found
       if (!syntheticLogs.length) {
-        if (this.logger.isLevelEnabled('trace')) {
-          this.logger.trace(`no tx for ${hash}`);
-        }
+        this.logger.trace('no tx for %s', hash);
         return null;
       }
 
@@ -214,9 +206,7 @@ export class TransactionService implements ITransactionService {
    * @returns {Promise<ITransactionReceipt | null>} A promise that resolves to a transaction receipt or null if not found
    */
   async getTransactionReceipt(hash: string, requestDetails: RequestDetails): Promise<ITransactionReceipt | null> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`getTransactionReceipt(${hash})`);
-    }
+    this.logger.trace('getTransactionReceipt(%s)', hash);
 
     const receiptResponse = await this.mirrorNodeClient.getContractResultWithRetry(
       this.mirrorNodeClient.getContractResult.name,
@@ -228,9 +218,7 @@ export class TransactionService implements ITransactionService {
       return await this.handleSyntheticTransactionReceipt(hash, requestDetails);
     } else {
       const receipt = await this.handleRegularTransactionReceipt(receiptResponse, requestDetails);
-      if (this.logger.isLevelEnabled('trace')) {
-        this.logger.trace(`receipt for ${hash} found in block ${receipt.blockNumber}`);
-      }
+      this.logger.trace('receipt for %s found in block %s', hash, receipt.blockNumber);
 
       return receipt;
     }
@@ -283,9 +271,6 @@ export class TransactionService implements ITransactionService {
    * @returns A JsonRpcError indicating that the method is not supported
    */
   public sendTransaction(): JsonRpcError {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('sendTransaction()');
-    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
@@ -294,9 +279,6 @@ export class TransactionService implements ITransactionService {
    * @returns A JsonRpcError indicating that the method is not supported
    */
   public signTransaction(): JsonRpcError {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('signTransaction()');
-    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
@@ -305,9 +287,6 @@ export class TransactionService implements ITransactionService {
    * @returns A JsonRpcError indicating that the method is not supported
    */
   public sign(): JsonRpcError {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('sign()');
-    }
     return predefined.UNSUPPORTED_METHOD;
   }
 
@@ -435,9 +414,7 @@ export class TransactionService implements ITransactionService {
 
     // no tx found
     if (!syntheticLogs.length) {
-      if (this.logger.isLevelEnabled('trace')) {
-        this.logger.trace(`no receipt for ${hash}`);
-      }
+      this.logger.trace('no receipt for %s', hash);
       return null;
     }
 
@@ -452,9 +429,7 @@ export class TransactionService implements ITransactionService {
     };
     const receipt: ITransactionReceipt = TransactionReceiptFactory.createSyntheticReceipt(params);
 
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`receipt for ${hash} found in block ${receipt.blockNumber}`);
-    }
+    this.logger.trace('receipt for %s found in block %s', hash, receipt.blockNumber);
 
     return receipt;
   }
@@ -472,13 +447,11 @@ export class TransactionService implements ITransactionService {
     requestDetails: RequestDetails,
   ): Promise<void> {
     try {
-      if (this.logger.isLevelEnabled('debug')) {
-        this.logger.debug(`Transaction undergoing prechecks: transaction=${JSON.stringify(parsedTx)}`);
-      }
+      this.logger.debug('Transaction undergoing prechecks: transaction=%o', parsedTx);
 
       await this.precheck.sendRawTransactionCheck(parsedTx, networkGasPriceInWeiBars, requestDetails);
     } catch (e: any) {
-      this.logger.error(`Precheck failed: transaction=${JSON.stringify(parsedTx)}`);
+      this.logger.error(e, 'Precheck failed: transaction=%o', parsedTx);
       throw this.common.genericErrorHandler(e);
     }
   }
@@ -553,7 +526,7 @@ export class TransactionService implements ITransactionService {
             throw sendRawTransactionError;
           }
 
-          this.logger.warn(`No matching transaction record retrieved: transactionId=${submittedTransactionId}`);
+          this.logger.warn('No matching transaction record retrieved: transactionId=%s', submittedTransactionId);
 
           throw predefined.INTERNAL_ERROR(
             `No matching transaction record retrieved: transactionId=${submittedTransactionId}`,
@@ -561,7 +534,7 @@ export class TransactionService implements ITransactionService {
         }
 
         if (contractResult.hash == null) {
-          this.logger.error(`Transaction returned a null transaction hash: transactionId=${submittedTransactionId}`);
+          this.logger.error('Transaction returned a null transaction hash: transactionId=%s', submittedTransactionId);
           throw predefined.INTERNAL_ERROR(
             `Transaction returned a null transaction hash: transactionId=${submittedTransactionId}`,
           );
@@ -599,7 +572,7 @@ export class TransactionService implements ITransactionService {
     parsedTx: EthersTransaction,
     requestDetails: RequestDetails,
   ): Promise<string | JsonRpcError> {
-    this.logger.error(e, `Failed to successfully submit sendRawTransaction: transaction=${JSON.stringify(parsedTx)}`);
+    this.logger.error(e, 'Failed to successfully submit sendRawTransaction: transaction=%o', parsedTx);
     if (e instanceof JsonRpcError) {
       return e;
     }
@@ -607,7 +580,7 @@ export class TransactionService implements ITransactionService {
     if (e instanceof SDKClientError) {
       if (e.nodeAccountId) {
         // Log the target node account ID, right now, it's populated only for MaxAttemptsOrTimeout error
-        this.logger.info(`Transaction failed to execute against node with id: ${e.nodeAccountId}`);
+        this.logger.info('Transaction failed to execute against node with id: %s', e.nodeAccountId);
       }
 
       this.hapiService.decrementErrorCounter(e.statusCode);
@@ -624,16 +597,17 @@ export class TransactionService implements ITransactionService {
             break;
           }
 
-          if (this.logger.isLevelEnabled('trace')) {
-            this.logger.trace(
-              `Repeating retry to poll for updated account nonce. Count ${i} of ${mirrorNodeGetContractResultRetries}. Waiting ${this.mirrorNodeClient.getMirrorNodeRetryDelay()} ms before initiating a new request`,
-            );
-          }
+          this.logger.trace(
+            'Repeating retry to poll for updated account nonce. Count %d of %d. Waiting %d ms before initiating a new request',
+            i,
+            mirrorNodeGetContractResultRetries,
+            this.mirrorNodeClient.getMirrorNodeRetryDelay(),
+          );
           await new Promise((r) => setTimeout(r, this.mirrorNodeClient.getMirrorNodeRetryDelay()));
         }
 
         if (!accountNonce) {
-          this.logger.warn(`Cannot find updated account nonce.`);
+          this.logger.warn('Cannot find updated account nonce.');
           throw predefined.INTERNAL_ERROR(`Cannot find updated account nonce for WRONG_NONCE error.`);
         }
 
@@ -653,9 +627,8 @@ export class TransactionService implements ITransactionService {
 
     this.logger.error(
       e,
-      `Failed sendRawTransaction during record retrieval for transaction, returning computed hash: transaction=${JSON.stringify(
-        parsedTx,
-      )}`,
+      'Failed sendRawTransaction during record retrieval for transaction, returning computed hash: transaction=%o',
+      parsedTx,
     );
     //Return computed hash if unable to retrieve EthereumHash from record due to error
     return Utils.computeTransactionHash(transactionBuffer);

--- a/packages/relay/src/lib/services/hapiService/hapiService.ts
+++ b/packages/relay/src/lib/services/hapiService/hapiService.ts
@@ -286,9 +286,10 @@ export default class HAPIService {
     client.setRequestTimeout(SDK_REQUEST_TIMEOUT);
 
     logger.info(
-      `SDK client successfully configured to ${JSON.stringify(hederaNetwork)} for account ${
-        client.operatorAccountId
-      } with request timeout value: ${SDK_REQUEST_TIMEOUT}`,
+      'SDK client successfully configured to %o for account %s with request timeout value: %d',
+      hederaNetwork,
+      client.operatorAccountId,
+      SDK_REQUEST_TIMEOUT,
     );
 
     return client;
@@ -312,7 +313,7 @@ export default class HAPIService {
     }
 
     if (this.shouldReset) {
-      this.logger.warn(`SDK Client reinitialization.`);
+      this.logger.warn('SDK Client reinitialization.');
       this.resetClient();
     }
     this.decrementTransactionCounter();

--- a/packages/relay/src/lib/services/metricService/metricService.ts
+++ b/packages/relay/src/lib/services/metricService/metricService.ts
@@ -178,11 +178,13 @@ export default class MetricService {
     requestDetails,
     originalCallerAddress,
   }: IExecuteQueryEventPayload): Promise<void> => {
-    if (this.logger.isLevelEnabled('debug')) {
-      this.logger.debug(
-        `Capturing transaction fee charged to operator: executionMode=${executionMode} transactionId=${transactionId}, txConstructorName=${txConstructorName}, cost=${cost} tinybars`,
-      );
-    }
+    this.logger.debug(
+      'Capturing transaction fee charged to operator: executionMode=%s transactionId=%s, txConstructorName=%s, cost=%d tinybars',
+      executionMode,
+      transactionId,
+      txConstructorName,
+      cost,
+    );
 
     await this.hbarLimitService.addExpense(cost, originalCallerAddress ?? '', requestDetails);
     this.captureMetrics(executionMode, txConstructorName, status, cost, gasUsed);

--- a/packages/relay/src/lib/services/rateLimiterService/RedisRateLimitStore.ts
+++ b/packages/relay/src/lib/services/rateLimiterService/RedisRateLimitStore.ts
@@ -59,7 +59,7 @@ export class RedisRateLimitStore implements RateLimitStore {
       socket: {
         reconnectStrategy: (retries: number) => {
           const delay = retries * reconnectDelay;
-          this.logger.warn(`Rate limiter Redis reconnection attempt #${retries}. Delay: ${delay}ms`);
+          this.logger.warn('Rate limiter Redis reconnection attempt #%d. Delay: %dms', retries, delay);
           return delay;
         },
       },
@@ -75,7 +75,7 @@ export class RedisRateLimitStore implements RateLimitStore {
 
     this.redisClient.on('ready', () => {
       this.connected = Promise.resolve(true);
-      this.logger.info(`Rate limiter connected to Redis server successfully!`);
+      this.logger.info('Rate limiter connected to Redis server successfully!');
     });
 
     this.redisClient.on('end', () => {
@@ -87,9 +87,9 @@ export class RedisRateLimitStore implements RateLimitStore {
       this.connected = Promise.resolve(false);
       const redisError = new RedisCacheError(error);
       if (redisError.isSocketClosed()) {
-        this.logger.error(`Rate limiter Redis error when closing socket: ${redisError.message}`);
+        this.logger.error('Rate limiter Redis error when closing socket: %s', redisError.message);
       } else {
-        this.logger.error(`Rate limiter Redis error: ${redisError.fullError}`);
+        this.logger.error('Rate limiter Redis error: %s', redisError.fullError);
       }
     });
   }
@@ -130,7 +130,9 @@ export class RedisRateLimitStore implements RateLimitStore {
 
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.error(
-        `Rate limit store operation failed for IP address method for method ${key.method}. Error: ${errorMessage}. Allowing request to proceed (fail-open behavior).`,
+        'Rate limit store operation failed for IP address method for method %s. Error: %s. Allowing request to proceed (fail-open behavior).',
+        key.method,
+        errorMessage,
         error,
       );
 

--- a/packages/relay/src/lib/services/rateLimiterService/rateLimiterService.ts
+++ b/packages/relay/src/lib/services/rateLimiterService/rateLimiterService.ts
@@ -64,7 +64,7 @@ export class IPRateLimiterService {
       const normalizedType = String(configuredStoreType).trim().toUpperCase() as RateLimitStoreType;
 
       if (Object.values(RateLimitStoreType).includes(normalizedType)) {
-        this.logger.info(`Using configured rate limit store type: ${normalizedType}`);
+        this.logger.info('Using configured rate limit store type: %s', normalizedType);
         return normalizedType;
       }
 
@@ -77,7 +77,7 @@ export class IPRateLimiterService {
 
     // Only fall back to REDIS_ENABLED if IP_RATE_LIMIT_STORE is not set
     const fallbackType = ConfigService.get('REDIS_ENABLED') ? RateLimitStoreType.REDIS : RateLimitStoreType.LRU;
-    this.logger.info(`IP_RATE_LIMIT_STORE not configured, using fallback based on REDIS_ENABLED: ${fallbackType}`);
+    this.logger.info('IP_RATE_LIMIT_STORE not configured, using fallback based on REDIS_ENABLED: %s', fallbackType);
     return fallbackType;
   }
 

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -1086,7 +1086,7 @@ describe('SdkClient', async function () {
       executeQueryStub = sinon.stub(sdkClient as any, 'executeQuery');
       loggerWarnStub = sinon.stub(logger, 'warn');
       loggerTraceStub = sinon.stub(logger, 'trace');
-      sinon.stub(logger, 'isLevelEnabled').returns(true);
+      sinon.stub(logger, 'isLevelEnabled').returns(false);
     });
 
     afterEach(() => {

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -1086,7 +1086,7 @@ describe('SdkClient', async function () {
       executeQueryStub = sinon.stub(sdkClient as any, 'executeQuery');
       loggerWarnStub = sinon.stub(logger, 'warn');
       loggerTraceStub = sinon.stub(logger, 'trace');
-      sinon.stub(logger, 'isLevelEnabled').returns(false);
+      sinon.stub(logger, 'isLevelEnabled').returns(true);
     });
 
     afterEach(() => {

--- a/packages/relay/tests/redisInMemoryServer.ts
+++ b/packages/relay/tests/redisInMemoryServer.ts
@@ -35,9 +35,7 @@ export class RedisInMemoryServer {
   }
 
   async start(): Promise<void> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('Starting Redis in-memory server....');
-    }
+    this.logger.trace('Starting Redis in-memory server....');
     const started = await this.inMemoryRedisServer.start();
     if (started) {
       const host = await this.getHost();
@@ -58,9 +56,7 @@ export class RedisInMemoryServer {
   }
 
   async stop(): Promise<void> {
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace('Stopping Redis in-memory server....');
-    }
+    this.logger.trace('Stopping Redis in-memory server....');
     const stopped = await this.inMemoryRedisServer.stop();
     if (stopped) {
       this.logger.info('Stopped Redis in-memory server successfully.');
@@ -73,11 +69,9 @@ export class RedisInMemoryServer {
     try {
       // Ensure that the instance is running -> throws error if instance cannot be started
       const instanceData = await this.inMemoryRedisServer.ensureInstance();
-      if (this.logger.isLevelEnabled('debug')) {
-        this.logger.debug(
-          `Redis in-memory server health check passed, server is running on port ${instanceData.port}.`,
-        );
-      }
+      this.logger.debug(
+        `Redis in-memory server health check passed, server is running on port ${instanceData.port}.`,
+      );
     } catch (error) {
       this.logger.warn(`Redis in-memory server health check failed: ${error}`);
     }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -172,13 +172,13 @@ app.getKoaApp().use(async (ctx, next) => {
   const ms = Date.now() - start;
 
   if (ctx.method !== 'POST') {
-    logger.info(`[${ctx.method}]: ${ctx.url} ${ctx.status} ${ms} ms`);
+    logger.info('[%s]: %s %s %s ms', ctx.method, ctx.url, ctx.status, ms);
   } else {
     // Since ctx.state.status might contain the request ID from JsonRpcError, remove it for a cleaner log.
     const contextStatus = ctx.state.status?.replace(`[Request ID: ${ctx.state.reqId}] `, '') || ctx.status;
 
     // log call type, method, status code and latency
-    logger.info(`${formatRequestIdMessage(ctx.state.reqId)} [POST]: ${ctx.state.methodName} ${contextStatus} ${ms} ms`);
+    logger.info('%s [POST]: %s %s %s ms', formatRequestIdMessage(ctx.state.reqId), ctx.state.methodName, contextStatus, ms);
     methodResponseHistogram.labels(ctx.state.methodName, `${ctx.status}`).observe(ms);
   }
 });
@@ -258,7 +258,7 @@ app.getKoaApp().use(async (ctx, next) => {
     // support CORS preflight
     ctx.status = 200;
   } else {
-    logger.warn(`skipping HTTP method: [${ctx.method}], url: ${ctx.url}, status: ${ctx.status}`);
+    logger.warn('skipping HTTP method: [%s], url: %s, status: %s', ctx.method, ctx.url, ctx.status);
   }
 });
 
@@ -293,7 +293,7 @@ app.getKoaApp().use(async (ctx) => {
 });
 
 process.on('unhandledRejection', (reason, p) => {
-  logger.error(`Unhandled Rejection at: Promise: ${JSON.stringify(p)}, reason: ${reason}`);
+  logger.error('Unhandled Rejection at: Promise: %s, reason: %s', JSON.stringify(p), reason);
 });
 
 process.on('uncaughtException', (err) => {

--- a/packages/server/tests/acceptance/hbarLimiter.spec.ts
+++ b/packages/server/tests/acceptance/hbarLimiter.spec.ts
@@ -109,12 +109,10 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
 
     const verifyRemainingLimit = (expectedCost: number, remainingHbarsBefore: number, remainingHbarsAfter: number) => {
       const delta = transactionReecordCostTolerance * expectedCost;
-      if (global.logger.isLevelEnabled('debug')) {
-        global.logger.debug(`Tolerance: ${transactionReecordCostTolerance}`);
-        global.logger.debug(`Expected cost: ${expectedCost} ±${delta}`);
-        global.logger.debug(`Actual cost: ${remainingHbarsBefore - remainingHbarsAfter}`);
-        global.logger.debug(`Actual delta: ${(remainingHbarsBefore - remainingHbarsAfter) / (expectedCost * 100)}`);
-      }
+      global.logger.debug(`Tolerance: ${transactionReecordCostTolerance}`);
+      global.logger.debug(`Expected cost: ${expectedCost} ±${delta}`);
+      global.logger.debug(`Actual cost: ${remainingHbarsBefore - remainingHbarsAfter}`);
+      global.logger.debug(`Actual delta: ${(remainingHbarsBefore - remainingHbarsAfter) / (expectedCost * 100)}`);
       expect(remainingHbarsAfter).to.be.approximately(remainingHbarsBefore - expectedCost, delta);
     };
 
@@ -442,9 +440,7 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
             await Utils.wait(6000);
 
             const parentContractAddress = parentContract.target as string;
-            if (global.logger.isLevelEnabled('trace')) {
-              global.logger.trace(`Deploy parent contract on address ${parentContractAddress}`);
-            }
+            global.logger.trace(`Deploy parent contract on address ${parentContractAddress}`);
 
             expect(evmAddressSpendingPlanRepository.findByAddress(accounts[2].address)).to.be.rejected;
             const gasPrice = await relay.gasPrice(requestId);

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -119,9 +119,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
       );
 
       parentContractAddress = parentContract.target as string;
-      if (global.logger.isLevelEnabled('trace')) {
-        global.logger.trace(`Deploy parent contract on address ${parentContractAddress}`);
-      }
+      global.logger.trace(`Deploy parent contract on address ${parentContractAddress}`);
 
       const response = await accounts[0].wallet.sendTransaction({
         to: parentContractAddress,
@@ -133,9 +131,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
       createChildTx = await parentContract.createChild(1);
       await relay.pollForValidTransactionReceipt(createChildTx.hash);
 
-      if (global.logger.isLevelEnabled('trace')) {
-        global.logger.trace(`Contract call createChild on parentContract results in tx hash: ${createChildTx.hash}`);
-      }
+      global.logger.trace(`Contract call createChild on parentContract results in tx hash: ${createChildTx.hash}`);
       // get contract result details
       mirrorContractDetails = await mirrorNode.get(`/contracts/results/${createChildTx.hash}`, requestId);
 

--- a/packages/server/tests/acceptance/rpc_batch2.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch2.spec.ts
@@ -152,9 +152,7 @@ describe('@api-batch-2 RPC Server Acceptance Tests', function () {
       servicesNode.transferToken(tokenId, accounts[1].accountId, 10, requestId),
     ]);
 
-    if (global.logger.isLevelEnabled('trace')) {
-      global.logger.trace(`Setup completed`);
-    }
+    global.logger.trace(`Setup completed`);
   });
 
   this.beforeEach(async () => {

--- a/packages/server/tests/clients/metricsClient.ts
+++ b/packages/server/tests/clients/metricsClient.ts
@@ -49,9 +49,7 @@ export default class MetricsClient {
    */
   async get(metric: string, requestId?: string) {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
-    if (this.logger.isLevelEnabled('debug')) {
-      this.logger.debug(`${requestIdPrefix} [GET] Read all metrics from ${this.relayUrl}/metrics`);
-    }
+    this.logger.debug(`${requestIdPrefix} [GET] Read all metrics from ${this.relayUrl}/metrics`);
     const allMetrics = (await this.client.get('')).data;
     const allMetricsArray = allMetrics.split('\n');
     const matchPattern = `${metric} `;

--- a/packages/server/tests/clients/mirrorClient.ts
+++ b/packages/server/tests/clients/mirrorClient.ts
@@ -47,9 +47,7 @@ export default class MirrorClient {
 
   async get(path: string, requestId?: string) {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
-    if (this.logger.isLevelEnabled('debug')) {
-      this.logger.debug(`${requestIdPrefix} [GET] MirrorNode ${path} endpoint`);
-    }
+    this.logger.debug(`${requestIdPrefix} [GET] MirrorNode ${path} endpoint`);
     return (await this.client.get(path)).data;
   }
 }

--- a/packages/server/tests/clients/relayClient.ts
+++ b/packages/server/tests/clients/relayClient.ts
@@ -28,13 +28,11 @@ export default class RelayClient {
   async call(methodName: string, params: any[], requestId?: string) {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
     const result = await this.provider.send(methodName, params);
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(
-        `${requestIdPrefix} [POST] to relay '${methodName}' with params [${JSON.stringify(
-          params,
-        )}] returned ${JSON.stringify(result)}`,
-      );
-    }
+    this.logger.trace(
+      `${requestIdPrefix} [POST] to relay '${methodName}' with params [${JSON.stringify(
+        params,
+      )}] returned ${JSON.stringify(result)}`,
+    );
     return result;
   }
 
@@ -73,11 +71,9 @@ export default class RelayClient {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
     try {
       const res = await this.call(methodName, params, requestId);
-      if (this.logger.isLevelEnabled('trace')) {
-        this.logger.trace(
-          `${requestIdPrefix} [POST] to relay '${methodName}' with params [${params}] returned ${JSON.stringify(res)}`,
-        );
-      }
+      this.logger.trace(
+        `${requestIdPrefix} [POST] to relay '${methodName}' with params [${params}] returned ${JSON.stringify(res)}`,
+      );
       Assertions.expectedError();
     } catch (e: any) {
       if (expectedRpcError.message.includes('execution reverted')) {
@@ -117,9 +113,7 @@ export default class RelayClient {
    */
   async getBalance(address: ethers.AddressLike, block: BlockTag = 'latest', requestId?: string) {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
-    if (this.logger.isLevelEnabled('debug')) {
-      this.logger.debug(`${requestIdPrefix} [POST] to relay eth_getBalance for address ${address}]`);
-    }
+    this.logger.debug(`${requestIdPrefix} [POST] to relay eth_getBalance for address ${address}]`);
     return this.provider.getBalance(address, block);
   }
 
@@ -130,9 +124,7 @@ export default class RelayClient {
    */
   async getAccountNonce(evmAddress: string, requestId?: string): Promise<number> {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
-    if (this.logger.isLevelEnabled('debug')) {
-      this.logger.debug(`${requestIdPrefix} [POST] to relay for eth_getTransactionCount for address ${evmAddress}`);
-    }
+    this.logger.debug(`${requestIdPrefix} [POST] to relay for eth_getTransactionCount for address ${evmAddress}`);
     const nonce = await this.provider.send('eth_getTransactionCount', [evmAddress, 'latest']);
     return Number(nonce);
   }
@@ -146,9 +138,7 @@ export default class RelayClient {
    */
   async sendRawTransaction(signedTx, requestId?: string): Promise<string> {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
-    if (this.logger.isLevelEnabled('debug')) {
-      this.logger.debug(`${requestIdPrefix} [POST] to relay for eth_sendRawTransaction`);
-    }
+    this.logger.debug(`${requestIdPrefix} [POST] to relay for eth_sendRawTransaction`);
     return this.provider.send('eth_sendRawTransaction', [signedTx]);
   }
 

--- a/packages/server/tests/clients/servicesClient.ts
+++ b/packages/server/tests/clients/servicesClient.ts
@@ -109,11 +109,9 @@ export default class ServicesClient {
     );
     const address = wallet.address;
 
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(
-        `${requestIdPrefix} Create new Eth compatible account w alias: ${address} and balance ~${initialBalance} HBar`,
-      );
-    }
+    this.logger.trace(
+      `${requestIdPrefix} Create new Eth compatible account w alias: ${address} and balance ~${initialBalance} HBar`,
+    );
 
     const aliasCreationResponse = await this.executeTransaction(
       new TransferTransaction()
@@ -188,9 +186,7 @@ export default class ServicesClient {
   async createToken(initialSupply: number = 1000, requestId?: string) {
     const requestIdPrefix = Utils.formatRequestIdMessage(requestId);
     const symbol = Math.random().toString(36).slice(2, 6).toUpperCase();
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`symbol = ${symbol}`);
-    }
+    this.logger.trace(`symbol = ${symbol}`);
     const resp = await this.executeAndGetTransactionReceipt(
       new TokenCreateTransaction()
         .setTokenName(`relay-acceptance token ${symbol}`)
@@ -202,9 +198,7 @@ export default class ServicesClient {
       requestId,
     );
 
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(`get token id from receipt`);
-    }
+    this.logger.trace(`get token id from receipt`);
     const tokenId = resp?.tokenId;
     this.logger.info(`${requestIdPrefix} token id = ${tokenId?.toString()}`);
     return tokenId!;
@@ -367,11 +361,9 @@ export default class ServicesClient {
     // Create a KeyList of both keys and specify that only 1 is required for signing transactions
     const keyList = new KeyList(keys, 1);
 
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(
-        `${requestIdPrefix} Create new Eth compatible account w ContractId key: ${contractId}, privateKey: ${privateKey}, alias: ${publicKey.toEvmAddress()} and balance ~${initialBalance} hb`,
-      );
-    }
+    this.logger.trace(
+      `${requestIdPrefix} Create new Eth compatible account w ContractId key: ${contractId}, privateKey: ${privateKey}, alias: ${publicKey.toEvmAddress()} and balance ~${initialBalance} hb`,
+    );
 
     const accountCreateTx = await new AccountCreateTransaction()
       .setInitialBalance(new Hbar(initialBalance))
@@ -397,11 +389,9 @@ export default class ServicesClient {
     const publicKey = privateKey.publicKey;
     const aliasAccountId = publicKey.toAccountId(0, 0);
 
-    if (this.logger.isLevelEnabled('trace')) {
-      this.logger.trace(
-        `${requestIdPrefix} Create new Eth compatible account w alias: ${aliasAccountId.toString()} and balance ~${initialBalance} hb`,
-      );
-    }
+    this.logger.trace(
+      `${requestIdPrefix} Create new Eth compatible account w alias: ${aliasAccountId.toString()} and balance ~${initialBalance} hb`,
+    );
 
     const aliasCreationResponse = await this.executeTransaction(
       new TransferTransaction()

--- a/packages/server/tests/helpers/assertions.ts
+++ b/packages/server/tests/helpers/assertions.ts
@@ -451,11 +451,10 @@ export default class Assertions {
    * @param tolerance
    */
   static expectWithinTolerance(expected: number, actual: number, tolerance: number) {
-    if (global.logger.isLevelEnabled('debug')) {
-      global.logger.debug(`Expected: ${expected} ±${tolerance}%`);
-      global.logger.debug(`Actual: ${actual}`);
-      global.logger.debug(`Actual delta: ${(actual - expected) / 100}%`);
-    }
+
+    global.logger.debug(`Expected: ${expected} ±${tolerance}%`);
+    global.logger.debug(`Actual: ${actual}`);
+    global.logger.debug(`Actual delta: ${(actual - expected) / 100}%`);
     const delta = tolerance * expected;
     expect(actual).to.be.approximately(expected, delta);
   }

--- a/packages/server/tests/helpers/utils.ts
+++ b/packages/server/tests/helpers/utils.ts
@@ -319,11 +319,10 @@ export class Utils {
         requestDetails.requestId,
         initialAmountInTinyBar,
       );
-      if (global.logger.isLevelEnabled('trace')) {
-        global.logger.trace(
-          `Create new Eth compatible account w alias: ${account.address} and balance ~${initialAmountInTinyBar} wei`,
-        );
-      }
+
+      global.logger.trace(
+        `Create new Eth compatible account w alias: ${account.address} and balance ~${initialAmountInTinyBar} wei`,
+      );
       accounts.push(account);
     }
     return accounts;

--- a/packages/ws-server/src/controllers/jsonRpcController.ts
+++ b/packages/ws-server/src/controllers/jsonRpcController.ts
@@ -55,9 +55,7 @@ const handleSendingRequestsToRelay = async ({
   logger,
   requestDetails,
 }: ISharedParams): Promise<IJsonRpcResponse> => {
-  if (logger.isLevelEnabled('trace')) {
-    logger.trace(`Submitting request=${JSON.stringify(request)} to relay.`);
-  }
+  logger.trace(`Submitting request=${JSON.stringify(request)} to relay.`);
   try {
     // call the public API entry point on the Relay package to execute the RPC method
     const result = await relay.executeRpcMethod(method, params, requestDetails);

--- a/packages/ws-server/src/metrics/connectionLimiter.ts
+++ b/packages/ws-server/src/metrics/connectionLimiter.ts
@@ -175,9 +175,7 @@ export default class ConnectionLimiter {
     websocket.inactivityTTL = setTimeout(() => {
       if (websocket.readyState !== 3) {
         // 3 = CLOSED, Avoid closing already closed connections
-        if (this.logger.isLevelEnabled('debug')) {
-          this.logger.debug(`Closing connection ${websocket.id} due to reaching TTL (${maxInactivityTTL}ms)`);
-        }
+        this.logger.debug(`Closing connection ${websocket.id} due to reaching TTL (${maxInactivityTTL}ms)`);
         try {
           this.inactivityTTLCounter.inc();
           websocket.send(

--- a/packages/ws-server/src/service/pollerService.ts
+++ b/packages/ws-server/src/service/pollerService.ts
@@ -57,9 +57,7 @@ export class PollerService {
   private poll() {
     this.polls.forEach(async (poll) => {
       try {
-        if (this.logger.isLevelEnabled('debug')) {
           this.logger.debug(`${LOGGER_PREFIX} Fetching data for tag: ${poll.tag}`);
-        }
 
         const { event, filters } = JSON.parse(poll.tag);
         let data;
@@ -91,17 +89,13 @@ export class PollerService {
 
         if (Array.isArray(data)) {
           if (data.length) {
-            if (this.logger.isLevelEnabled('trace')) {
-              this.logger.trace(`${LOGGER_PREFIX} Received ${data.length} results from tag: ${poll.tag}`);
-            }
+            this.logger.trace(`${LOGGER_PREFIX} Received ${data.length} results from tag: ${poll.tag}`);
             data.forEach((d) => {
               poll.callback(d);
             });
           }
         } else {
-          if (this.logger.isLevelEnabled('trace')) {
-            this.logger.trace(`${LOGGER_PREFIX} Received 1 result from tag: ${poll.tag}`);
-          }
+          this.logger.trace(`${LOGGER_PREFIX} Received 1 result from tag: ${poll.tag}`);
           poll.callback(data);
         }
       } catch (error) {

--- a/packages/ws-server/src/service/subscriptionService.ts
+++ b/packages/ws-server/src/service/subscriptionService.ts
@@ -88,9 +88,7 @@ export class SubscriptionService {
       // Check if the connection is already subscribed to this event
       const existingSub = this.subscriptions[tag].find((sub) => sub.connection.id === connection.id);
       if (existingSub) {
-        if (this.logger.isLevelEnabled('debug')) {
-          this.logger.debug(`Connection ${connection.id}: Attempting to subscribe to ${tag}; already subscribed`);
-        }
+        this.logger.debug(`Connection ${connection.id}: Attempting to subscribe to ${tag}; already subscribed`);
         return existingSub.subscriptionId;
       }
     }
@@ -124,11 +122,9 @@ export class SubscriptionService {
       this.subscriptions[tag] = subs.filter((sub) => {
         const match = sub.connection.id === id && (!subId || subId === sub.subscriptionId);
         if (match) {
-          if (this.logger.isLevelEnabled('debug')) {
-            this.logger.debug(
-              `Connection ${sub.connection.id}. Unsubscribing subId: ${sub.subscriptionId}; tag: ${tag}`,
-            );
-          }
+          this.logger.debug(
+            `Connection ${sub.connection.id}. Unsubscribing subId: ${sub.subscriptionId}; tag: ${tag}`,
+          );
           sub.endTimer();
           subCount++;
         }
@@ -137,9 +133,7 @@ export class SubscriptionService {
       });
 
       if (!this.subscriptions[tag].length) {
-        if (this.logger.isLevelEnabled('debug')) {
-          this.logger.debug(`No subscribers for ${tag}. Removing from list.`);
-        }
+        this.logger.debug(`No subscribers for ${tag}. Removing from list.`);
         delete this.subscriptions[tag];
         this.pollerService.remove(tag);
       }
@@ -160,11 +154,9 @@ export class SubscriptionService {
         // If the hash exists in the cache then the data has recently been sent to the subscriber
         if (!this.cache.get(hash)) {
           this.cache.set(hash, true);
-          if (this.logger.isLevelEnabled('debug')) {
-            this.logger.debug(
-              `Sending data from tag: ${tag} to subscriptionId: ${sub.subscriptionId}, connectionId: ${sub.connection.id}, data: ${subscriptionData}`,
-            );
-          }
+          this.logger.debug(
+            `Sending data from tag: ${tag} to subscriptionId: ${sub.subscriptionId}, connectionId: ${sub.connection.id}, data: ${subscriptionData}`,
+          );
           this.resultsSentToSubscribersCounter.labels('sub.subscriptionId', tag).inc();
           sub.connection.send(
             JSON.stringify({

--- a/packages/ws-server/src/webSocketServer.ts
+++ b/packages/ws-server/src/webSocketServer.ts
@@ -139,9 +139,7 @@ app.ws.use(async (ctx: Koa.Context) => {
 
       // check if request is a batch request (array) or a signle request (JSON)
       if (Array.isArray(request)) {
-        if (logger.isLevelEnabled('trace')) {
-          logger.trace(`Receive batch request=${JSON.stringify(request)}`);
-        }
+        logger.trace(`Receive batch request=${JSON.stringify(request)}`);
 
         // Increment metrics for batch_requests
         wsMetricRegistry.getCounter('methodsCounter').labels(WS_CONSTANTS.BATCH_REQUEST_METHOD_NAME).inc();
@@ -197,9 +195,7 @@ app.ws.use(async (ctx: Koa.Context) => {
         // send to client
         sendToClient(ctx.websocket, request, responses, logger);
       } else {
-        if (logger.isLevelEnabled('trace')) {
-          logger.trace(`Receive single request=${JSON.stringify(request)}`);
-        }
+        logger.trace(`Receive single request=${JSON.stringify(request)}`);
 
         // process requests
         const response = await getRequestResult(


### PR DESCRIPTION
### Description

This PR removes `isLevelEnabled` guards from logging statements and replaces template literals with Pino's interpolation values to improve code readability and maintainability. The changes eliminate code clutter while maintaining performance by leveraging Pino's built-in interpolation mechanism that avoids string construction when the log level is inactive.

Key improvements:
- Converted template literals (`` `string ${variable}` ``) to interpolation format (`'string %s', variable`)
- Removed `isLevelEnabled` guards where only simple variable interpolation was used
- Retained guards only where complex preprocessing is required (e.g., IP address redaction)
- Removed redundant trace logs from `@rpcMethod` decorated methods since the dispatcher already logs RPC execution
- Standardized log message formatting across the codebase

### Related issue(s)

Fixes #4080

### Testing Guide

1. Run the existing test suite to ensure no regressions:
   ```bash
   npm test
   ```

2. Run K6 performance tests to verify no performance impact:
  --

3. Test logging behavior at different log levels:
  --

4. Verify complex logging scenarios still work (where guards were retained):
   - Check IP address redaction in cache logs
   - Verify sensitive data masking still functions

### Changes from original design (optional)

N/A

### Additional work needed (optional)

- Monitor production logs after deployment to ensure interpolation performance meets expectations
- Consider updating logging guidelines/documentation for future development

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable) 
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)