### PR TITLE
fix: move ethereum conformity methods into service (#4716)

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -17,10 +17,7 @@ import { formatRequestIdMessage } from './formatters';
 import KoaJsonRpc from './koaJsonRpc';
 import { spec } from './koaJsonRpc/lib/RpcError';
 import { getLimitDuration } from './koaJsonRpc/lib/utils';
-import {
-  EthereumRPCConformityService,
-  INVALID_METHOD_RESPONSE_BODY,
-} from './koaJsonRpc/services/EthereumRPCConformityService';
+import EthereumRPCConformityService from './koaJsonRpc/services/EthereumRPCConformityService';
 
 // https://nodejs.org/api/async_context.html#asynchronous-context-tracking
 const context = new AsyncLocalStorage<{ requestId: string }>();
@@ -49,6 +46,8 @@ const mainLogger = pino({
     },
   }),
 });
+
+const ethereumRPCConformityService = new EthereumRPCConformityService();
 
 export const logger = mainLogger.child({ name: 'rpc-server' });
 export const register = new Registry();
@@ -307,7 +306,7 @@ export async function initializeServer() {
       ctx.status = 200;
     } else {
       ctx.status = 405;
-      ctx.body = structuredClone(INVALID_METHOD_RESPONSE_BODY);
+      ctx.body = EthereumRPCConformityService.INVALID_METHOD_RESPONSE_BODY;
     }
   });
 
@@ -339,7 +338,7 @@ export async function initializeServer() {
 
   app.use(async (ctx) => {
     await rpcApp(ctx);
-    EthereumRPCConformityService.ensureEthereumJsonRpcCompliance(ctx);
+    ethereumRPCConformityService.ensureEthereumJsonRpcCompliance(ctx);
   });
 
   process.on('unhandledRejection', (reason, p) => {


### PR DESCRIPTION
### Description

Moves ethereum conformity service methods directly into the service instead of keeping them as static dependencies.

### Related issue(s)

Fixes #4716

Parent #4630 

### Testing Guide

1. No behaviour changes expected, rerun tests in workflows....

### Changes from original design (optional)

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
