### PR TITLE
fix: extend xts suite with new coverage for HBAR transfers to zero address and reserved system accounts

### DIFF
--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -100,7 +100,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
       expectedGasPrice = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GAS_PRICE, []);
 
       const initialAccount: AliasAccount = global.accounts[0];
-      const neededAccounts: number = 4;
+      const neededAccounts: number = 6;
       accounts.push(
         ...(await Utils.createMultipleAliasAccounts(mirrorNode, initialAccount, neededAccounts, initialBalance)),
       );

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -100,7 +100,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
       expectedGasPrice = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GAS_PRICE, []);
 
       const initialAccount: AliasAccount = global.accounts[0];
-      const neededAccounts: number = 4;
+      const neededAccounts: number = 3;
       accounts.push(
         ...(await Utils.createMultipleAliasAccounts(mirrorNode, initialAccount, neededAccounts, initialBalance)),
       );
@@ -1136,67 +1136,23 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           description: '0.0.999 (existent)',
           expectedError: null,
         },
-
-        // Ethereum precompiles (0x1 to 0xa) - should return INVALID_CONTRACT_ID
-        {
-          address: '0x0000000000000000000000000000000000000001',
-          description: '0x1 EC-recover',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x0000000000000000000000000000000000000004',
-          description: '0x4 identity',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x0000000000000000000000000000000000000005',
-          description: '0x5 modexp',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x0000000000000000000000000000000000000006',
-          description: '0x6 ecadd',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x0000000000000000000000000000000000000007',
-          description: '0x7 ecmul',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x0000000000000000000000000000000000000008',
-          description: '0x8 ecpairing',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x0000000000000000000000000000000000000009',
-          description: '0x9 blake2f',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x000000000000000000000000000000000000000a',
-          description: '0xa point evaluation',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
       ];
 
