### PR TITLE
feat: add worker threads related metrics

### DIFF
--- a/packages/relay/src/lib/services/workersService/WorkersPool.ts
+++ b/packages/relay/src/lib/services/workersService/WorkersPool.ts
@@ -231,7 +231,6 @@ export class WorkersPool {
     this.cacheService = cacheService as MeasurableCache;
 
     const taskType = (options as { type: string }).type;
-    this.workerTasksCompletedTotalCounter?.labels(taskType).inc();
     this.workerQueueWaitTimeHistogram?.observe(this.instance.histogram.waitTime.average);
     this.workerPoolUtilizationGauge?.set(this.instance.utilization);
     this.workerPoolActiveThreadsGauge?.set(this.instance.threads.length);
@@ -243,10 +242,10 @@ export class WorkersPool {
       .catch((error: unknown) => {
         const unwrappedErr = WorkersPool.unwrapError(error);
 
-        this.workerTaskFailuresCounter?.labels(taskType, `${unwrappedErr.name} - ${unwrappedErr.message}`).inc();
         this.workerTaskDurationSecondsHistogram
           ?.labels(taskType)
           .observe(Number(process.hrtime.bigint() - startTime) * 1e-9);
+        this.workerTaskFailuresCounter?.labels(taskType, `${unwrappedErr.name} - ${unwrappedErr.message}`).inc();
 
         throw unwrappedErr;
       });
@@ -256,6 +255,7 @@ export class WorkersPool {
     this.workerTaskDurationSecondsHistogram
       ?.labels(taskType)
       .observe(Number(process.hrtime.bigint() - startTime) * 1e-9);
+    this.workerTasksCompletedTotalCounter?.labels(taskType).inc();
 
     return result;
   }


### PR DESCRIPTION
### Description

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->


Add metrics for:
- Task Duration
  - Name: rpc_relay_worker_task_duration_seconds
  - Type: Histogram
  - Purpose: Tracks how long each task takes to execute. Enables P50/P95/P99 latency analysis.
  - How: Measured manually by timing before/after pool.run()
- Tasks Completed
  - Name: rpc_relay_worker_tasks_completed_total
  - Type: Counter
  - Purpose: Counts total tasks by type
  - How: Use piscina property pool.completed (total completed tasks count)
- Queue Wait Time
  - Name: rpc_relay_worker_queue_wait_time_seconds
  - Type: Gauge
  - Purpose: Total time tasks have spent waiting in queue. High values indicate workers are overwhelmed and tasks are delayed before even starting execution.
  - How: Use piscina property pool.waitTime
- Pool Utilization
  - Name: rpc_relay_worker_pool_utilization
  - Type: Gauge
  - Purpose: Ratio (0-1) of how busy workers are. High means near capacity, low means over-provisioned.
  - How: Use piscina property pool.utilization
- Active Threads
  - Name: rpc_relay_worker_pool_active_threads
  - Type: Gauge
  - Purpose: Current number of worker threads. Shows scaling behavior over time.
  - How: Use piscina property pool.threads

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #4685 

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1.
2.
3.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
