### PR TITLE
test: ensure trace works without non-synth data (#4752)

### DIFF
--- a/packages/relay/src/lib/debug.ts
+++ b/packages/relay/src/lib/debug.ts
@@ -436,7 +436,7 @@ export class DebugImpl implements Debug {
         ]),
       ]);
 
-      if (!actionsResponse || actionsResponse.length === 0 || !transactionsResponse) {
+      if (!actionsResponse?.[0]?.call_type || !transactionsResponse) {
         return (await this.handleSyntheticTransaction(
           transactionHash,
           TracerType.CallTracer,

--- a/packages/relay/tests/lib/debug.spec.ts
+++ b/packages/relay/tests/lib/debug.spec.ts
@@ -575,6 +575,26 @@ describe('Debug API Test Suite', async function () {
               [syntheticTxHash, tracerObjectCallTracerFalse, requestDetails],
             );
           });
+
+          [
+            { label: 'empty', result: [] },
+            { label: 'missing', result: undefined },
+            { label: 'malformed', result: [{}] },
+          ].forEach(({ label, result }) => {
+            it(`should fallback to synthetic transaction handling for ${label} non-synthetic data`, async function () {
+              restMock.onGet(CONTRACT_RESULTS_LOGS_SYNTHETIC).reply(200, JSON.stringify({ logs: [syntheticLog] }));
+              restMock.onGet(CONTRACTS_RESULTS_ACTIONS_SYNTHETIC).reply(200, JSON.stringify({ actions: result }));
+              restMock.onGet(CONTRACTS_RESULTS_SYNTHETIC).reply(200, JSON.stringify(contractsResultsByHashResult));
+              restMock.onGet(SENDER_BY_ADDRESS).reply(200, JSON.stringify(accountsResult));
+              restMock.onGet(ACCOUNT_BY_ADDRESS).reply(200, JSON.stringify({ evm_address: accountAddress }));
+              const { type } = await debugService.traceTransaction(
+                syntheticTxHash,
+                tracerObjectCallTracerFalse,
+                requestDetails,
+              );
+              expect(type).to.equal('CALL');
+            });
+          });
         });
       });
 


### PR DESCRIPTION
### Description

The issue described in task #4752 was already fixed in PR (see link below).
https://github.com/hiero-ledger/hiero-json-rpc-relay/pull/4694/files#diff-959d3e5e8549ad6f36c7d26d57e415ee3f438982ee705306dfff51dc7836b1e2R439

This PR adds additional tests to ensure the fix is properly covered and remains in place.

### Related issue(s)

Fixes #4752

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1. Run the new tests in GitHub Actions and make sure they pass.

### Changes from original design (optional)

N/A

### Additional work needed (optional)


N/A

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
