### PR TITLE
feat: use a different RequestID for each ws request within a single connection

### DIFF
--- a/packages/ws-server/src/webSocketServer.ts
+++ b/packages/ws-server/src/webSocketServer.ts
@@ -33,12 +33,16 @@ const mainLogger = pino({
   // https://github.com/pinojs/pino/blob/main/docs/api.md#mixin-function
   mixin: () => {
     const store = context.getStore();
-    return store
-      ? {
-          connectionId: `[Connection ID: ${store.connectionId}] `,
-          requestId: `[Request ID: ${store.requestId}] `,
-        }
-      : {};
+    if (store) {
+      // generate a new uuid for each request within a single connection
+      store.requestId = uuid();
+
+      return {
+        connectionId: `[Connection ID: ${store.connectionId}] `,
+        requestId: `[Request ID: ${store.requestId}] `,
+      };
+    }
+    return {};
   },
   transport: {
     target: 'pino-pretty',

--- a/packages/ws-server/src/webSocketServer.ts
+++ b/packages/ws-server/src/webSocketServer.ts
@@ -33,16 +33,12 @@ const mainLogger = pino({
   // https://github.com/pinojs/pino/blob/main/docs/api.md#mixin-function
   mixin: () => {
     const store = context.getStore();
-    if (store) {
-      // generate a new uuid for each request within a single connection
-      store.requestId = uuid();
-
-      return {
-        connectionId: `[Connection ID: ${store.connectionId}] `,
-        requestId: `[Request ID: ${store.requestId}] `,
-      };
-    }
-    return {};
+    return store
+      ? {
+          connectionId: `[Connection ID: ${store.connectionId}] `,
+          requestId: `[Request ID: ${store.requestId}] `,
+        }
+      : {};
   },
   transport: {
     target: 'pino-pretty',
@@ -75,10 +71,8 @@ const app = websockify(new Koa());
 
 app.ws.use((ctx: Koa.Context, next: Koa.Next) => {
   const connectionId = subscriptionService.generateId();
-  const requestId = uuid();
   ctx.websocket.id = connectionId;
-  ctx.websocket.requestId = requestId;
-  return context.run({ requestId, connectionId }, next);
+  next();
 });
 
 app.ws.use(async (ctx: Koa.Context) => {
@@ -89,12 +83,6 @@ app.ws.use(async (ctx: Koa.Context) => {
   const startTime = process.hrtime();
   ctx.websocket.limiter = limiter;
   ctx.websocket.wsMetricRegistry = wsMetricRegistry;
-
-  const requestDetails = new RequestDetails({
-    requestId: ctx.websocket.requestId,
-    ipAddress: ctx.request.ip,
-    connectionId: ctx.websocket.id,
-  });
 
   logger.info(
     // @ts-ignore
@@ -119,9 +107,17 @@ app.ws.use(async (ctx: Koa.Context) => {
   limiter.applyLimits(ctx);
 
   // listen on message event
-  ctx.websocket.on(
-    'message',
-    AsyncResource.bind(async (msg) => {
+  ctx.websocket.on('message', async (msg) => {
+    const requestId = uuid();
+    ctx.websocket.requestId = requestId;
+
+    const requestDetails = new RequestDetails({
+      requestId,
+      ipAddress: ctx.request.ip,
+      connectionId: ctx.websocket.id,
+    });
+
+    context.run({ requestId, connectionId: requestDetails.connectionId! }, async () => {
       // Increment the total messages counter for each message received
       wsMetricRegistry.getCounter('totalMessageCounter').inc();
 
@@ -229,8 +225,8 @@ app.ws.use(async (ctx: Koa.Context) => {
       // Update the connection duration histogram with the calculated duration
       const methodLabel = Array.isArray(request) ? WS_CONSTANTS.BATCH_REQUEST_METHOD_NAME : request.method;
       wsMetricRegistry.getHistogram('messageDuration').labels(methodLabel).observe(msgDurationInMiliSeconds);
-    }),
-  );
+    });
+  });
 
   if (pingInterval > 0) {
     setInterval(async () => {


### PR DESCRIPTION
### Description

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

WebSocket Request ID stays the same for multiple requests within the Connection ID.

For example, the following logs were obtained first connecting to the WebSocket, then making two requests (`eth_chainId` in this case) and finally disconnecting

```txt
INFO: [Connection ID: 0x77a0021d80263409155d8b45116d9283] [Request ID: 9695871f-59f8-4acd-a528-be1716e3e135] New connection established. Current active connections: 1
TRACE: [Connection ID: 0x77a0021d80263409155d8b45116d9283] [Request ID: 9695871f-59f8-4acd-a528-be1716e3e135]: Receive single request={"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}
TRACE: [Connection ID: 0x77a0021d80263409155d8b45116d9283] [Request ID: 9695871f-59f8-4acd-a528-be1716e3e135]: Submitting request={"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]} to relay.
TRACE: [Request ID: 9695871f-59f8-4acd-a528-be1716e3e135] chainId()
TRACE: [Connection ID: 0x77a0021d80263409155d8b45116d9283] [Request ID: 9695871f-59f8-4acd-a528-be1716e3e135]: Sending result={"result":"0x128","jsonrpc":"2.0","id":1} to client for request={"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}
TRACE: [Connection ID: 0x77a0021d80263409155d8b45116d9283] [Request ID: 9695871f-59f8-4acd-a528-be1716e3e135]: Receive single request={"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}
TRACE: [Connection ID: 0x77a0021d80263409155d8b45116d9283] [Request ID: 9695871f-59f8-4acd-a528-be1716e3e135]: Submitting request={"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]} to relay.
TRACE: [Request ID: 9695871f-59f8-4acd-a528-be1716e3e135] chainId()
TRACE: [Connection ID: 0x77a0021d80263409155d8b45116d9283] [Request ID: 9695871f-59f8-4acd-a528-be1716e3e135]: Sending result={"result":"0x128","jsonrpc":"2.0","id":1} to client for request={"jsonrpc":"2.0","id":1,"method":"eth_chainId","params":[]}
INFO: [Connection ID: 0x77a0021d80263409155d8b45116d9283] [Request ID: 9695871f-59f8-4acd-a528-be1716e3e135] Closing connection 0x77a0021d80263409155d8b45116d9283 | code: 1000, message: 
INFO: Connection 0x77a0021d80263409155d8b45116d9283: Unsubscribing from all subscriptions
```

_removed time, logger name, pid and host name from logs to improve readability_

Note how both Connection ID and Request ID stay the same across the duration of the connection.

Each individual request should have its own Request ID instead.

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #4083 

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1.
2.
3.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
