### PR TITLE
feat: remove caching from getTransactionCount with block tag = latest

### DIFF
--- a/packages/relay/src/lib/services/ethService/accountService/AccountService.ts
+++ b/packages/relay/src/lib/services/ethService/accountService/AccountService.ts
@@ -311,10 +311,10 @@ export class AccountService implements IAccountService {
       return await this.getAccountNonceForHistoricBlock(address, blockNum, requestDetails);
     } else if (blockNumOrTag.length == constants.BLOCK_HASH_LENGTH && blockNumOrTag.startsWith(constants.EMPTY_HEX)) {
       return await this.getAccountNonceForHistoricBlock(address, blockNumOrTag, requestDetails);
-    } else {
-      // return a '-39001: Unknown block' error per api-spec
-      throw predefined.UNKNOWN_BLOCK();
     }
+
+    // return a '-39001: Unknown block' error per api-spec
+    throw predefined.UNKNOWN_BLOCK();
   }
 
   /**


### PR DESCRIPTION
### Description

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

Currently, we cache getTransactionCount("latest") with ttl 500ms, however, we may still return an old value that is not relevant, if e.g we cache the getTransactionCount("latest") for 500ms, but after 300ms a new block is mined, the value needs to be updated, but we will still return the older value.

### Motivation

Avoid returning an old value on request to `eth_getTransctionCount` with block tag = latest


### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #4389 

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1.
2.
3.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
