### PR TITLE
feat: add optional stateOverride parameter validation to eth_call

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -968,6 +968,7 @@ export class EthImpl implements Eth {
   @rpcParamValidationRules({
     0: { type: 'transaction', required: true },
     1: { type: 'blockParams', required: true },
+    2: { type: 'stateOverride', required: false },
   })
   @cache({
     skipParams: [{ index: '1', value: constants.NON_CACHABLE_BLOCK_PARAMS }],

--- a/packages/relay/src/lib/validators/types.ts
+++ b/packages/relay/src/lib/validators/types.ts
@@ -150,6 +150,14 @@ export const TYPES = {
     },
     error: 'Expected TracerConfigWrapper which contains a valid TracerType and/or TracerConfig',
   },
+  stateOverride: {
+    test: (param: any) => {
+      // Must be an object if provided
+      // TODO: This validation should be more detailed when state override is officially supported.
+      return typeof param === 'object' && !Array.isArray(param);
+    },
+    error: 'Expected StateOverride object (currently accepting any object structure)',
+  },
 } satisfies {
   [paramTypeName: string]: {
     test: (param: any) => boolean;

--- a/packages/server/tests/acceptance/rpc_batch3.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch3.spec.ts
@@ -2094,6 +2094,7 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
           data: '0x70a082310000000000000000000000006E0d01A76C3Cf4288372a29124A26D4353EE51BE',
         },
         'latest',
+        {},
         null,
       ],
       eth_getTransactionByHash: ['0x4cc9a77780cf0e6d0dc75373bf00e3437db450ede45cb51b5da936fb46342c99', null],


### PR DESCRIPTION
### Description

Adds support for the optional `stateOverride` parameter to the `eth_call` JSON-RPC method to maintain compatibility with client tools.

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #4417

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
