### PR TITLE
test: add tests for createTransactionByType and createTransactionFromLog

### DIFF
--- a/packages/relay/src/lib/factories/transactionFactory.ts
+++ b/packages/relay/src/lib/factories/transactionFactory.ts
@@ -17,7 +17,7 @@ import { Log, Transaction, Transaction1559, Transaction2930 } from '../model';
 
 // TransactionFactory is a factory class that creates a Transaction object based on the type of transaction.
 export class TransactionFactory {
-  public static createTransactionByType(type: 2, fields: any): Transaction1559;
+  public static createTransactionByType(type: number, fields: any): Transaction1559;
 
   public static createTransactionByType(type: number, fields: any): Transaction | null {
     switch (type) {


### PR DESCRIPTION
### Description

1. Added unit tests for createTransactionByType and createTransactionFromLog methods.
2. Updated the declared interface of TransactionFactory.createTransactionByType to match its actual implementation (numeric values are allowed, other than 2).

### Related issue(s)

Fixes #4209

### Testing Guide


1. Run tests
```
npx lerna run test
```
2. check if the coverage for mentioned methods is 100% in packages/relay/coverage/index.html file

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
