### PR TITLE
feat: adds `cache:` prefix to all CacheService keys

### DIFF
--- a/packages/relay/src/lib/services/transactionPoolService/RedisPendingTransactionStorage.ts
+++ b/packages/relay/src/lib/services/transactionPoolService/RedisPendingTransactionStorage.ts
@@ -9,9 +9,11 @@ export class RedisPendingTransactionStorage implements PendingTransactionStorage
    * Prefix used to namespace all keys managed by this storage.
    *
    * @remarks
-   * Using a prefix allows efficient scanning and cleanup of related keys
+   * Using a prefix allows efficient scanning and cleanup of related keys.
+   * Uses 'txpool:pending:' to distinguish from other transaction pool states
+   * (e.g., future 'txpool:queue:').
    */
-  private readonly keyPrefix = 'pending:';
+  private readonly keyPrefix = 'txpool:pending:';
 
   /**
    * The time-to-live (TTL) for the pending transaction storage in seconds.
@@ -29,7 +31,7 @@ export class RedisPendingTransactionStorage implements PendingTransactionStorage
    * Resolves the Redis key for a given address.
    *
    * @param addr - Account address whose pending list key should be derived.
-   * @returns The Redis key (e.g., `pending:<address>`).
+   * @returns The Redis key (e.g., `txpool:pending:<address>`).
    */
   private keyFor(address: string): string {
     return `${this.keyPrefix}${address}`;
@@ -67,7 +69,7 @@ export class RedisPendingTransactionStorage implements PendingTransactionStorage
   }
 
   /**
-   * Removes all keys managed by this storage (all `pending:*`).
+   * Removes all keys managed by this storage (all `txpool:pending:*`).
    */
   async removeAll(): Promise<void> {
     const keys = await this.redisClient.keys(`${this.keyPrefix}*`);

--- a/packages/relay/tests/lib/clients/localLRUCache.spec.ts
+++ b/packages/relay/tests/lib/clients/localLRUCache.spec.ts
@@ -179,7 +179,7 @@ describe('LocalLRUCache Test Suite', async function () {
         const ttl = -1;
 
         await customLocalLRUCache.set(key, value, callingMethod, ttl);
-        sinon.assert.calledOnceWithExactly(lruCacheSpy.set, key, value, { ttl: 0 });
+        sinon.assert.calledOnceWithExactly(lruCacheSpy.set, `cache:${key}`, value, { ttl: 0 });
 
         const cachedValue = await customLocalLRUCache.get(key, callingMethod);
         expect(cachedValue).equal(value);


### PR DESCRIPTION
### Description

`CacheService` stores Redis keys without a prefix, while other services use prefixes (`pending:*`, `hbar-limit:*`, etc.). This causes:

1. **Unsafe clearing**: `CacheService.clear()` can't distinguish its keys from others, so we hardcode a filter:
   ```typescript
   const keysToDelete = allKeys.filter((key) => !key.startsWith('pending:'));
   ```
   This couples RedisCache to TransactionPoolService and doesn't scale.

2. **No ownership**: Can't tell which keys belong to which service.

3. **Maintenance burden**: Every new Redis user must update the filter.

This PR solves that by adding the prefix to all CacheService keys. The `pending:` key was also changed to `txpool:pending`. All tests have been added to reflect that.

### Related issue(s)

Fixes #4501 

### Testing Guide

1. Call any method using cache
2. Check keys in Redis

### Changes from original design (optional)

N/A

### Additional work needed (optional)

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
