### PR TITLE
fix: replace fee collector account in Postman tests to prevent CI timeouts

### DIFF
--- a/charts/hedera-json-rpc-relay/postman.json
+++ b/charts/hedera-json-rpc-relay/postman.json
@@ -272,7 +272,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getBalance\",\n    \"params\": [\"0x0000000000000000000000000000000000000062\", \"latest\"]\n}",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getBalance\",\n    \"params\": [\"0x0000000000000000000000000000000000000002\", \"latest\"]\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -1033,7 +1033,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getTransactionCount\",\n    \"params\": [\n        \"0x0000000000000000000000000000000000000062\", \"latest\"\n    ]\n}",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getTransactionCount\",\n    \"params\": [\n        \"0x0000000000000000000000000000000000000002\", \"latest\"\n    ]\n}",
           "options": {
             "raw": {
               "language": "json"

--- a/packages/server/tests/postman.json
+++ b/packages/server/tests/postman.json
@@ -272,7 +272,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getBalance\",\n    \"params\": [\"0x0000000000000000000000000000000000000062\", \"latest\"]\n}",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getBalance\",\n    \"params\": [\"0x0000000000000000000000000000000000000002\", \"latest\"]\n}",
           "options": {
             "raw": {
               "language": "json"
@@ -1073,7 +1073,7 @@
         "header": [],
         "body": {
           "mode": "raw",
-          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getTransactionCount\",\n    \"params\": [\n        \"0x0000000000000000000000000000000000000062\", \"latest\"\n    ]\n}",
+          "raw": "{\n    \"id\": \"test_id\",\n    \"jsonrpc\": \"2.0\",\n    \"method\": \"eth_getTransactionCount\",\n    \"params\": [\n        \"0x0000000000000000000000000000000000000002\", \"latest\"\n    ]\n}",
           "options": {
             "raw": {
               "language": "json"


### PR DESCRIPTION
### Description

This PR fixes the chart install workflow failures in CI by updating the test account used in Postman tests from the fee collector account (0.0.98 / `0x0000000000000000000000000000000000000062`) to account 0.0.2 (`0x0000000000000000000000000000000000000002`).

The root cause was that the fee collector account has billions of transactions in its history, causing the testnet mirror node to time out (503 Service Unavailable after ~20 seconds) when trying to fetch account information. This resulted in consistent failures during the `ct install` step of the chart installation workflow.

This is an immediate workaround that unblocks CI with no code changes to the relay itself.

### Related issue(s)

Fixes #4545

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
