### PR TITLE
test: stabilize tests by adjusting time waiting for mine and price tolerance (#4658)

### DIFF
--- a/packages/server/tests/acceptance/hbarLimiter.spec.ts
+++ b/packages/server/tests/acceptance/hbarLimiter.spec.ts
@@ -330,6 +330,7 @@ describe('@hbarlimiter HBAR Limiter Acceptance Tests', function () {
         });
 
         it('should deploy a large contract and decrease remaining HBAR in limiter when transaction data is large', async function () {
+          overrideEnvsInMochaDescribe({ TEST_TRANSACTION_RECORD_COST_TOLERANCE: 0.25 });
           const initialRemainingHbars = Number(await metrics.get(testConstants.METRICS.REMAINING_HBAR_LIMIT));
           expect(initialRemainingHbars).to.be.gt(0);
 

--- a/packages/server/tests/acceptance/rpc_batch1.spec.ts
+++ b/packages/server/tests/acceptance/rpc_batch1.spec.ts
@@ -688,7 +688,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
       it('should not cache "latest" block in "eth_getBlockByNumber" ', async function () {
         const blockResult = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER, ['latest', false]);
-        await Utils.wait(1000);
+        await Utils.wait(2000);
 
         const blockResult2 = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER, ['latest', false]);
         expect(blockResult).to.not.deep.equal(blockResult2);
@@ -696,7 +696,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
       it('should not cache "finalized" block in "eth_getBlockByNumber" ', async function () {
         const blockResult = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER, ['finalized', false]);
-        await Utils.wait(1000);
+        await Utils.wait(2000);
 
         const blockResult2 = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER, ['finalized', false]);
         expect(blockResult).to.not.deep.equal(blockResult2);
@@ -704,7 +704,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
       it('should not cache "safe" block in "eth_getBlockByNumber" ', async function () {
         const blockResult = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER, ['safe', false]);
-        await Utils.wait(1000);
+        await Utils.wait(2000);
 
         const blockResult2 = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER, ['safe', false]);
         expect(blockResult).to.not.deep.equal(blockResult2);
@@ -712,7 +712,7 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
 
       it('should not cache "pending" block in "eth_getBlockByNumber" ', async function () {
         const blockResult = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER, ['pending', false]);
-        await Utils.wait(1000);
+        await Utils.wait(2000);
 
         const blockResult2 = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BLOCK_BY_NUMBER, ['pending', false]);
         expect(blockResult).to.not.deep.equal(blockResult2);


### PR DESCRIPTION
### Description
Making some of the tests that fail during GitHub Actions runs more stable, focusing on those whose failure messages don’t clearly indicate whether the cause is nondeterministic:
1. A test which fails because the block hasn’t been mined yet.
2. A test which fails because it wasn’t executed with the expected price limits.

### Related issue(s)

Fixes #4658

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1. Run tests in GH action

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
