### PR TITLE
feat: use `amountSentLD` in `.transferToken` on `_debit` function in LayerZero HTSConnector

### DIFF
--- a/tools/layer-zero-example/contracts/HTSConnector.sol
+++ b/tools/layer-zero-example/contracts/HTSConnector.sol
@@ -88,7 +88,7 @@ abstract contract HTSConnector is OFTCore, KeyHelper, HederaTokenService {
 
         (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
 
-        int256 transferResponse = HederaTokenService.transferToken(htsTokenAddress, _from, address(this), int64(uint64(_amountLD)));
+        int256 transferResponse = HederaTokenService.transferToken(htsTokenAddress, _from, address(this), int64(uint64(amountSentLD)));
         require(transferResponse == HederaTokenService.SUCCESS_CODE, "HTS: Transfer failed");
 
         (int256 response,) = HederaTokenService.burnToken(htsTokenAddress, int64(uint64(amountSentLD)), new int64[](0));

--- a/tools/layer-zero-example/contracts/HTSConnectorExistingToken.sol
+++ b/tools/layer-zero-example/contracts/HTSConnectorExistingToken.sol
@@ -60,7 +60,7 @@ abstract contract HTSConnectorExistingToken is OFTCore, KeyHelper, HederaTokenSe
     ) internal virtual override returns (uint256 amountSentLD, uint256 amountReceivedLD) {
         (amountSentLD, amountReceivedLD) = _debitView(_amountLD, _minAmountLD, _dstEid);
 
-        int256 transferResponse = HederaTokenService.transferToken(htsTokenAddress, _from, address(this), int64(uint64(_amountLD)));
+        int256 transferResponse = HederaTokenService.transferToken(htsTokenAddress, _from, address(this), int64(uint64(amountSentLD)));
         require(transferResponse == HederaTokenService.SUCCESS_CODE, "HTS: Transfer failed");
 
         (int256 response,) = HederaTokenService.burnToken(htsTokenAddress, int64(uint64(amountSentLD)), new int64[](0));


### PR DESCRIPTION
### Description

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->
In the debit function, there is a call to the debitView function, which returns an `amountSentLD`, but in the transfer function, `_amountLD` is used.

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #4448 

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1.
2.
3.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