-      hederaReservedAccounts.forEach(({ address, description, expectedError }, index) => {
+      hederaReservedAccounts.forEach(({ address, description, expectedError }) => {
         const testDescription = expectedError
           ? `@xts should reject HBAR transfer to ${description} (${address}) with ${expectedError}`
           : `@xts should successfully execute HBAR transfer to ${description} (${address})`;
 
         it(testDescription, async function () {
-          const accountIndex = index % accounts.length; // Cycle between accounts to avoid exhausting funds
-
           const sendHbarTx = {
             ...defaultLegacyTransactionData,
             value: ONE_TINYBAR,
             to: address,
-            nonce: await relay.getAccountNonce(accounts[accountIndex].address),
+            nonce: await relay.getAccountNonce(accounts[1].address),
             gasPrice: await relay.gasPrice(),
           };
 
-          const signedSendHbarTx = await accounts[accountIndex].wallet.signTransaction(sendHbarTx);
+          const signedSendHbarTx = await accounts[1].wallet.signTransaction(sendHbarTx);
           const txHash = await relay.sendRawTransaction(signedSendHbarTx);
           const txReceipt = await relay.pollForValidTransactionReceipt(txHash);
 

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -997,11 +997,11 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           ...defaultLegacyTransactionData,
           value: ONE_TINYBAR,
           to: ethers.ZeroAddress,
-          nonce: await relay.getAccountNonce(accounts[0].address),
+          nonce: await relay.getAccountNonce(accounts[2].address),
           gasPrice: await relay.gasPrice(),
         };
 
-        const signedSendHbarTx = await accounts[0].wallet.signTransaction(sendHbarTx);
+        const signedSendHbarTx = await accounts[2].wallet.signTransaction(sendHbarTx);
         const error = predefined.INTERNAL_ERROR('Transaction execution returns a null value');
 
         await Assertions.assertPredefinedRpcError(error, sendRawTransaction, true, relay, [
@@ -1040,11 +1040,11 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             ...defaultLegacyTransactionData,
             value: ONE_TINYBAR,
             to: address,
-            nonce: await relay.getAccountNonce(accounts[0].address),
+            nonce: await relay.getAccountNonce(accounts[2].address),
             gasPrice: await relay.gasPrice(),
           };
 
-          const signedSendHbarTx = await accounts[0].wallet.signTransaction(sendHbarTx);
+          const signedSendHbarTx = await accounts[2].wallet.signTransaction(sendHbarTx);
           const txHash = await relay.sendRawTransaction(signedSendHbarTx);
           const txReceipt = await relay.pollForValidTransactionReceipt(txHash);
 
@@ -1077,11 +1077,11 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             ...defaultLegacyTransactionData,
             value: ONE_TINYBAR,
             to: address,
-            nonce: await relay.getAccountNonce(accounts[0].address),
+            nonce: await relay.getAccountNonce(accounts[2].address),
             gasPrice: await relay.gasPrice(),
           };
 
-          const signedSendHbarTx = await accounts[0].wallet.signTransaction(sendHbarTx);
+          const signedSendHbarTx = await accounts[2].wallet.signTransaction(sendHbarTx);
           const txHash = await relay.sendRawTransaction(signedSendHbarTx);
           const txReceipt = await relay.pollForValidTransactionReceipt(txHash);
 

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -100,7 +100,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
       expectedGasPrice = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GAS_PRICE, []);
 
       const initialAccount: AliasAccount = global.accounts[0];
-      const neededAccounts: number = 3;
+      const neededAccounts: number = 4;
       accounts.push(
         ...(await Utils.createMultipleAliasAccounts(mirrorNode, initialAccount, neededAccounts, initialBalance)),
       );
@@ -1136,23 +1136,67 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           description: '0.0.999 (existent)',
           expectedError: null,
         },
+
+        // Ethereum precompiles (0x1 to 0xa) - should return INVALID_CONTRACT_ID
+        {
+          address: '0x0000000000000000000000000000000000000001',
+          description: '0x1 EC-recover',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x0000000000000000000000000000000000000004',
+          description: '0x4 identity',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x0000000000000000000000000000000000000005',
+          description: '0x5 modexp',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x0000000000000000000000000000000000000006',
+          description: '0x6 ecadd',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x0000000000000000000000000000000000000007',
+          description: '0x7 ecmul',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x0000000000000000000000000000000000000008',
+          description: '0x8 ecpairing',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x0000000000000000000000000000000000000009',
+          description: '0x9 blake2f',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x000000000000000000000000000000000000000a',
+          description: '0xa point evaluation',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
       ];
 
-      hederaReservedAccounts.forEach(({ address, description, expectedError }) => {
+      hederaReservedAccounts.forEach(({ address, description, expectedError }, index) => {
         const testDescription = expectedError
           ? `@xts should reject HBAR transfer to ${description} (${address}) with ${expectedError}`
           : `@xts should successfully execute HBAR transfer to ${description} (${address})`;
 
         it(testDescription, async function () {
+          const accountIndex = index % accounts.length; // Cycle between accounts to avoid exhausting funds
+
           const sendHbarTx = {
             ...defaultLegacyTransactionData,
             value: ONE_TINYBAR,
             to: address,
-            nonce: await relay.getAccountNonce(accounts[1].address),
+            nonce: await relay.getAccountNonce(accounts[accountIndex].address),
             gasPrice: await relay.gasPrice(),
           };
 
-          const signedSendHbarTx = await accounts[1].wallet.signTransaction(sendHbarTx);
+          const signedSendHbarTx = await accounts[accountIndex].wallet.signTransaction(sendHbarTx);
           const txHash = await relay.sendRawTransaction(signedSendHbarTx);
           const txReceipt = await relay.pollForValidTransactionReceipt(txHash);
 

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -1010,32 +1010,140 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
         ]);
       });
 
-      it('@xts should reject eth_sendRawTransaction requests for HBAR crypto transfers to reserved system account addresses (accounts ≤ 0.0.750) with INVALID_CONTRACT_ID.', async function () {
-        // https://github.com/hiero-ledger/hiero-consensus-node/blob/main/hedera-node/docs/system-accounts-operations.md
-        const hederaSystemAccounts = [
-          // system accounts
-          '0x0000000000000000000000000000000000000002', // 0.0.2 treasury
-          '0x0000000000000000000000000000000000000003', // 0.0.3
-          '0x0000000000000000000000000000000000000032', // 0.0.50 system admin
-          '0x0000000000000000000000000000000000000037', // 0.0.55 address book admin
-          '0x0000000000000000000000000000000000000039', // 0.0.57 exchange rates admin
-          '0x000000000000000000000000000000000000003a', // 0.0.58 freeze admin
-          '0x000000000000000000000000000000000000003b', // 0.0.59 system delete admin
-          '0x000000000000000000000000000000000000003c', // 0.0.60 system undelete admin
+      // https://github.com/hiero-ledger/hiero-consensus-node/blob/main/hedera-node/docs/system-accounts-operations.md
+      const hederaReservedAccounts = [
+        // system accounts (≤ 0.0.750) - should return INVALID_CONTRACT_ID
+        {
+          address: '0x0000000000000000000000000000000000000002',
+          description: '0.0.2 treasury',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x0000000000000000000000000000000000000003',
+          description: '0.0.3',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x0000000000000000000000000000000000000032',
+          description: '0.0.50 system admin',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x0000000000000000000000000000000000000037',
+          description: '0.0.55 address book admin',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x0000000000000000000000000000000000000039',
+          description: '0.0.57 exchange rates admin',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x000000000000000000000000000000000000003a',
+          description: '0.0.58 freeze admin',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x000000000000000000000000000000000000003b',
+          description: '0.0.59 system delete admin',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x000000000000000000000000000000000000003c',
+          description: '0.0.60 system undelete admin',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
 
-          // system contracts (precompiles)
-          '0x0000000000000000000000000000000000000167', // 0.0.359 HTS
-          '0x0000000000000000000000000000000000000168', // 0.0.360 Exchange Rate
-          '0x0000000000000000000000000000000000000169', // 0.0.361 PRNG
-          '0x000000000000000000000000000000000000016a', // 0.0.362 HAS
+        // system contracts (precompiles) (≤ 0.0.750) - should return INVALID_CONTRACT_ID
+        {
+          address: '0x0000000000000000000000000000000000000167',
+          description: '0.0.359 HTS',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x0000000000000000000000000000000000000168',
+          description: '0.0.360 Exchange Rate',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x0000000000000000000000000000000000000169',
+          description: '0.0.361 PRNG',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x000000000000000000000000000000000000016a',
+          description: '0.0.362 HAS',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x000000000000000000000000000000000000016b',
+          description: '0.0.363 HSS',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
 
-          // non-existent accounts
-          '0x00000000000000000000000000000000000001C2', // 0.0.450
-          '0x00000000000000000000000000000000000001FE', // 0.0.510
-          '0x00000000000000000000000000000000000002EE', // 0.0.750
-        ];
+        // non-existent accounts (≤ 0.0.750) - should return INVALID_CONTRACT_ID
+        {
+          address: '0x00000000000000000000000000000000000001C2',
+          description: '0.0.450',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x00000000000000000000000000000000000001FE',
+          description: '0.0.510',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
+        {
+          address: '0x00000000000000000000000000000000000002EE',
+          description: '0.0.750',
+          expectedError: 'INVALID_CONTRACT_ID',
+        },
 
-        for (const address of hederaSystemAccounts) {
+        // accounts (> 0.0.750) - non-existent should return INVALID_ALIAS_KEY
+        {
+          address: '0x00000000000000000000000000000000000002f1',
+          description: '0.0.753 (non-existent)',
+          expectedError: 'INVALID_ALIAS_KEY',
+        },
+        {
+          address: '0x000000000000000000000000000000000000032A',
+          description: '0.0.810 (non-existent)',
+          expectedError: 'INVALID_ALIAS_KEY',
+        },
+
+        // accounts (> 0.0.750) - existent should succeed (null = no error expected)
+        {
+          address: '0x0000000000000000000000000000000000000320',
+          description: '0.0.800 staking reward account',
+          expectedError: null,
+        },
+        {
+          address: '0x0000000000000000000000000000000000000321',
+          description: '0.0.801 node reward account',
+          expectedError: null,
+        },
+        {
+          address: '0x00000000000000000000000000000000000003A2',
+          description: '0.0.930 (existent)',
+          expectedError: null,
+        },
+        {
+          address: '0x00000000000000000000000000000000000003C0',
+          description: '0.0.960 (existent)',
+          expectedError: null,
+        },
+        {
+          address: '0x00000000000000000000000000000000000003E7',
+          description: '0.0.999 (existent)',
+          expectedError: null,
+        },
+      ];
+
+      hederaReservedAccounts.forEach(({ address, description, expectedError }) => {
+        const testDescription = expectedError
+          ? `@xts should reject HBAR transfer to ${description} (${address}) with ${expectedError}`
+          : `@xts should successfully execute HBAR transfer to ${description} (${address})`;
+
+        it(testDescription, async function () {
           const sendHbarTx = {
             ...defaultLegacyTransactionData,
             value: ONE_TINYBAR,
@@ -1048,58 +1156,14 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           const txHash = await relay.sendRawTransaction(signedSendHbarTx);
           const txReceipt = await relay.pollForValidTransactionReceipt(txHash);
 
-          expect(txReceipt.revertReason).to.not.be.null;
-          expect(txReceipt.revertReason).to.not.be.empty;
-          expect(Buffer.from((txReceipt.revertReason as string).slice(2), 'hex').toString('utf8')).to.equal(
-            'INVALID_CONTRACT_ID',
-          );
-        }
-      });
-
-      it('@xts should validate HBAR transfers to reserved system accounts based on account existence for accounts from 0.0.750 to 0.0.999', async function () {
-        const hederaSystemAccounts = [
-          // non-existent accounts
-          '0x00000000000000000000000000000000000002f1', // 0.0.753
-          '0x000000000000000000000000000000000000032A', // 0.0.810
-
-          // system accounts
-          '0x0000000000000000000000000000000000000320', // 0.0.800 staking reward account;
-          '0x0000000000000000000000000000000000000321', // 0.0.801 node reward account
-
-          // existent accounts
-          '0x00000000000000000000000000000000000003A2', // 0.0.930
-          '0x00000000000000000000000000000000000003A2', // 0.0.960
-          '0x00000000000000000000000000000000000003A2', // 0.0.999
-        ];
-
-        for (const address of hederaSystemAccounts) {
-          const sendHbarTx = {
-            ...defaultLegacyTransactionData,
-            value: ONE_TINYBAR,
-            to: address,
-            nonce: await relay.getAccountNonce(accounts[1].address),
-            gasPrice: await relay.gasPrice(),
-          };
-
-          const signedSendHbarTx = await accounts[1].wallet.signTransaction(sendHbarTx);
-          const txHash = await relay.sendRawTransaction(signedSendHbarTx);
-          const txReceipt = await relay.pollForValidTransactionReceipt(txHash);
-
-          // Crypto Transfers are successful if accounts exist
-          try {
-            const accountInfo = await global.mirrorNode.get(`/accounts/${address}`);
-            expect(accountInfo).to.exist;
+          if (expectedError) {
+            expect(txReceipt.revertReason).to.not.be.empty;
+            expect(Buffer.from(txReceipt.revertReason!.slice(2), 'hex').toString('utf8')).to.equal(expectedError);
+          } else {
             expect(txReceipt.status).to.equal('0x1');
             expect(txReceipt.revertReason).to.be.undefined;
-          } catch (error) {
-            expect(error.status).to.equal(404);
-            expect(txReceipt.revertReason).to.not.be.null;
-            expect(txReceipt.revertReason).to.not.be.empty;
-            expect(Buffer.from((txReceipt.revertReason as string).slice(2), 'hex').toString('utf8')).to.equal(
-              'INVALID_ALIAS_KEY',
-            );
           }
-        }
+        });
       });
 
       it('@xts should execute "eth_sendRawTransaction" for deterministic deployment transaction', async function () {

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -1054,7 +1054,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           expectedError: 'INVALID_CONTRACT_ID',
         },
 
-        // system contracts (precompiles) (≤ 0.0.750) - should return INVALID_CONTRACT_ID
+        // system contracts (≤ 0.0.750) - should return INVALID_CONTRACT_ID
         {
           address: '0x0000000000000000000000000000000000000167',
           description: '0.0.359 HTS',

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -100,7 +100,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
       expectedGasPrice = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GAS_PRICE, []);
 
       const initialAccount: AliasAccount = global.accounts[0];
-      const neededAccounts: number = 4;
+      const neededAccounts: number = 3;
       accounts.push(
         ...(await Utils.createMultipleAliasAccounts(mirrorNode, initialAccount, neededAccounts, initialBalance)),
       );
@@ -1012,58 +1012,6 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
       // https://github.com/hiero-ledger/hiero-consensus-node/blob/main/hedera-node/docs/system-accounts-operations.md
       const hederaReservedAccounts = [
-        // Ethereum precompiles (0x1 to 0xa) - should return INVALID_CONTRACT_ID
-        {
-          address: '0x0000000000000000000000000000000000000001',
-          description: '0x1 EC-recover',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x0000000000000000000000000000000000000002',
-          description: '0x2 SHA2-256',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x0000000000000000000000000000000000000003',
-          description: '0x3 RIPEMD-160',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x0000000000000000000000000000000000000004',
-          description: '0x4 identity',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x0000000000000000000000000000000000000005',
-          description: '0x5 modexp',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x0000000000000000000000000000000000000006',
-          description: '0x6 ecadd',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x0000000000000000000000000000000000000007',
-          description: '0x7 ecmul',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x0000000000000000000000000000000000000008',
-          description: '0x8 ecpairing',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x0000000000000000000000000000000000000009',
-          description: '0x9 blake2f',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-        {
-          address: '0x000000000000000000000000000000000000000a',
-          description: '0xa point evaluation',
-          expectedError: 'INVALID_CONTRACT_ID',
-        },
-
         // system accounts (≤ 0.0.750) - should return INVALID_CONTRACT_ID
         {
           address: '0x0000000000000000000000000000000000000002',
@@ -1190,23 +1138,21 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
         },
       ];
 
-      hederaReservedAccounts.forEach(({ address, description, expectedError }, index) => {
+      hederaReservedAccounts.forEach(({ address, description, expectedError }) => {
         const testDescription = expectedError
           ? `@xts should reject HBAR transfer to ${description} (${address}) with ${expectedError}`
           : `@xts should successfully execute HBAR transfer to ${description} (${address})`;
 
         it(testDescription, async function () {
-          const accountIndex = index % accounts.length; // Cycle between accounts to avoid exhausting funds
-
           const sendHbarTx = {
             ...defaultLegacyTransactionData,
             value: ONE_TINYBAR,
             to: address,
-            nonce: await relay.getAccountNonce(accounts[accountIndex].address),
+            nonce: await relay.getAccountNonce(accounts[1].address),
             gasPrice: await relay.gasPrice(),
           };
 
-          const signedSendHbarTx = await accounts[accountIndex].wallet.signTransaction(sendHbarTx);
+          const signedSendHbarTx = await accounts[1].wallet.signTransaction(sendHbarTx);
           const txHash = await relay.sendRawTransaction(signedSendHbarTx);
           const txReceipt = await relay.pollForValidTransactionReceipt(txHash);
 
@@ -1599,24 +1545,24 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
       });
 
       it('@xts should execute "eth_sendRawTransaction" and deploy a contract with reasonable transaction fee within expected bounds', async function () {
-        const balanceBefore = await relay.getBalance(accounts[3].wallet.address, 'latest');
+        const balanceBefore = await relay.getBalance(accounts[2].wallet.address, 'latest');
 
         const gasPrice = await relay.gasPrice();
         const transaction = {
           type: 2,
           chainId: Number(CHAIN_ID),
-          nonce: await relay.getAccountNonce(accounts[3].address),
+          nonce: await relay.getAccountNonce(accounts[2].address),
           maxPriorityFeePerGas: gasPrice,
           maxFeePerGas: gasPrice,
           gasLimit: Constants.MAX_TRANSACTION_FEE_THRESHOLD,
           data: '0x' + '00'.repeat(100),
         };
 
-        const signedTx = await accounts[3].wallet.signTransaction(transaction);
+        const signedTx = await accounts[2].wallet.signTransaction(transaction);
         const transactionHash = await relay.sendRawTransaction(signedTx);
         await relay.pollForValidTransactionReceipt(transactionHash);
         const info = await mirrorNode.get(`/contracts/results/${transactionHash}`);
-        const balanceAfter = await relay.getBalance(accounts[3].wallet.address, 'latest');
+        const balanceAfter = await relay.getBalance(accounts[2].wallet.address, 'latest');
         expect(info).to.have.property('contract_id');
         expect(info.contract_id).to.not.be.null;
         expect(info).to.have.property('created_contract_ids');

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -997,11 +997,11 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
           ...defaultLegacyTransactionData,
           value: ONE_TINYBAR,
           to: ethers.ZeroAddress,
-          nonce: await relay.getAccountNonce(accounts[2].address),
+          nonce: await relay.getAccountNonce(accounts[1].address),
           gasPrice: await relay.gasPrice(),
         };
 
-        const signedSendHbarTx = await accounts[2].wallet.signTransaction(sendHbarTx);
+        const signedSendHbarTx = await accounts[1].wallet.signTransaction(sendHbarTx);
         const error = predefined.INTERNAL_ERROR('Transaction execution returns a null value');
 
         await Assertions.assertPredefinedRpcError(error, sendRawTransaction, true, relay, [
@@ -1040,11 +1040,11 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             ...defaultLegacyTransactionData,
             value: ONE_TINYBAR,
             to: address,
-            nonce: await relay.getAccountNonce(accounts[2].address),
+            nonce: await relay.getAccountNonce(accounts[1].address),
             gasPrice: await relay.gasPrice(),
           };
 
-          const signedSendHbarTx = await accounts[2].wallet.signTransaction(sendHbarTx);
+          const signedSendHbarTx = await accounts[1].wallet.signTransaction(sendHbarTx);
           const txHash = await relay.sendRawTransaction(signedSendHbarTx);
           const txReceipt = await relay.pollForValidTransactionReceipt(txHash);
 
@@ -1077,11 +1077,11 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             ...defaultLegacyTransactionData,
             value: ONE_TINYBAR,
             to: address,
-            nonce: await relay.getAccountNonce(accounts[2].address),
+            nonce: await relay.getAccountNonce(accounts[1].address),
             gasPrice: await relay.gasPrice(),
           };
 
-          const signedSendHbarTx = await accounts[2].wallet.signTransaction(sendHbarTx);
+          const signedSendHbarTx = await accounts[1].wallet.signTransaction(sendHbarTx);
           const txHash = await relay.sendRawTransaction(signedSendHbarTx);
           const txReceipt = await relay.pollForValidTransactionReceipt(txHash);
 


### PR DESCRIPTION
### Description

This PR adds negative test coverage for HBAR transfer edge cases specific to Hedera behavior via eth_sendRawTransaction. The tests verify expected Hedera-specific reverts for:

- Sending HBARs to the zero address → expect INVALID_SOLIDITY_ADDRESS
- Sending HBARs to a long zero address below 359 (e.g., id = 100) → expect INVALID_CONTRACT_ID
- Sending HBARs to a non-existing long zero address between 750–1000 (e.g., id = 850) → expect INVALID_ALIAS_KEY
- Updated contract deployment fee assertion test for [HIP-1249](https://hips.hedera.com/hip/hip-1249) compatibility (eliminates 80% minimum charge rule). This feature was recently merged to HEAD of consensus main in this PR https://github.com/hiero-ledger/hiero-consensus-node/pull/20703.

New tests are added to the acceptance suite and XTS test suite to ensure proper validation of these edge cases.

### Related issue(s)

Fixes #4332

### Testing Guide

1. Run the acceptance test suite to verify the new negative tests: `npm run acceptancetest:xts`
2. Check that the tests correctly expect the specified Hedera-specific revert reasons (INVALID_SOLIDITY_ADDRESS, INVALID_CONTRACT_ID, INVALID_ALIAS_KEY) for the respective edge cases.

### Changes from original design (optional)

N/A

### Additional work needed (optional)

N/A

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
