### PR TITLE
chore: update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3239,6 +3239,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/@lerna/create/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.4.tgz",
@@ -11860,6 +11873,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/lerna/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/leven": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
@@ -19785,13 +19811,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "packages/server/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/server/node_modules/axios-retry": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
@@ -20185,13 +20204,6 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
-    },
-    "packages/ws-server/node_modules/@types/node": {
-      "version": "17.0.45",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "dev": true,
-      "license": "MIT"
     },
     "packages/ws-server/node_modules/axios-retry": {
       "version": "4.5.0",
@@ -21940,12 +21952,6 @@
             "@noble/hashes": "1.3.2"
           }
         },
-        "@types/node": {
-          "version": "17.0.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-          "dev": true
-        },
         "axios-retry": {
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
@@ -22225,12 +22231,6 @@
           "requires": {
             "@noble/hashes": "1.3.2"
           }
-        },
-        "@types/node": {
-          "version": "17.0.45",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-          "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-          "dev": true
         },
         "axios-retry": {
           "version": "4.5.0",
@@ -23361,6 +23361,11 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "uuid": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+          "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="
         }
       }
     },
@@ -29547,6 +29552,11 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        },
+        "uuid": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+          "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="
         }
       }
     },
@@ -30216,7 +30226,7 @@
       "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
       "dev": true,
       "requires": {
-        "semver": "^7.5.3"
+        "semver": "^6.0.0"
       }
     },
     "make-error": {


### PR DESCRIPTION
### Description

This PR fixes a critical CI failure where all PRs are blocked due to `package.json` and `package-lock.json` being out of sync. The `npm ci` command fails because the lock file is missing the `uuid@11.1.0` dependency. This resolves the issue by updating `package-lock.json` to match the current `package.json`.

### Related issue(s)

Fixes #4548

### Testing Guide

1. Run `npm ci` locally to verify the lock file is now in sync with `package.json`
2. Trigger a CI build on this PR and confirm the npm install step passes
3. Verify no build errors occur in the next stage after npm install

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
