### PR TITLE
chore: create PR to update openrpc only when it hits `main`

### DIFF
--- a/.github/workflows/openrpc-updater.yml
+++ b/.github/workflows/openrpc-updater.yml
@@ -6,11 +6,12 @@ on:
       - main
     paths:
       - 'docs/openrpc.json'
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'docs/openrpc.json'
+  # Needs to be removed for now
+  # pull_request:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - 'docs/openrpc.json'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
### Description

This PR restores the update openrpc workflow to only trigger the PR creation when it hits main. This avoids the PR loop creation caused when `docs/openrpc.json` gets modified.

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #4300.

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
