### PR TITLE
feat: set cors aligned with other json rpc providers (#4671)

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -5,8 +5,8 @@ import { AsyncLocalStorage } from 'node:async_hooks';
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
 import { Relay } from '@hashgraph/json-rpc-relay/dist';
 import { RedisClientManager } from '@hashgraph/json-rpc-relay/dist/lib/clients/redisClientManager';
-import cors from '@koa/cors';
 import { RateLimitStoreFactory } from '@hashgraph/json-rpc-relay/dist/lib/services';
+import cors from '@koa/cors';
 import fs from 'fs';
 import path from 'path';
 import pino from 'pino';
@@ -202,7 +202,7 @@ export async function initializeServer() {
   });
 
   // Set CORS
-  app.use(cors());
+  app.use(cors({ allowMethods: ['GET', 'POST'] }));
 
   // Middleware for non POST request timing
   app.use(async (ctx, next) => {

--- a/packages/server/tests/integration/server.spec.ts
+++ b/packages/server/tests/integration/server.spec.ts
@@ -102,8 +102,8 @@ describe('RPC Server', function () {
       ).to.have.property('access-control-allow-methods');
       expect(
         response.headers['access-control-allow-methods'],
-        "Preflight response: 'headers[access-control-allow-methods]' should equal 'GET,HEAD,PUT,POST,DELETE,PATCH'",
-      ).to.be.equal('GET,HEAD,PUT,POST,DELETE,PATCH');
+        "Preflight response: 'headers[access-control-allow-methods]' should equal 'GET,POST'",
+      ).to.be.equal('GET,POST');
 
       BaseTest.validCorsCheck(response);
     });


### PR DESCRIPTION
### Description

Configuring koa/cors lib to return GET and POST in allowed methods header to algin wth other json rpc providers behaviour.

### Related issue(s)

Fixes #4671

### Testing Guide

1. Run tests (server.spec.ts), HTTP Endpoints -> should execute HTTP OPTIONS cors preflight check and see if they pass.

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
