### PR TITLE
chore: updates prom-client to new major version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "pino": "^9.7.0",
         "pino-pretty": "^7.6.1",
         "pnpm": "^10.0.0",
-        "prom-client": "^14.0.1",
+        "prom-client": "^15.1.3",
         "redis": "^5.8.0"
       },
       "devDependencies": {
@@ -3826,6 +3826,15 @@
       "dev": true,
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -15334,14 +15343,16 @@
       }
     },
     "node_modules/prom-client": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
-      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
       "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^16 || ^18 || >=20"
       }
     },
     "node_modules/promise": {
@@ -23162,6 +23173,11 @@
       "resolved": "https://registry.npmjs.org/@open-rpc/specification-extension-spec/-/specification-extension-spec-1.0.2.tgz",
       "integrity": "sha512-EPVI1Mgp5vDSN2Xn+eWjd2t30WU+R0nFeNoP/dp3ox5/qUhNdqlNcwGJDNoJlqK56rk09FYXWJXKLHae4eBE8w==",
       "dev": true
+    },
+    "@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -31277,10 +31293,11 @@
       "integrity": "sha512-69agxLtnI8xBs9gUGqEnK26UfiexpHy+KUpBQWabiytQjnn5wFY8rklAi7GRfABIuPNnQ/ik48+LGLkYYJcy4A=="
     },
     "prom-client": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-14.2.0.tgz",
-      "integrity": "sha512-sF308EhTenb/pDRPakm+WgiN+VdM/T1RaHj1x+MvAuT8UiQP8JmOEbxVqtkbfR4LrvOg5n7ic01kRBDGXjYikA==",
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
       "requires": {
+        "@opentelemetry/api": "^1.4.0",
         "tdigest": "^0.1.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "pino": "^9.7.0",
     "pino-pretty": "^7.6.1",
     "pnpm": "^10.0.0",
-    "prom-client": "^14.0.1",
+    "prom-client": "^15.1.3",
     "redis": "^5.8.0"
   },
   "overrides": {

--- a/packages/ws-server/tests/unit/utils.spec.ts
+++ b/packages/ws-server/tests/unit/utils.spec.ts
@@ -137,15 +137,13 @@ describe('Utilities unit tests', async function () {
       relayStub.eth.returns(sinon.createStubInstance(EthImpl));
       limiterStub = sinon.createStubInstance(ConnectionLimiter);
       wsMetricRegistryStub = sinon.createStubInstance(WsMetricRegistry);
-      wsMetricRegistryStub.getCounter.returns(sinon.createStubInstance(Counter));
-      wsMetricRegistryStub.getHistogram.returns(
-        sinon.createStubInstance(Histogram, {
-          labels: sinon.stub<[Partial<Record<any, string | number>>]>().returns({
-            observe: sinon.spy(),
-            startTimer: sinon.spy(),
-          }),
-        }),
-      );
+      const counterStub = { inc: sinon.stub() } as unknown as Counter;
+      wsMetricRegistryStub.getCounter.returns(counterStub);
+      const fakeHistogram = {
+        observe: sinon.stub(),
+        startTimer: sinon.stub(),
+      } as unknown as Histogram;
+      wsMetricRegistryStub.getHistogram.returns(fakeHistogram);
       ctxStub = {
         websocket: {
           id: 'mock-id',


### PR DESCRIPTION
### Description

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->
This PR manually updates prom-client to newer major version - 15. 
It also updates unit tests, since in the new version some methods are actually instance objects, not prorotype
### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #4185 

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1.
2.
3.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

Changes in unit testing had to be done, since some of the functions of the prom-client objects e.g Counter and Histogram, were now change to be instance properties, so when stubbing them they wont actually exist (since you are not creating an instance)
https://github.com/hiero-ledger/hiero-json-rpc-relay/pull/4219/files#diff-680694a70a29a291f93442348a6ec8cdb70c6e6c6f5abfc2c51f4fd84e593e95R140

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
