### PR TITLE
feat: reduce memory footprint by replacing full ethers.js import with selective submodule imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9761,21 +9761,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC"
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",

--- a/packages/relay/src/lib/clients/mirrorNodeClient.ts
+++ b/packages/relay/src/lib/clients/mirrorNodeClient.ts
@@ -4,7 +4,6 @@ import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services'
 import Axios, { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 import axiosRetry from 'axios-retry';
 import { install as betterLookupInstall } from 'better-lookup';
-import { ethers } from 'ethers';
 import http from 'http';
 import https from 'https';
 import JSONBigInt from 'json-bigint';
@@ -1120,7 +1119,7 @@ export class MirrorNodeClient {
     contractLogsResultsParams?: IContractLogsResultsParams,
     limitOrderParams?: ILimitOrderParams,
   ): Promise<MirrorNodeContractLog[]> {
-    if (address === ethers.ZeroAddress) return [];
+    if (address === constants.ZERO_ADDRESS_HEX) return [];
 
     const apiEndpoint = MirrorNodeClient.GET_CONTRACT_RESULT_LOGS_BY_ADDRESS_ENDPOINT.replace(
       MirrorNodeClient.ADDRESS_PLACEHOLDER,

--- a/packages/relay/src/lib/db/repositories/hbarLimiter/hbarSpendingPlanRepository.ts
+++ b/packages/relay/src/lib/db/repositories/hbarLimiter/hbarSpendingPlanRepository.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { randomBytes, uuidV4 } from 'ethers';
+import { randomUUID } from 'crypto';
 import { Logger } from 'pino';
 
 import type { ICacheClient } from '../../../clients/cache/ICacheClient';
@@ -72,7 +72,7 @@ export class HbarSpendingPlanRepository {
    */
   async create(subscriptionTier: SubscriptionTier, ttl: number, planId?: string): Promise<IDetailedHbarSpendingPlan> {
     const plan: IDetailedHbarSpendingPlan = {
-      id: planId ?? uuidV4(randomBytes(16)),
+      id: planId ?? randomUUID(),
       subscriptionTier: subscriptionTier,
       createdAt: new Date(),
       active: true,

--- a/packages/relay/src/lib/factories/blockFactory.ts
+++ b/packages/relay/src/lib/factories/blockFactory.ts
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { RLP } from '@ethereumjs/rlp';
-import { AuthorizationLike, ethers } from 'ethers';
+import { Signature } from 'ethers/crypto';
+import type { AuthorizationLike } from 'ethers/transaction';
+import { Transaction as EthersTransaction } from 'ethers/transaction';
 
 import { numberTo0x, prepend0x, strip0x, toHash32 } from '../../formatters';
 import { obtainBlockGasLimit } from '../config/blockGasLimit';
@@ -70,7 +72,7 @@ export class BlockFactory {
     const r = tx.r === '0x' || tx.r === '0x0' ? constants.ZERO_HEX_32_BYTE : prepend0x(strip0x(tx.r).padStart(64, '0'));
     const s = tx.s === '0x' || tx.s === '0x0' ? constants.ZERO_HEX_32_BYTE : prepend0x(strip0x(tx.s).padStart(64, '0'));
 
-    const ethersTx = new ethers.Transaction();
+    const ethersTx = new EthersTransaction();
 
     // Common fields
     ethersTx.type = txType;
@@ -95,7 +97,7 @@ export class BlockFactory {
                 chainId: entry.chainId,
                 nonce: entry.nonce,
                 address: entry.address,
-                signature: ethers.Signature.from({
+                signature: Signature.from({
                   r: entry.r,
                   s: entry.s,
                   yParity: Number(entry.yParity) as 0 | 1,
@@ -130,7 +132,7 @@ export class BlockFactory {
       return ethersTx.unsignedSerialized;
     }
 
-    ethersTx.signature = ethers.Signature.from({
+    ethersTx.signature = Signature.from({
       r,
       s,
       v: Number(tx.v ?? '0x0'),

--- a/packages/relay/src/lib/precheck.ts
+++ b/packages/relay/src/lib/precheck.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
-import { ethers, Transaction } from 'ethers';
+import { Transaction } from 'ethers/transaction';
 
 import { prepend0x } from '../formatters';
 import { MirrorNodeClient } from './clients';
@@ -66,7 +66,7 @@ export class Precheck {
    * @param parsedTx - The parsed transaction.
    * @throws If the transaction does not meet tx-pool eligibility requirements.
    */
-  validateBasicPropertiesStateless(parsedTx: ethers.Transaction) {
+  validateBasicPropertiesStateless(parsedTx: Transaction) {
     this.callDataSize(parsedTx);
     this.transactionSize(parsedTx);
     this.transactionType(parsedTx);
@@ -88,7 +88,7 @@ export class Precheck {
    * @throws If the transaction does not meet send-time requirements.
    */
   async validateAccountAndNetworkStateful(
-    parsedTx: ethers.Transaction,
+    parsedTx: Transaction,
     networkGasPriceInWeiBars: number,
     requestDetails: RequestDetails,
   ): Promise<void> {

--- a/packages/relay/src/lib/services/ethService/transactionService/TransactionService.ts
+++ b/packages/relay/src/lib/services/ethService/transactionService/TransactionService.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
 import { FileId } from '@hashgraph/sdk';
-import { Transaction as EthersTransaction } from 'ethers';
+import { Transaction as EthersTransaction } from 'ethers/transaction';
 import EventEmitter from 'events';
 import { Logger } from 'pino';
 import { Counter, Registry } from 'prom-client';

--- a/packages/relay/src/lib/services/transactionPoolService/transactionPoolService.ts
+++ b/packages/relay/src/lib/services/transactionPoolService/transactionPoolService.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
-import { Transaction } from 'ethers';
+import { Transaction } from 'ethers/transaction';
 import { Logger } from 'pino';
 import { Counter, Gauge, Registry } from 'prom-client';
 

--- a/packages/relay/src/lib/txpool.ts
+++ b/packages/relay/src/lib/txpool.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ConfigService } from '@hashgraph/json-rpc-config-service/dist/services';
-import { ethers } from 'ethers';
+import { Transaction } from 'ethers/transaction';
 
 import { numberTo0x } from '../formatters';
 import { predefined, TxPool } from '../index';
@@ -93,7 +93,7 @@ export class TxPoolImpl implements TxPool {
     const txs: TxPoolTransaction[] = [];
 
     rlpTxs.forEach((rlpTx: string) => {
-      const tx: ethers.Transaction = ethers.Transaction.from(rlpTx);
+      const tx: Transaction = Transaction.from(rlpTx);
 
       const txPoolTransaction: TxPoolTransaction = {
         blockHash: constants.ZERO_HEX_32_BYTE,

--- a/packages/relay/src/lib/types/transactionPool.ts
+++ b/packages/relay/src/lib/types/transactionPool.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { Transaction } from 'ethers';
+import { Transaction } from 'ethers/transaction';
 
 /**
  * Service responsible for managing pending transactions in the pool and coordinating with consensus results.

--- a/packages/relay/src/logsBloomUtils.ts
+++ b/packages/relay/src/logsBloomUtils.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { keccak256 } from 'ethers';
+import { keccak256 } from 'ethers/crypto';
 
 import { prepend0x, strip0x } from './formatters';
 import constants from './lib/constants';

--- a/packages/relay/src/types/ethers-subpath.d.ts
+++ b/packages/relay/src/types/ethers-subpath.d.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * TypeScript declarations for ethers v6 subpath exports.
+ *
+ * ethers v6 exposes individual submodules via its package.json `"exports"` field
+ * (e.g. `ethers/transaction`, `ethers/crypto`). Importing a subpath loads only that
+ * submodule at runtime instead of the entire ethers barrel, significantly reducing
+ * the memory footprint by omitting heavy modules and data tables not required by
+ * the relay.
+ *
+ * This file acts as a "bridge" between the TypeScript compiler and Node.js.
+ * Under the current `moduleResolution: "node"` setting, TypeScript doesn't know
+ * how to find these subpaths. These declarations tell the compiler that these
+ * modules exist and what types they contain, while allowing Node.js to resolve
+ * them correctly at runtime.
+ *
+ * Only add declarations here for subpaths and exports actually used by this package.
+ */
+
+declare module 'ethers/transaction' {
+  export type { AuthorizationLike } from 'ethers';
+  export { Transaction } from 'ethers';
+}
+
+declare module 'ethers/crypto' {
+  export { keccak256, Signature } from 'ethers';
+}


### PR DESCRIPTION
### Description

This PR replaces full `ethers` barrel imports with selective subpath imports (e.g., `ethers/transaction`, `ethers/crypto`) to reduce the relay's memory footprint. In CommonJS mode, `require('ethers')` eagerly evaluates the entire barrel, loading a large chunk of memory of unused code and data into the heap (primarily ENS normalization tables and BIP39 wordlists, ~11MB).

Selective subpath imports ensure only necessary modules are loaded at runtime. An ambient module declaration file has been added to bridge the gap between the TypeScript compiler's `moduleResolution: "node"` and Node.js's ESM subpath exports.

Additional optimizations:

- Replaced `ethers.ZeroAddress` with `constants.ZERO_ADDRESS_HEX`.
- Replaced `uuidV4(randomBytes(16))` with Node's native `crypto.randomUUID()`.

### Related issue(s)

#5137

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
