### PR TITLE
feat: improve error handling in SDKClient.executeTransaction to preserve original error details

### DIFF
--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -329,15 +329,7 @@ export class SDKClient {
       }
 
       if (!transactionResponse) {
-        // Transactions may experience "SDK timeout exceeded" or "Connection Dropped" errors from the SDK, yet they may still be able to reach the consensus layer.
-        // Throw Connection Drop and Timeout errors as additional handling logic is expected in a higher layer.
-        if (sdkClientError.isConnectionDropped() || sdkClientError.isTimeoutExceeded()) {
-          throw sdkClientError;
-        } else {
-          throw predefined.INTERNAL_ERROR(
-            `Transaction execution returns a null value: transactionId=${transaction.transactionId}, callerName=${callerName}, txConstructorName=${txConstructorName}`,
-          );
-        }
+        throw sdkClientError;
       }
       return transactionResponse;
     } finally {

--- a/packages/relay/tests/lib/sdkClient.spec.ts
+++ b/packages/relay/tests/lib/sdkClient.spec.ts
@@ -435,6 +435,22 @@ describe('SdkClient', async function () {
         await expect(callSubmit(buffer)).to.be.rejectedWith(SDKClientError, 'No fileId created for transaction.');
       });
     });
+
+    it('should wrap every error in a SDKClientError if transaction execution fails', async () => {
+      sinon.stub(EthereumTransaction.prototype, 'execute').throwsException();
+
+      expect(
+        sdkClient.executeTransaction(
+          new EthereumTransaction().setCallDataFileId(fileId).setEthereumData(transactionBuffer),
+          mockedCallerName,
+          requestDetails,
+          true,
+          randomAccountAddress,
+        ),
+      ).to.eventually.be.rejected.and.satisfy((err: any) => {
+        expect(err?.constructor?.name).to.equal(SDKClientError.constructor.name);
+      });
+    });
   });
 
   describe('HBAR Limiter', async () => {


### PR DESCRIPTION
### Description

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

In `packages/relay/src/lib/clients/sdkClient.ts`, the `executeTransaction` method has inconsistent error handling when `!transactionResponse`. Currently:

- For "Connection Dropped" or "timeout exceeded" errors: throws `sdkClientError` (preserving original error details)
- For all other SDK errors: throws `INTERNAL_ERROR` with a generic message that doesn't include the original error details

This obfuscates the real reason for failure from the network, making debugging more difficult.

### Solution


Always throw `sdkClientError` when `!transactionResponse`, so that specific error details (status, message, transactionId, nodeAccountId) are preserved and can reach the client for better debugging.

```typescript
if (!transactionResponse) {
  throw sdkClientError;
}
```

### Impact

- Better error reporting to clients
- More consistent error handling across the codebase
- Improved debugging capabilities
- No breaking changes to existing error handling logic in higher layers

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #4353 

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1.
2.
3.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
