### PR TITLE
fix: removed caching logic for eth_gasPrice endpoint

### DIFF
--- a/packages/relay/src/lib/eth.ts
+++ b/packages/relay/src/lib/eth.ts
@@ -290,9 +290,6 @@ export class EthImpl implements Eth {
    */
   @rpcMethod
   @rpcParamLayoutConfig(RPC_LAYOUT.REQUEST_DETAILS_ONLY)
-  @cache({
-    ttl: constants.CACHE_TTL.FIFTEEN_MINUTES,
-  })
   async gasPrice(requestDetails: RequestDetails): Promise<string> {
     return this.common.gasPrice(requestDetails);
   }


### PR DESCRIPTION
### Description

This PR removes the caching decorator from the `eth_gasPrice` method to resolve MetaMask wallet failures caused by stale gas price values. The current 15-minute cache TTL misaligns with hourly gas price changes, causing intermittent transaction failures. This hotfix ensures accurate, real-time gas prices are returned on every call.

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #4583

### Testing Guide

1. Run the unit tests:
2. Verify the new test "eth_gasPrice does not use cache and returns updated values" passes
3. Verify the skipped test "eth_gasPrice with cached value" remains skipped (xit)
4. Manually test: Call `eth_gasPrice` twice with network fees changing between calls and see no caching in place

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

Future ticket: Implement a more sophisticated caching solution that aligns cache expiration with hourly gas price changes and includes proper cache invalidation on hour boundaries.

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
