### PR TITLE
feat: calculate gasUsedRatio in eth_feeHistory (#5066)

### DIFF
--- a/packages/relay/tests/lib/services/feeService/FeeService.spec.ts
+++ b/packages/relay/tests/lib/services/feeService/FeeService.spec.ts
@@ -81,13 +81,13 @@ describe('FeeService', function () {
     });
   });
 
-  describe('gasUsedRatioForBlock (private)', function () {
+  describe('getGasUsedRatioForBlock (private)', function () {
     let warnSpy: sinon.SinonSpy;
     let feeService: FeeService;
     let obtainStub: sinon.SinonStub;
 
     function ratioFor(block: MirrorNodeBlock): number {
-      return (feeService as any).gasUsedRatioForBlock(block);
+      return (feeService as any).getGasUsedRatioForBlock(block);
     }
 
     beforeEach(function () {
@@ -131,10 +131,14 @@ describe('FeeService', function () {
     });
 
     it('returns 1 and warns when gasUsed exceeds obtainBlockGasLimit', function () {
-      const limit = blockGasLimit.obtainBlockGasLimit('0.0.0');
-      expect(ratioFor(minimalMirrorBlock(5, limit + 1, '0.0.0'))).to.equal(1);
+      const blockNumber = 5;
+      const blockGasLimitValue = blockGasLimit.obtainBlockGasLimit('0.0.0');
+      const gasUsed = blockGasLimitValue + 1;
+      expect(ratioFor(minimalMirrorBlock(blockNumber, gasUsed, '0.0.0'))).to.equal(1);
       expect(warnSpy.calledOnce).to.be.true;
-      expect(warnSpy.firstCall.args[1]).to.include('clamping gasUsedRatio to 1');
+      expect(warnSpy.firstCall.args[0]).to.be.equal(
+        `eth_feeHistory: gasUsed exceeds block gas limit for block ${blockNumber}; Gas used: ${gasUsed}, Block gas limit: ${blockGasLimitValue}; clamping gasUsedRatio to 1`,
+      );
     });
 
     it('returns a fractional ratio when stub supplies a small limit', function () {

--- a/packages/relay/tests/lib/services/feeService/FeeService.spec.ts
+++ b/packages/relay/tests/lib/services/feeService/FeeService.spec.ts
@@ -136,9 +136,6 @@ describe('FeeService', function () {
       const gasUsed = blockGasLimitValue + 1;
       expect(ratioFor(minimalMirrorBlock(blockNumber, gasUsed, '0.0.0'))).to.equal(1);
       expect(warnSpy.calledOnce).to.be.true;
-      expect(warnSpy.firstCall.args[0]).to.be.equal(
-        `eth_feeHistory: gasUsed exceeds block gas limit for block ${blockNumber}; Gas used: ${gasUsed}, Block gas limit: ${blockGasLimitValue}; clamping gasUsedRatio to 1`,
-      );
     });
 
     it('returns a fractional ratio when stub supplies a small limit', function () {

--- a/packages/relay/tests/lib/services/feeService/FeeService.spec.ts
+++ b/packages/relay/tests/lib/services/feeService/FeeService.spec.ts
@@ -6,6 +6,7 @@ import { Logger } from 'pino';
 import sinon from 'sinon';
 
 import { numberTo0x } from '../../../../src/formatters';
+import * as blockGasLimit from '../../../../src/lib/config/blockGasLimit';
 import constants from '../../../../src/lib/constants';
 import { FeeService } from '../../../../src/lib/services/ethService/feeService/FeeService';
 import { RequestDetails } from '../../../../src/lib/types';
@@ -14,13 +15,12 @@ import { MirrorNodeBlock } from '../../../../src/lib/types/mirrorNode';
 
 describe('FeeService', function () {
   const requestDetails = new RequestDetails({ requestId: 'feeServiceUnitTest', ipAddress: '0.0.0.0' });
-  const originalBlockGasLimit = constants.BLOCK_GAS_LIMIT;
 
-  function minimalMirrorBlock(number: number, gasUsed: number): MirrorNodeBlock {
+  function minimalMirrorBlock(number: number, gasUsed: number, hapiVersion: string = '0.0.0'): MirrorNodeBlock {
     return {
       count: 0,
       gas_used: gasUsed,
-      hapi_version: '0.0.0',
+      hapi_version: hapiVersion,
       hash: '0x',
       logs_bloom: '0x',
       name: '',
@@ -58,7 +58,7 @@ describe('FeeService', function () {
       const head = 100;
       commonStub.translateBlockTag.withArgs(constants.BLOCK_LATEST, requestDetails).resolves(head);
 
-      const block = minimalMirrorBlock(head, 1_000_000);
+      const block = minimalMirrorBlock(head, 1_000_000, '0.0.0');
       mirrorStub.getBlock.withArgs(head, requestDetails).resolves(block);
       commonStub.getGasPriceInWeibars.withArgs(requestDetails, `lte:${block.timestamp.to}`).resolves(77);
     });
@@ -67,13 +67,14 @@ describe('FeeService', function () {
       sinon.restore();
     });
 
-    it('returns fee history with computed gasUsedRatio when newest block is latest', async function () {
+    it('returns fee history with gasUsedRatio from obtainBlockGasLimit(hapi_version) when newest block is latest', async function () {
       const result = await feeService.feeHistory(1, 'latest', null, requestDetails);
 
       expect(result).to.not.have.property('code');
       const feeHistory = result as IFeeHistory;
+      const expectedLimit = blockGasLimit.obtainBlockGasLimit('0.0.0');
       expect(feeHistory.oldestBlock).to.equal(numberTo0x(100));
-      expect(feeHistory.gasUsedRatio).to.deep.equal([1_000_000 / constants.BLOCK_GAS_LIMIT]);
+      expect(feeHistory.gasUsedRatio).to.deep.equal([1_000_000 / expectedLimit]);
       expect(feeHistory.baseFeePerGas).to.deep.equal([numberTo0x(77), numberTo0x(77)]);
       expect(mirrorStub.getBlock.callCount).to.equal(1);
       expect(mirrorStub.getBlock.firstCall.args).to.deep.equal([100, requestDetails]);
@@ -83,69 +84,83 @@ describe('FeeService', function () {
   describe('gasUsedRatioForBlock (private)', function () {
     let warnSpy: sinon.SinonSpy;
     let feeService: FeeService;
+    let obtainStub: sinon.SinonStub;
 
-    function ratioFor(block: Pick<MirrorNodeBlock, 'number' | 'gas_used'>): number {
+    function ratioFor(block: MirrorNodeBlock): number {
       return (feeService as any).gasUsedRatioForBlock(block);
     }
 
     beforeEach(function () {
-      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = originalBlockGasLimit;
       warnSpy = sinon.spy();
       feeService = new FeeService({} as any, {} as any, { warn: warnSpy } as unknown as Logger);
+      obtainStub = sinon.stub(blockGasLimit, 'obtainBlockGasLimit').callThrough();
     });
 
     afterEach(function () {
-      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = originalBlockGasLimit;
+      sinon.restore();
     });
 
-    it('returns gasUsed / blockGasLimit when within limit', function () {
-      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = 10_000_000;
-      expect(ratioFor({ number: 1, gas_used: 2_500_000 })).to.equal(0.25);
+    it('returns gasUsed / obtainBlockGasLimit(hapi_version) when within limit (0.0.0 tier)', function () {
+      expect(ratioFor(minimalMirrorBlock(1, 7_500_000, '0.0.0'))).to.equal(0.25);
+      expect(warnSpy.called).to.be.false;
+    });
+
+    it('uses higher limit for 0.69.0 HAPI version', function () {
+      const limit = blockGasLimit.obtainBlockGasLimit('0.69.0');
+      expect(limit).to.equal(150_000_000);
+      expect(ratioFor(minimalMirrorBlock(1, 75_000_000, '0.69.0'))).to.equal(0.5);
       expect(warnSpy.called).to.be.false;
     });
 
     it('returns 0 when gasUsed is 0', function () {
-      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = 10_000_000;
-      expect(ratioFor({ number: 2, gas_used: 0 })).to.equal(0);
+      expect(ratioFor(minimalMirrorBlock(2, 0, '0.0.0'))).to.equal(0);
       expect(warnSpy.called).to.be.false;
     });
 
     it('treats missing gas_used as 0', function () {
-      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = 10_000_000;
-      expect(ratioFor({ number: 3, gas_used: undefined as unknown as number })).to.equal(0);
+      const block = minimalMirrorBlock(3, 0, '0.0.0');
+      (block as { gas_used: number | undefined }).gas_used = undefined;
+      expect(ratioFor(block)).to.equal(0);
       expect(warnSpy.called).to.be.false;
     });
 
-    it('returns 1 when gasUsed equals blockGasLimit', function () {
-      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = 5_000_000;
-      expect(ratioFor({ number: 4, gas_used: 5_000_000 })).to.equal(1);
+    it('returns 1 when gasUsed equals block gas limit for that HAPI version', function () {
+      const limit = blockGasLimit.obtainBlockGasLimit('0.0.0');
+      expect(ratioFor(minimalMirrorBlock(4, limit, '0.0.0'))).to.equal(1);
       expect(warnSpy.called).to.be.false;
     });
 
-    it('returns 1 and warns when gasUsed exceeds blockGasLimit', function () {
-      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = 100;
-      expect(ratioFor({ number: 5, gas_used: 101 })).to.equal(1);
+    it('returns 1 and warns when gasUsed exceeds obtainBlockGasLimit', function () {
+      const limit = blockGasLimit.obtainBlockGasLimit('0.0.0');
+      expect(ratioFor(minimalMirrorBlock(5, limit + 1, '0.0.0'))).to.equal(1);
       expect(warnSpy.calledOnce).to.be.true;
       expect(warnSpy.firstCall.args[1]).to.include('clamping gasUsedRatio to 1');
     });
 
-    it('returns 0 and warns when blockGasLimit is 0', function () {
-      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = 0;
-      expect(ratioFor({ number: 6, gas_used: 50 })).to.equal(0);
+    it('returns 0 and warns when obtainBlockGasLimit is 0', function () {
+      obtainStub.returns(0);
+      expect(ratioFor(minimalMirrorBlock(6, 50, '0.0.0'))).to.equal(0);
       expect(warnSpy.calledOnce).to.be.true;
       expect(warnSpy.firstCall.args[1]).to.include('non-positive');
     });
 
-    it('returns 0 and warns when blockGasLimit is negative', function () {
-      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = -1;
-      expect(ratioFor({ number: 7, gas_used: 1 })).to.equal(0);
+    it('returns 0 and warns when obtainBlockGasLimit is negative', function () {
+      obtainStub.returns(-1);
+      expect(ratioFor(minimalMirrorBlock(7, 1, '0.0.0'))).to.equal(0);
       expect(warnSpy.calledOnce).to.be.true;
       expect(warnSpy.firstCall.args[1]).to.include('non-positive');
     });
 
-    it('returns an irreducible fractional ratio', function () {
-      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = 7;
-      expect(ratioFor({ number: 1, gas_used: 3 })).to.be.closeTo(3 / 7, 1e-12);
+    it('returns a fractional ratio when stub supplies a small limit', function () {
+      obtainStub.returns(7);
+      expect(ratioFor(minimalMirrorBlock(8, 3, '0.0.0'))).to.be.closeTo(3 / 7, 1e-12);
+      expect(warnSpy.called).to.be.false;
+    });
+
+    it('uses DEFAULT_BLOCK_GAS_LIMIT when hapi_version is invalid (obtainBlockGasLimit fallback)', function () {
+      const gasUsed = constants.DEFAULT_BLOCK_GAS_LIMIT / 4;
+      expect(ratioFor(minimalMirrorBlock(9, gasUsed, 'not-a-version'))).to.equal(0.25);
+      expect(warnSpy.called).to.be.false;
     });
   });
 });

--- a/packages/relay/tests/lib/services/feeService/FeeService.spec.ts
+++ b/packages/relay/tests/lib/services/feeService/FeeService.spec.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
+import { expect } from 'chai';
+import { Logger } from 'pino';
+import sinon from 'sinon';
+
+import { numberTo0x } from '../../../../src/formatters';
+import constants from '../../../../src/lib/constants';
+import { FeeService } from '../../../../src/lib/services/ethService/feeService/FeeService';
+import { RequestDetails } from '../../../../src/lib/types';
+import { IFeeHistory } from '../../../../src/lib/types/IFeeHistory';
+import { MirrorNodeBlock } from '../../../../src/lib/types/mirrorNode';
+
+describe('FeeService', function () {
+  const requestDetails = new RequestDetails({ requestId: 'feeServiceUnitTest', ipAddress: '0.0.0.0' });
+  const originalBlockGasLimit = constants.BLOCK_GAS_LIMIT;
+
+  function minimalMirrorBlock(number: number, gasUsed: number): MirrorNodeBlock {
+    return {
+      count: 0,
+      gas_used: gasUsed,
+      hapi_version: '0.0.0',
+      hash: '0x',
+      logs_bloom: '0x',
+      name: '',
+      number,
+      previous_hash: '0x',
+      size: 0,
+      timestamp: { from: '1651560386.0', to: '1651560389.0' },
+    };
+  }
+
+  describe('feeHistory (happy path)', function () {
+    let feeService: FeeService;
+    let mirrorStub: { getBlock: sinon.SinonStub };
+    let commonStub: {
+      translateBlockTag: sinon.SinonStub;
+      getGasPriceInWeibars: sinon.SinonStub;
+    };
+
+    beforeEach(function () {
+      sinon.stub(ConfigService, 'get').callsFake((key: string) => {
+        if (key === 'TEST') return true;
+        if (key === 'ETH_FEE_HISTORY_FIXED') return false;
+        return undefined;
+      });
+
+      mirrorStub = { getBlock: sinon.stub() };
+      commonStub = {
+        translateBlockTag: sinon.stub(),
+        getGasPriceInWeibars: sinon.stub(),
+      };
+
+      const logger = { error: sinon.stub(), warn: sinon.stub() } as unknown as Logger;
+      feeService = new FeeService(mirrorStub as any, commonStub as any, logger);
+
+      const head = 100;
+      commonStub.translateBlockTag.withArgs(constants.BLOCK_LATEST, requestDetails).resolves(head);
+
+      const block = minimalMirrorBlock(head, 1_000_000);
+      mirrorStub.getBlock.withArgs(head, requestDetails).resolves(block);
+      commonStub.getGasPriceInWeibars.withArgs(requestDetails, `lte:${block.timestamp.to}`).resolves(77);
+    });
+
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    it('returns fee history with computed gasUsedRatio when newest block is latest', async function () {
+      const result = await feeService.feeHistory(1, 'latest', null, requestDetails);
+
+      expect(result).to.not.have.property('code');
+      const feeHistory = result as IFeeHistory;
+      expect(feeHistory.oldestBlock).to.equal(numberTo0x(100));
+      expect(feeHistory.gasUsedRatio).to.deep.equal([1_000_000 / constants.BLOCK_GAS_LIMIT]);
+      expect(feeHistory.baseFeePerGas).to.deep.equal([numberTo0x(77), numberTo0x(77)]);
+      expect(mirrorStub.getBlock.callCount).to.equal(1);
+      expect(mirrorStub.getBlock.firstCall.args).to.deep.equal([100, requestDetails]);
+    });
+  });
+
+  describe('gasUsedRatioForBlock (private)', function () {
+    let warnSpy: sinon.SinonSpy;
+    let feeService: FeeService;
+
+    function ratioFor(block: Pick<MirrorNodeBlock, 'number' | 'gas_used'>): number {
+      return (feeService as any).gasUsedRatioForBlock(block);
+    }
+
+    beforeEach(function () {
+      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = originalBlockGasLimit;
+      warnSpy = sinon.spy();
+      feeService = new FeeService({} as any, {} as any, { warn: warnSpy } as unknown as Logger);
+    });
+
+    afterEach(function () {
+      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = originalBlockGasLimit;
+    });
+
+    it('returns gasUsed / blockGasLimit when within limit', function () {
+      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = 10_000_000;
+      expect(ratioFor({ number: 1, gas_used: 2_500_000 })).to.equal(0.25);
+      expect(warnSpy.called).to.be.false;
+    });
+
+    it('returns 0 when gasUsed is 0', function () {
+      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = 10_000_000;
+      expect(ratioFor({ number: 2, gas_used: 0 })).to.equal(0);
+      expect(warnSpy.called).to.be.false;
+    });
+
+    it('treats missing gas_used as 0', function () {
+      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = 10_000_000;
+      expect(ratioFor({ number: 3, gas_used: undefined as unknown as number })).to.equal(0);
+      expect(warnSpy.called).to.be.false;
+    });
+
+    it('returns 1 when gasUsed equals blockGasLimit', function () {
+      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = 5_000_000;
+      expect(ratioFor({ number: 4, gas_used: 5_000_000 })).to.equal(1);
+      expect(warnSpy.called).to.be.false;
+    });
+
+    it('returns 1 and warns when gasUsed exceeds blockGasLimit', function () {
+      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = 100;
+      expect(ratioFor({ number: 5, gas_used: 101 })).to.equal(1);
+      expect(warnSpy.calledOnce).to.be.true;
+      expect(warnSpy.firstCall.args[1]).to.include('clamping gasUsedRatio to 1');
+    });
+
+    it('returns 0 and warns when blockGasLimit is 0', function () {
+      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = 0;
+      expect(ratioFor({ number: 6, gas_used: 50 })).to.equal(0);
+      expect(warnSpy.calledOnce).to.be.true;
+      expect(warnSpy.firstCall.args[1]).to.include('non-positive');
+    });
+
+    it('returns 0 and warns when blockGasLimit is negative', function () {
+      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = -1;
+      expect(ratioFor({ number: 7, gas_used: 1 })).to.equal(0);
+      expect(warnSpy.calledOnce).to.be.true;
+      expect(warnSpy.firstCall.args[1]).to.include('non-positive');
+    });
+
+    it('returns an irreducible fractional ratio', function () {
+      (constants as { BLOCK_GAS_LIMIT: number }).BLOCK_GAS_LIMIT = 7;
+      expect(ratioFor({ number: 1, gas_used: 3 })).to.be.closeTo(3 / 7, 1e-12);
+    });
+  });
+});

--- a/packages/relay/tests/lib/services/feeService/FeeService.spec.ts
+++ b/packages/relay/tests/lib/services/feeService/FeeService.spec.ts
@@ -137,20 +137,6 @@ describe('FeeService', function () {
       expect(warnSpy.firstCall.args[1]).to.include('clamping gasUsedRatio to 1');
     });
 
-    it('returns 0 and warns when obtainBlockGasLimit is 0', function () {
-      obtainStub.returns(0);
-      expect(ratioFor(minimalMirrorBlock(6, 50, '0.0.0'))).to.equal(0);
-      expect(warnSpy.calledOnce).to.be.true;
-      expect(warnSpy.firstCall.args[1]).to.include('non-positive');
-    });
-
-    it('returns 0 and warns when obtainBlockGasLimit is negative', function () {
-      obtainStub.returns(-1);
-      expect(ratioFor(minimalMirrorBlock(7, 1, '0.0.0'))).to.equal(0);
-      expect(warnSpy.calledOnce).to.be.true;
-      expect(warnSpy.firstCall.args[1]).to.include('non-positive');
-    });
-
     it('returns a fractional ratio when stub supplies a small limit', function () {
       obtainStub.returns(7);
       expect(ratioFor(minimalMirrorBlock(8, 3, '0.0.0'))).to.be.closeTo(3 / 7, 1e-12);

--- a/src/relay/lib/factories/blockFactory.ts
+++ b/src/relay/lib/factories/blockFactory.ts
@@ -37,7 +37,7 @@ export class BlockFactory {
       difficulty: constants.ZERO_HEX,
       extraData: constants.EMPTY_HEX,
       gasLimit: numberTo0x(obtainBlockGasLimit(blockResponse.hapi_version)),
-      gasUsed: numberTo0x(blockResponse.gas_used),
+      gasUsed: numberTo0x(blockResponse.gas_used ?? 0),
       hash: blockHash,
       logsBloom: blockResponse.logs_bloom === constants.EMPTY_HEX ? constants.EMPTY_BLOOM : blockResponse.logs_bloom,
       miner: constants.ZERO_ADDRESS_HEX,

--- a/src/relay/lib/services/ethService/feeService/FeeService.ts
+++ b/src/relay/lib/services/ethService/feeService/FeeService.ts
@@ -260,13 +260,6 @@ export class FeeService implements IFeeService {
     const gasUsed = block.gas_used || 0;
     const blockNumber = block.number;
 
-    if (blockGasLimit <= 0) {
-      this.logger.warn(
-        { blockNumber, gasUsed, blockGasLimit },
-        'eth_feeHistory: block gas limit is non-positive; using 0 for gasUsedRatio',
-      );
-      return 0;
-    }
     if (gasUsed > blockGasLimit) {
       this.logger.warn(
         { blockNumber, gasUsed, blockGasLimit },

--- a/src/relay/lib/services/ethService/feeService/FeeService.ts
+++ b/src/relay/lib/services/ethService/feeService/FeeService.ts
@@ -261,7 +261,10 @@ export class FeeService implements IFeeService {
 
     if (gasUsed > blockGasLimit) {
       this.logger.warn(
-        `eth_feeHistory: gasUsed exceeds block gas limit for block ${blockNumber}; Gas used: ${gasUsed}, Block gas limit: ${blockGasLimit}; clamping gasUsedRatio to 1`,
+        'eth_feeHistory: gasUsed exceeds block gas limit for block %s; Gas used: %s, Block gas limit: %s; clamping gasUsedRatio to 1',
+        blockNumber,
+        gasUsed,
+        blockGasLimit,
       );
       return 1;
     }

--- a/src/relay/lib/services/ethService/feeService/FeeService.ts
+++ b/src/relay/lib/services/ethService/feeService/FeeService.ts
@@ -8,7 +8,7 @@ import { numberTo0x } from '../../../../formatters';
 import { MirrorNodeClient } from '../../../clients';
 import constants from '../../../constants';
 import { JsonRpcError, predefined } from '../../../errors/JsonRpcError';
-import { IFeeHistory, RequestDetails } from '../../../types';
+import { IFeeHistory, MirrorNodeBlock, RequestDetails } from '../../../types';
 import { ICommonService } from '../ethCommonService/ICommonService';
 import { IFeeService } from '../feeService/IFeeService';
 
@@ -193,10 +193,12 @@ export class FeeService implements IFeeService {
 
     // get fees from oldest to newest blocks
     for (let blockNumber = oldestBlockNumber; blockNumber <= newestBlockNumber; blockNumber++) {
-      const fee = await this.getFeeByBlockNumber(blockNumber, requestDetails);
+      const block = await this.mirrorNodeClient.getBlock(blockNumber, requestDetails);
+      const fee = await this.getFeeFromBlock(block, requestDetails);
+      const gasUsedRatio = this.gasUsedRatioForBlock(block);
 
       feeHistory.baseFeePerGas?.push(fee);
-      feeHistory.gasUsedRatio?.push(constants.DEFAULT_GAS_USED_RATIO);
+      feeHistory.gasUsedRatio?.push(gasUsedRatio);
     }
 
     // get latest block fee
@@ -205,7 +207,8 @@ export class FeeService implements IFeeService {
 
     if (latestBlockNumber > newestBlockNumber) {
       // get next block fee if the newest block is not the latest
-      nextBaseFeePerGas = await this.getFeeByBlockNumber(newestBlockNumber + 1, requestDetails);
+      const nextBlock = await this.mirrorNodeClient.getBlock(newestBlockNumber + 1, requestDetails);
+      nextBaseFeePerGas = await this.getFeeFromBlock(nextBlock, requestDetails);
     }
 
     if (nextBaseFeePerGas) {
@@ -224,20 +227,52 @@ export class FeeService implements IFeeService {
    * @param requestDetails
    * @private
    */
-  private async getFeeByBlockNumber(blockNumber: number, requestDetails: RequestDetails): Promise<string> {
+  private async getFeeFromBlock(block: MirrorNodeBlock, requestDetails: RequestDetails): Promise<string> {
     let fee = 0;
     try {
-      const block = await this.mirrorNodeClient.getBlock(blockNumber, requestDetails);
       fee = await this.common.getGasPriceInWeibars(requestDetails, `lte:${block.timestamp.to}`);
     } catch (error) {
       this.logger.warn(
         error,
         `Fee history cannot retrieve block or fee. Returning %s fee for block %s`,
         fee,
-        blockNumber,
+        block.number,
       );
     }
 
     return numberTo0x(fee);
+  }
+
+  /**
+   * Returns the `gasUsedRatio` entry for for a block
+   * `gasUsed / blockGasLimit`, using {@link MirrorNodeBlock.gas_used} as gas used.
+   *
+   * If the effective block gas limit is non-positive, logs a warning and returns `0`.
+   * If `gasUsed` exceeds that limit, logs a warning and returns `1` (100% usage).
+   *
+   * @param block - Mirror node block metadata (must include `number`, `gas_used`)
+   * @returns Ratio in the range [0, 1] suitable for JSON-RPC `gasUsedRatio`
+   * @private
+   */
+  private gasUsedRatioForBlock(block: MirrorNodeBlock): number {
+    const blockGasLimit = constants.BLOCK_GAS_LIMIT; //FIXME: Get the value from blockGasLimit.ts after #5065 is merged
+    const gasUsed = block.gas_used || 0;
+    const blockNumber = block.number;
+
+    if (blockGasLimit <= 0) {
+      this.logger.warn(
+        { blockNumber, gasUsed, blockGasLimit },
+        'eth_feeHistory: block gas limit is non-positive; using 0 for gasUsedRatio',
+      );
+      return 0;
+    }
+    if (gasUsed > blockGasLimit) {
+      this.logger.warn(
+        { blockNumber, gasUsed, blockGasLimit },
+        'eth_feeHistory: gasUsed exceeds block gas limit; clamping gasUsedRatio to 1',
+      );
+      return 1;
+    }
+    return gasUsed / blockGasLimit;
   }
 }

--- a/src/relay/lib/services/ethService/feeService/FeeService.ts
+++ b/src/relay/lib/services/ethService/feeService/FeeService.ts
@@ -229,18 +229,30 @@ export class FeeService implements IFeeService {
     blockNumber: number,
     requestDetails: RequestDetails,
   ): Promise<{ fee: string; gasUsedRatio: number }> {
+    let block: MirrorNodeBlock | undefined;
     try {
-      const block = await this.mirrorNodeClient.getBlock(blockNumber, requestDetails);
-      const fee = await this.common.getGasPriceInWeibars(requestDetails, `lte:${block.timestamp.to}`);
-      const gasUsedRatio = this.getGasUsedRatioForBlock(block);
-      return { fee: numberTo0x(fee), gasUsedRatio };
+      block = await this.mirrorNodeClient.getBlock(blockNumber, requestDetails);
+      if (!block) {
+        this.logger.warn(`Fee history: block ${blockNumber} not found. Returning zero fee and gasUsedRatio.`);
+        return { fee: constants.ZERO_HEX, gasUsedRatio: 0 };
+      }
     } catch (error) {
       this.logger.warn(
         error,
-        `Fee history cannot retrieve block or fee. Returning zero fee and gasUsedRatio for block %s`,
+        `Fee history cannot retrieve block. Returning zero fee and gasUsedRatio for block %s`,
         blockNumber,
       );
       return { fee: constants.ZERO_HEX, gasUsedRatio: 0 };
+    }
+
+    const gasUsedRatio = this.getGasUsedRatioForBlock(block);
+
+    try {
+      const fee = await this.common.getGasPriceInWeibars(requestDetails, `lte:${block.timestamp.to}`);
+      return { fee: numberTo0x(fee), gasUsedRatio };
+    } catch (error) {
+      this.logger.warn(error, `Fee history cannot retrieve fee. Returning zero fee for block %s`, blockNumber);
+      return { fee: constants.ZERO_HEX, gasUsedRatio };
     }
   }
 
@@ -256,7 +268,7 @@ export class FeeService implements IFeeService {
    */
   private getGasUsedRatioForBlock(block: MirrorNodeBlock): number {
     const blockGasLimit = obtainBlockGasLimit(block.hapi_version);
-    const gasUsed = block.gas_used || 0;
+    const gasUsed = block.gas_used ?? 0;
     const blockNumber = block.number;
 
     if (gasUsed > blockGasLimit) {

--- a/src/relay/lib/services/ethService/feeService/FeeService.ts
+++ b/src/relay/lib/services/ethService/feeService/FeeService.ts
@@ -196,7 +196,7 @@ export class FeeService implements IFeeService {
     for (let blockNumber = oldestBlockNumber; blockNumber <= newestBlockNumber; blockNumber++) {
       const block = await this.mirrorNodeClient.getBlock(blockNumber, requestDetails);
       const fee = await this.getFeeFromBlock(block, requestDetails);
-      const gasUsedRatio = this.gasUsedRatioForBlock(block);
+      const gasUsedRatio = this.getGasUsedRatioForBlock(block);
 
       feeHistory.baseFeePerGas?.push(fee);
       feeHistory.gasUsedRatio?.push(gasUsedRatio);
@@ -254,15 +254,14 @@ export class FeeService implements IFeeService {
    * @returns Ratio in the range [0, 1] suitable for JSON-RPC `gasUsedRatio`
    * @private
    */
-  private gasUsedRatioForBlock(block: MirrorNodeBlock): number {
+  private getGasUsedRatioForBlock(block: MirrorNodeBlock): number {
     const blockGasLimit = obtainBlockGasLimit(block.hapi_version);
     const gasUsed = block.gas_used || 0;
     const blockNumber = block.number;
 
     if (gasUsed > blockGasLimit) {
       this.logger.warn(
-        { blockNumber, gasUsed, blockGasLimit },
-        'eth_feeHistory: gasUsed exceeds block gas limit; clamping gasUsedRatio to 1',
+        `eth_feeHistory: gasUsed exceeds block gas limit for block ${blockNumber}; Gas used: ${gasUsed}, Block gas limit: ${blockGasLimit}; clamping gasUsedRatio to 1`,
       );
       return 1;
     }

--- a/src/relay/lib/services/ethService/feeService/FeeService.ts
+++ b/src/relay/lib/services/ethService/feeService/FeeService.ts
@@ -6,6 +6,7 @@ import { Logger } from 'pino';
 import { ConfigService } from '../../../../../config-service/services';
 import { numberTo0x } from '../../../../formatters';
 import { MirrorNodeClient } from '../../../clients';
+import { obtainBlockGasLimit } from '../../../config/blockGasLimit';
 import constants from '../../../constants';
 import { JsonRpcError, predefined } from '../../../errors/JsonRpcError';
 import { IFeeHistory, MirrorNodeBlock, RequestDetails } from '../../../types';
@@ -255,7 +256,7 @@ export class FeeService implements IFeeService {
    * @private
    */
   private gasUsedRatioForBlock(block: MirrorNodeBlock): number {
-    const blockGasLimit = constants.BLOCK_GAS_LIMIT; //FIXME: Get the value from blockGasLimit.ts after #5065 is merged
+    const blockGasLimit = obtainBlockGasLimit(block.hapi_version);
     const gasUsed = block.gas_used || 0;
     const blockNumber = block.number;
 

--- a/src/relay/lib/services/ethService/feeService/FeeService.ts
+++ b/src/relay/lib/services/ethService/feeService/FeeService.ts
@@ -194,9 +194,7 @@ export class FeeService implements IFeeService {
 
     // get fees from oldest to newest blocks
     for (let blockNumber = oldestBlockNumber; blockNumber <= newestBlockNumber; blockNumber++) {
-      const block = await this.mirrorNodeClient.getBlock(blockNumber, requestDetails);
-      const fee = await this.getFeeFromBlock(block, requestDetails);
-      const gasUsedRatio = this.getGasUsedRatioForBlock(block);
+      const { fee, gasUsedRatio } = await this.getFeeHistoryDataFromBlock(blockNumber, requestDetails);
 
       feeHistory.baseFeePerGas?.push(fee);
       feeHistory.gasUsedRatio?.push(gasUsedRatio);
@@ -208,8 +206,7 @@ export class FeeService implements IFeeService {
 
     if (latestBlockNumber > newestBlockNumber) {
       // get next block fee if the newest block is not the latest
-      const nextBlock = await this.mirrorNodeClient.getBlock(newestBlockNumber + 1, requestDetails);
-      nextBaseFeePerGas = await this.getFeeFromBlock(nextBlock, requestDetails);
+      nextBaseFeePerGas = (await this.getFeeHistoryDataFromBlock(newestBlockNumber + 1, requestDetails)).fee;
     }
 
     if (nextBaseFeePerGas) {
@@ -228,20 +225,23 @@ export class FeeService implements IFeeService {
    * @param requestDetails
    * @private
    */
-  private async getFeeFromBlock(block: MirrorNodeBlock, requestDetails: RequestDetails): Promise<string> {
-    let fee = 0;
+  private async getFeeHistoryDataFromBlock(
+    blockNumber: number,
+    requestDetails: RequestDetails,
+  ): Promise<{ fee: string; gasUsedRatio: number }> {
     try {
-      fee = await this.common.getGasPriceInWeibars(requestDetails, `lte:${block.timestamp.to}`);
+      const block = await this.mirrorNodeClient.getBlock(blockNumber, requestDetails);
+      const fee = await this.common.getGasPriceInWeibars(requestDetails, `lte:${block.timestamp.to}`);
+      const gasUsedRatio = this.getGasUsedRatioForBlock(block);
+      return { fee: numberTo0x(fee), gasUsedRatio };
     } catch (error) {
       this.logger.warn(
         error,
-        `Fee history cannot retrieve block or fee. Returning %s fee for block %s`,
-        fee,
-        block.number,
+        `Fee history cannot retrieve block or fee. Returning zero fee and gasUsedRatio for block %s`,
+        blockNumber,
       );
+      return { fee: constants.ZERO_HEX, gasUsedRatio: 0 };
     }
-
-    return numberTo0x(fee);
   }
 
   /**

--- a/src/relay/lib/services/ethService/feeService/FeeService.ts
+++ b/src/relay/lib/services/ethService/feeService/FeeService.ts
@@ -248,7 +248,6 @@ export class FeeService implements IFeeService {
    * Returns the `gasUsedRatio` entry for for a block
    * `gasUsed / blockGasLimit`, using {@link MirrorNodeBlock.gas_used} as gas used.
    *
-   * If the effective block gas limit is non-positive, logs a warning and returns `0`.
    * If `gasUsed` exceeds that limit, logs a warning and returns `1` (100% usage).
    *
    * @param block - Mirror node block metadata (must include `number`, `gas_used`)

--- a/src/relay/lib/types/mirrorNode.ts
+++ b/src/relay/lib/types/mirrorNode.ts
@@ -153,7 +153,7 @@ export interface LatestBlockNumberTimestamp {
 
 export interface MirrorNodeBlock {
   count: number;
-  gas_used: number;
+  gas_used?: number;
   hapi_version: string;
   hash: string;
   logs_bloom: string;

--- a/tests/relay/lib/eth/eth_feeHistory.spec.ts
+++ b/tests/relay/lib/eth/eth_feeHistory.spec.ts
@@ -170,7 +170,7 @@ describe('@ethFeeHistory using MirrorNode', async function () {
     function feeHistoryOnErrorExpect(feeHistory: any) {
       expect(feeHistory).to.exist;
       expect(feeHistory['baseFeePerGas'][0]).to.equal('0x0');
-      expect(feeHistory['gasUsedRatio'][0]).to.equal(0);
+      expect(feeHistory['gasUsedRatio'][0]).to.equal(0.03333333333333333);
       expect(feeHistory['oldestBlock']).to.equal(`0x${latestBlock.number.toString(16)}`);
     }
 
@@ -194,6 +194,35 @@ describe('@ethFeeHistory using MirrorNode', async function () {
     it('eth_feeHistory on mirror 500', async function () {
       const feeHistory = await ethImpl.feeHistory(1, 'latest', null, requestDetails);
       feeHistoryOnErrorExpect(feeHistory);
+    });
+  });
+
+  describe('eth_feeHistory when block fetch returns null', function () {
+    const latestBlock = { ...DEFAULT_BLOCK, number: BLOCK_NUMBER_3 };
+
+    this.beforeEach(() => {
+      restMock.onGet(BLOCKS_LIMIT_ORDER_URL).reply(200, JSON.stringify({ blocks: [latestBlock] }));
+      restMock.onGet(`blocks/${latestBlock.number}`).reply(404, JSON.stringify(NOT_FOUND_RES));
+    });
+
+    it('returns zero fee and zero gasUsedRatio', async function () {
+      const feeHistory = await ethImpl.feeHistory(1, 'latest', null, requestDetails);
+
+      expect(feeHistory).to.exist;
+      expect(feeHistory['baseFeePerGas'][0]).to.equal(constants.ZERO_HEX);
+      expect(feeHistory['gasUsedRatio'][0]).to.equal(0);
+      expect(feeHistory['oldestBlock']).to.equal(`0x${latestBlock.number.toString(16)}`);
+    });
+
+    it('returns zero fee and zero gasUsedRatio with reward percentiles', async function () {
+      const feeHistory = await ethImpl.feeHistory(1, 'latest', [25, 75], requestDetails);
+
+      expect(feeHistory).to.exist;
+      expect(feeHistory['baseFeePerGas'][0]).to.equal(constants.ZERO_HEX);
+      expect(feeHistory['gasUsedRatio'][0]).to.equal(0);
+      const rewards = feeHistory['reward'][0];
+      expect(rewards[0]).to.equal('0x0');
+      expect(rewards[1]).to.equal('0x0');
     });
   });
 

--- a/tests/relay/lib/eth/eth_feeHistory.spec.ts
+++ b/tests/relay/lib/eth/eth_feeHistory.spec.ts
@@ -76,6 +76,7 @@ describe('@ethFeeHistory using MirrorNode', async function () {
       expect(feeHistory['baseFeePerGas'][0]).to.equal('0x870ab1a800');
       expect(feeHistory['baseFeePerGas'][1]).to.equal('0x84b6a5c400');
       expect(feeHistory['baseFeePerGas'][2]).to.equal('0x84b6a5c400');
+      //0.03333333333333333 comes from gasUsed 1_000_000 / 30_000_000 gasLimit for the test block (hapi version 0.28.1)
       expect(feeHistory['gasUsedRatio'][0]).to.equal(0.03333333333333333);
       expect(feeHistory['oldestBlock']).to.equal(`0x${previousBlock.number.toString(16)}`);
       const rewards = feeHistory['reward'][0];
@@ -156,6 +157,7 @@ describe('@ethFeeHistory using MirrorNode', async function () {
 
     expect(firstFeeHistory).to.exist;
     expect(firstFeeHistory['baseFeePerGas'][0]).to.equal(BASE_FEE_PER_GAS_HEX);
+    //0.03333333333333333 comes from gasUsed 1_000_000 / 30_000_000 gasLimit for the test block (hapi version 0.28.1)
     expect(firstFeeHistory['gasUsedRatio'][0]).to.equal(0.03333333333333333);
     expect(firstFeeHistory['oldestBlock']).to.equal(hexBlockNumber);
 
@@ -168,7 +170,7 @@ describe('@ethFeeHistory using MirrorNode', async function () {
     function feeHistoryOnErrorExpect(feeHistory: any) {
       expect(feeHistory).to.exist;
       expect(feeHistory['baseFeePerGas'][0]).to.equal('0x0');
-      expect(feeHistory['gasUsedRatio'][0]).to.equal(0.03333333333333333);
+      expect(feeHistory['gasUsedRatio'][0]).to.equal(0);
       expect(feeHistory['oldestBlock']).to.equal(`0x${latestBlock.number.toString(16)}`);
     }
 

--- a/tests/relay/lib/eth/eth_feeHistory.spec.ts
+++ b/tests/relay/lib/eth/eth_feeHistory.spec.ts
@@ -15,7 +15,6 @@ import {
   BLOCKS_LIMIT_ORDER_URL,
   DEFAULT_BLOCK,
   DEFAULT_NETWORK_FEES,
-  GAS_USED_RATIO,
   NOT_FOUND_RES,
 } from './eth-config';
 import { generateEthTestEnv } from './eth-helpers';
@@ -77,7 +76,7 @@ describe('@ethFeeHistory using MirrorNode', async function () {
       expect(feeHistory['baseFeePerGas'][0]).to.equal('0x870ab1a800');
       expect(feeHistory['baseFeePerGas'][1]).to.equal('0x84b6a5c400');
       expect(feeHistory['baseFeePerGas'][2]).to.equal('0x84b6a5c400');
-      expect(feeHistory['gasUsedRatio'][0]).to.equal(GAS_USED_RATIO);
+      expect(feeHistory['gasUsedRatio'][0]).to.equal(0.03333333333333333);
       expect(feeHistory['oldestBlock']).to.equal(`0x${previousBlock.number.toString(16)}`);
       const rewards = feeHistory['reward'][0];
       expect(rewards[0]).to.equal('0x0');
@@ -157,7 +156,7 @@ describe('@ethFeeHistory using MirrorNode', async function () {
 
     expect(firstFeeHistory).to.exist;
     expect(firstFeeHistory['baseFeePerGas'][0]).to.equal(BASE_FEE_PER_GAS_HEX);
-    expect(firstFeeHistory['gasUsedRatio'][0]).to.equal(GAS_USED_RATIO);
+    expect(firstFeeHistory['gasUsedRatio'][0]).to.equal(0.03333333333333333);
     expect(firstFeeHistory['oldestBlock']).to.equal(hexBlockNumber);
 
     expect(firstFeeHistory).to.equal(secondFeeHistory);
@@ -169,7 +168,7 @@ describe('@ethFeeHistory using MirrorNode', async function () {
     function feeHistoryOnErrorExpect(feeHistory: any) {
       expect(feeHistory).to.exist;
       expect(feeHistory['baseFeePerGas'][0]).to.equal('0x0');
-      expect(feeHistory['gasUsedRatio'][0]).to.equal(GAS_USED_RATIO);
+      expect(feeHistory['gasUsedRatio'][0]).to.equal(0.03333333333333333);
       expect(feeHistory['oldestBlock']).to.equal(`0x${latestBlock.number.toString(16)}`);
     }
 

--- a/tests/relay/lib/services/feeService/FeeService.spec.ts
+++ b/tests/relay/lib/services/feeService/FeeService.spec.ts
@@ -1,17 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
 import { expect } from 'chai';
 import { Logger } from 'pino';
 import sinon from 'sinon';
 
-import { numberTo0x } from '../../../../src/formatters';
-import * as blockGasLimit from '../../../../src/lib/config/blockGasLimit';
-import constants from '../../../../src/lib/constants';
-import { FeeService } from '../../../../src/lib/services/ethService/feeService/FeeService';
-import { RequestDetails } from '../../../../src/lib/types';
-import { IFeeHistory } from '../../../../src/lib/types/IFeeHistory';
-import { MirrorNodeBlock } from '../../../../src/lib/types/mirrorNode';
+import { ConfigService } from '../../../../../src/config-service/services';
+import { numberTo0x } from '../../../../../src/relay/formatters';
+import * as blockGasLimit from '../../../../../src/relay/lib/config/blockGasLimit';
+import constants from '../../../../../src/relay/lib/constants';
+import { FeeService } from '../../../../../src/relay/lib/services/ethService/feeService/FeeService';
+import { IFeeHistory, MirrorNodeBlock, RequestDetails } from '../../../../../src/relay/lib/types';
 
 describe('FeeService', function () {
   const requestDetails = new RequestDetails({ requestId: 'feeServiceUnitTest', ipAddress: '0.0.0.0' });

--- a/tests/relay/lib/services/feeService/FeeService.spec.ts
+++ b/tests/relay/lib/services/feeService/FeeService.spec.ts
@@ -4,12 +4,12 @@ import { expect } from 'chai';
 import { Logger } from 'pino';
 import sinon from 'sinon';
 
-import { ConfigService } from '../../../../../src/config-service/services';
 import { numberTo0x } from '../../../../../src/relay/formatters';
 import * as blockGasLimit from '../../../../../src/relay/lib/config/blockGasLimit';
 import constants from '../../../../../src/relay/lib/constants';
 import { FeeService } from '../../../../../src/relay/lib/services/ethService/feeService/FeeService';
 import { IFeeHistory, MirrorNodeBlock, RequestDetails } from '../../../../../src/relay/lib/types';
+import { withOverriddenEnvsInMochaTest } from '../../../helpers';
 
 describe('FeeService', function () {
   const requestDetails = new RequestDetails({ requestId: 'feeServiceUnitTest', ipAddress: '0.0.0.0' });
@@ -37,45 +37,41 @@ describe('FeeService', function () {
       getGasPriceInWeibars: sinon.SinonStub;
     };
 
-    beforeEach(function () {
-      sinon.stub(ConfigService, 'get').callsFake((key: string) => {
-        if (key === 'TEST') return true;
-        if (key === 'ETH_FEE_HISTORY_FIXED') return false;
-        return undefined;
+    withOverriddenEnvsInMochaTest({ TEST: true, ETH_FEE_HISTORY_FIXED: false }, () => {
+      beforeEach(function () {
+        mirrorStub = { getBlock: sinon.stub() };
+        commonStub = {
+          translateBlockTag: sinon.stub(),
+          getGasPriceInWeibars: sinon.stub(),
+        };
+
+        const logger = { error: sinon.stub(), warn: sinon.stub() } as unknown as Logger;
+        feeService = new FeeService(mirrorStub as any, commonStub as any, logger);
+
+        const head = 100;
+        commonStub.translateBlockTag.withArgs(constants.BLOCK_LATEST, requestDetails).resolves(head);
+
+        const block = minimalMirrorBlock(head, 1_000_000, '0.0.0');
+        mirrorStub.getBlock.withArgs(head, requestDetails).resolves(block);
+        commonStub.getGasPriceInWeibars.withArgs(requestDetails, `lte:${block.timestamp.to}`).resolves(77);
       });
 
-      mirrorStub = { getBlock: sinon.stub() };
-      commonStub = {
-        translateBlockTag: sinon.stub(),
-        getGasPriceInWeibars: sinon.stub(),
-      };
+      afterEach(function () {
+        sinon.restore();
+      });
 
-      const logger = { error: sinon.stub(), warn: sinon.stub() } as unknown as Logger;
-      feeService = new FeeService(mirrorStub as any, commonStub as any, logger);
+      it('returns fee history with gasUsedRatio from obtainBlockGasLimit(hapi_version) when newest block is latest', async function () {
+        const result = await feeService.feeHistory(1, 'latest', null, requestDetails);
 
-      const head = 100;
-      commonStub.translateBlockTag.withArgs(constants.BLOCK_LATEST, requestDetails).resolves(head);
-
-      const block = minimalMirrorBlock(head, 1_000_000, '0.0.0');
-      mirrorStub.getBlock.withArgs(head, requestDetails).resolves(block);
-      commonStub.getGasPriceInWeibars.withArgs(requestDetails, `lte:${block.timestamp.to}`).resolves(77);
-    });
-
-    afterEach(function () {
-      sinon.restore();
-    });
-
-    it('returns fee history with gasUsedRatio from obtainBlockGasLimit(hapi_version) when newest block is latest', async function () {
-      const result = await feeService.feeHistory(1, 'latest', null, requestDetails);
-
-      expect(result).to.not.have.property('code');
-      const feeHistory = result as IFeeHistory;
-      const expectedLimit = blockGasLimit.obtainBlockGasLimit('0.0.0');
-      expect(feeHistory.oldestBlock).to.equal(numberTo0x(100));
-      expect(feeHistory.gasUsedRatio).to.deep.equal([1_000_000 / expectedLimit]);
-      expect(feeHistory.baseFeePerGas).to.deep.equal([numberTo0x(77), numberTo0x(77)]);
-      expect(mirrorStub.getBlock.callCount).to.equal(1);
-      expect(mirrorStub.getBlock.firstCall.args).to.deep.equal([100, requestDetails]);
+        expect(result).to.not.have.property('code');
+        const feeHistory = result as IFeeHistory;
+        const expectedLimit = blockGasLimit.obtainBlockGasLimit('0.0.0');
+        expect(feeHistory.oldestBlock).to.equal(numberTo0x(100));
+        expect(feeHistory.gasUsedRatio).to.deep.equal([1_000_000 / expectedLimit]);
+        expect(feeHistory.baseFeePerGas).to.deep.equal([numberTo0x(77), numberTo0x(77)]);
+        expect(mirrorStub.getBlock.callCount).to.equal(1);
+        expect(mirrorStub.getBlock.firstCall.args).to.deep.equal([100, requestDetails]);
+      });
     });
   });
 

--- a/tests/server/helpers/assertions.ts
+++ b/tests/server/helpers/assertions.ts
@@ -313,12 +313,6 @@ export default class Assertions {
       expected.oldestBlock,
     );
 
-    res.gasUsedRatio.map((gasRatio: string) =>
-      expect(gasRatio, "Assert feeHistory: 'gasRatio' should equal 'defaultGasUsed'").to.equal(
-        Assertions.defaultGasUsed,
-      ),
-    );
-
     if (expected.checkReward) {
       expect(res.reward, "Assert feeHistory: 'reward' should exist and be an Array").to.exist.to.be.an('Array');
       expect(res.reward.length, "Assert feeHistory: 'reward' length should equal passed expected value").to.equal(


### PR DESCRIPTION
### Description

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

This PR improves eth_feeHistory by computing gasUsedRatio from mirror block data (gas_used) divided by the effective block gas limit for that block’s HAPI version, using obtainBlockGasLimit from blockGasLimit.ts. The fee-history path fetches each block once and reuses it for both base-fee lookup and the ratio. Integration and server tests no longer assume every gasUsedRatio matches one global default.

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #5066

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1. Set `ETH_FEE_HISTORY_FIXED=false`
2. Find a block on network that has non-zero gas used (mainnet example: 92814068)
3. Query relay with 
```
{
  "method": "eth_feeHistory",
  "params": [
    "0x1",
    "0x5883AF4",
    [
      25,
      75
    ]
  ],
  "id": 1,
  "jsonrpc": "2.0"
}
```

4. Validate gasUsed ratio correctness

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
