### PR TITLE
chore(tests): remove @release tag from Read-Only mode test

### DIFF
--- a/packages/server/tests/acceptance/sendRawTransactionExtension.spec.ts
+++ b/packages/server/tests/acceptance/sendRawTransactionExtension.spec.ts
@@ -230,7 +230,7 @@ describe('@sendRawTransactionExtension Acceptance Tests', function () {
   });
 
   describe('Read-Only mode', function () {
-    it('@release should fail to execute "eth_sendRawTransaction" in Read-Only mode', async function () {
+    it('should fail to execute "eth_sendRawTransaction" in Read-Only mode', async function () {
       const readOnly = ConfigService.get('READ_ONLY');
       ConfigServiceTestHelper.dynamicOverride('READ_ONLY', true);
 


### PR DESCRIPTION
### Description

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

This PR removes the `@release` tag from the `should fail to execute "eth_sendRawTransaction" in Read-Only mode` test.

The test uses `ConfigServiceTestHelper.dynamicOverride('READ_ONLY', true)` to modify the `READ_ONLY` configuration. This dynamic override only affects the local test environment and does not propagate to remote servers used in release testing. Consequently, the test passes locally but fails when executed against remote/production servers (e.g., Hashio previewnet, testnet).

By removing the `@release` tag, the test execution is limitted to localenvironments where the configuration override functions correctly.

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #4779

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
