### PR TITLE
fix: non existing from triggers validation error now

### DIFF
--- a/packages/server/tests/acceptance/data/conformity-tests-batch-4.json
+++ b/packages/server/tests/acceptance/data/conformity-tests-batch-4.json
@@ -1,7 +1,7 @@
 {
   "eth_call - non existing contract": {
     "request": "{\"method\":\"eth_call\",\"params\":[{\"from\":\"0x6b175474e89094c44da98b954eedeac495271d0f\",\"to\":\"0x6b175474e89094c44da98b954eedeac495271d0f\",\"data\":\"0x70a082310000000000000000000000006E0d01A76C3Cf4288372a29124A26D4353EE51BE\"},\"latest\"],\"id\":1,\"jsonrpc\":\"2.0\"}",
-    "response": "{\"result\":\"0x\",\"jsonrpc\":\"2.0\",\"id\":1}"
+    "response": "{\"error\":{\"code\":3,\"message\":\"[Request ID: cdbdf697-85ab-4cc3-8723-fd6cc25a3763] execution reverted: Sender account not found.\",\"data\":\"\"},\"jsonrpc\":\"2.0\",\"id\":1}"
   },
   "eth_call - existing contract view function and existing from": {
     "request": "{\"method\":\"eth_call\",\"params\":[{\"from\":\"0x6b175474e89094c44da98b954eedeac495271d0f\",\"to\":\"0x6b175474e89094c44da98b954eedeac495271d0f\",\"data\":\"0x70a082310000000000000000000000006E0d01A76C3Cf4288372a29124A26D4353EE51BE\"},\"latest\"],\"id\":1,\"jsonrpc\":\"2.0\"}",
@@ -17,15 +17,15 @@
   },
   "eth_call - existing contract view function and non-existing from": {
     "request": "{\"method\":\"eth_call\",\"params\":[{\"from\":\"0x6b175474e89094c44da98b954eedeac495271d0f\",\"to\":\"0x6b175474e89094c44da98b954eedeac495271d0f\",\"data\":\"0x70a082310000000000000000000000006E0d01A76C3Cf4288372a29124A26D4353EE51BE\"},\"latest\"],\"id\":1,\"jsonrpc\":\"2.0\"}",
-    "response": "{\"result\":\"0x0000000000000000000000000000000000000000000000000000000000000004\",\"jsonrpc\":\"2.0\",\"id\":1}"
+    "response": "{\"error\":{\"code\":3,\"message\":\"[Request ID: cdbdf697-85ab-4cc3-8723-fd6cc25a3763] execution reverted: Sender account not found.\",\"data\":\"\"},\"jsonrpc\":\"2.0\",\"id\":1}"
   },
   "eth_call - existing contract tx and non-existing from": {
     "request": "{\"method\":\"eth_call\",\"params\":[{\"from\":\"0x6b175474e89094c44da98b954eedeac495271d0f\",\"to\":\"0x6b175474e89094c44da98b954eedeac495271d0f\",\"data\":\"0x70a082310000000000000000000000006E0d01A76C3Cf4288372a29124A26D4353EE51BE\"},\"latest\"],\"id\":1,\"jsonrpc\":\"2.0\"}",
-    "response": "{\"result\":\"0x0000000000000000000000000000000000000000000000000000000000000000\",\"jsonrpc\":\"2.0\",\"id\":1}"
+    "response": "{\"error\":{\"code\":3,\"message\":\"[Request ID: cdbdf697-85ab-4cc3-8723-fd6cc25a3763] execution reverted: Sender account not found.\",\"data\":\"\"},\"jsonrpc\":\"2.0\",\"id\":1}"
   },
   "eth_call - existing contract tx, non-existing from and positive value": {
     "request": "{\"method\":\"eth_call\",\"params\":[{\"from\":\"0x6b175474e89094c44da98b954eedeac495271d0f\",\"to\":\"0x6b175474e89094c44da98b954eedeac495271d0f\",\"data\":\"0x70a082310000000000000000000000006E0d01A76C3Cf4288372a29124A26D4353EE51BE\",\"value\":\"0x2540be400\"},\"latest\"],\"id\":1,\"jsonrpc\":\"2.0\"}",
-    "response": "{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":[]}"
+    "response": "{\"error\":{\"code\":3,\"message\":\"[Request ID: cdbdf697-85ab-4cc3-8723-fd6cc25a3763] execution reverted: Sender account not found.\",\"data\":\"\"},\"jsonrpc\":\"2.0\",\"id\":1}"
   },
   "eth_estimateGas - non existing contract": {
     "request": "{\"method\":\"eth_estimateGas\",\"params\":[{\"from\":\"0x6b175474e89094c44da98b954eedeac495271d0f\",\"to\":\"0x6b175474e89094c44da98b954eedeac495271d0f\",\"data\":\"0x70a082310000000000000000000000006E0d01A76C3Cf4288372a29124A26D4353EE51BE\"},\"latest\"],\"id\":1,\"jsonrpc\":\"2.0\"}",


### PR DESCRIPTION
### Description

The eth_call request will now trigger a validation error if the from field contains a non-existent account address. We need to update the tests to accept this new behavior.

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #4575

### Testing Guide

Github actions output check.

