### PR TITLE
feat: upgrade the logs object to include `blockТimestamp` field

### DIFF
--- a/packages/relay/src/lib/model.ts
+++ b/packages/relay/src/lib/model.ts
@@ -172,6 +172,7 @@ export class Log {
   public readonly address: string;
   public readonly blockHash: string;
   public readonly blockNumber: string;
+  public readonly blockTimestamp: string;
   public readonly data: string;
   public readonly logIndex: string;
   public readonly removed: boolean;
@@ -183,6 +184,7 @@ export class Log {
     this.address = args.address;
     this.blockHash = args.blockHash;
     this.blockNumber = args.blockNumber;
+    this.blockTimestamp = args.blockTimestamp;
     this.data = args.data;
     this.logIndex = args.logIndex;
     this.removed = args.removed;

--- a/packages/relay/src/lib/services/ethService/ethCommonService/CommonService.ts
+++ b/packages/relay/src/lib/services/ethService/ethCommonService/CommonService.ts
@@ -365,6 +365,7 @@ export class CommonService implements ICommonService {
       logs.push(
         new Log({
           address: log.address,
+          blockTimestamp: numberTo0x(log.timestamp.split('.')[0]),
           blockHash: toHash32(log.block_hash),
           blockNumber: numberTo0x(log.block_number),
           data: log.data,

--- a/packages/relay/src/lib/services/ethService/transactionService/TransactionService.ts
+++ b/packages/relay/src/lib/services/ethService/transactionService/TransactionService.ts
@@ -13,7 +13,6 @@ import { JsonRpcError, predefined } from '../../../errors/JsonRpcError';
 import { SDKClientError } from '../../../errors/SDKClientError';
 import { createTransactionFromContractResult, TransactionFactory } from '../../../factories/transactionFactory';
 import {
-  IRegularTransactionReceiptParams,
   ISyntheticTransactionReceiptParams,
   TransactionReceiptFactory,
 } from '../../../factories/transactionReceiptFactory';

--- a/packages/relay/src/lib/services/ethService/transactionService/TransactionService.ts
+++ b/packages/relay/src/lib/services/ethService/transactionService/TransactionService.ts
@@ -356,6 +356,7 @@ export class TransactionService implements ITransactionService {
         address: log.address,
         blockHash: toHash32(receiptResponse.block_hash),
         blockNumber: numberTo0x(receiptResponse.block_number),
+        blockTimestamp: numberTo0x(receiptResponse.timestamp.split('.')[0]),
         data: log.data,
         logIndex: numberTo0x(log.index),
         removed: false,
@@ -369,16 +370,13 @@ export class TransactionService implements ITransactionService {
       this.common.resolveEvmAddress(receiptResponse.to, requestDetails),
     ]);
 
-    const transactionReceiptParams: IRegularTransactionReceiptParams = {
+    return TransactionReceiptFactory.createRegularReceipt({
       effectiveGas,
       from,
       logs,
       receiptResponse,
       to,
-    };
-    const receipt: ITransactionReceipt = TransactionReceiptFactory.createRegularReceipt(transactionReceiptParams);
-
-    return receipt;
+    });
   }
 
   /**

--- a/packages/relay/tests/helpers.ts
+++ b/packages/relay/tests/helpers.ts
@@ -99,6 +99,7 @@ export const expectLogData = (res, log, tx) => {
   expect(res.address).to.eq(log.address);
   expect(res.blockHash).to.eq(toHash32(tx.block_hash));
   expect(res.blockHash.length).to.eq(66);
+  expect(res.blockTimestamp).to.eq(numberTo0x(tx.timestamp.split('.')[0]));
   expect(res.blockNumber).to.eq(numberTo0x(tx.block_number));
   expect(res.data).to.eq(log.data);
   expect(res.logIndex).to.eq(numberTo0x(log.index));

--- a/packages/relay/tests/lib/eth/eth_getBlockReceipts.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getBlockReceipts.spec.ts
@@ -213,6 +213,7 @@ describe('@ethGetBlockReceipts using MirrorNode', async function () {
       expect(receipts[1].logs.length).to.equal(1);
       expect(receipts[1].transactionHash).to.equal(defaultLogs1[0].transaction_hash);
       expect(receipts[1].transactionHash).to.equal(defaultLogs1[1].transaction_hash);
+      expect(receipts[1].logs[0].blockTimestamp).to.equal(numberTo0x(defaultLogs1[0].timestamp.split('.')[0]));
     });
 
     it('should handle null to field for contract creation transactions', async function () {

--- a/packages/relay/tests/lib/eth/eth_getBlockReceipts.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getBlockReceipts.spec.ts
@@ -6,13 +6,11 @@ import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 
 import { numberTo0x } from '../../../dist/formatters';
-import { predefined } from '../../../src';
 import { SDKClient } from '../../../src/lib/clients';
 import { EthImpl } from '../../../src/lib/eth';
 import { CacheService } from '../../../src/lib/services/cacheService/cacheService';
 import HAPIService from '../../../src/lib/services/hapiService/hapiService';
 import { RequestDetails } from '../../../src/lib/types';
-import RelayAssertions from '../../assertions';
 import { defaultContractResults, defaultContractResultsOnlyHash2, defaultLogs1 } from '../../helpers';
 import {
   BLOCK_HASH,

--- a/packages/relay/tests/lib/eth/eth_getTransactionReceipt.spec.ts
+++ b/packages/relay/tests/lib/eth/eth_getTransactionReceipt.spec.ts
@@ -95,6 +95,7 @@ describe('@ethGetTransactionReceipt eth_getTransactionReceipt tests', async func
         address: '0x0000000000000000000000000000000000001389',
         blockHash: '0xd693b532a80fed6392b428604171fb32fdbf953728a3a7ecc7d4062b1652c042',
         blockNumber: '0x11',
+        blockTimestamp: '0x167654',
         data: '0x0123',
         logIndex: '0x0',
         removed: false,


### PR DESCRIPTION
### Description

[geth 1.16.0](https://github.com/ethereum/go-ethereum/releases/tag/v1.16.0) updated https://github.com/ethereum/go-ethereum/pull/31887 to return receipt for logs containing the blockTimestamp info, as proposed by https://github.com/ethereum/execution-apis/pull/639.

### Solution

Upgrade the relay to comply with the new logs receipt format.

**Affected methods:**
- `eth_getLogs`
- `eth_getTransactionReceipt`
- `eth_getBlockReceipt`
- `eth_getFilterLogs`
- `eth_getFilterChanges`

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #3890

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1.
2.
3.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
