### PR TITLE
fix: eliminate unnecessary pino worker threads to reduce memory footprint

### DIFF
--- a/packages/config-service/src/services/index.ts
+++ b/packages/config-service/src/services/index.ts
@@ -10,15 +10,31 @@ import { GlobalConfig } from './globalConfig';
 import { LoggerService } from './loggerService';
 import { ValidationService } from './validationService';
 
+// Bootstrap dotenv early so PRETTY_LOGS_ENABLED is available before logger construction.
+// ConfigService loads .env lazily in its constructor, but the logger is created at module
+// load time — before the singleton is ever instantiated. A second dotenv.config() call
+// in the constructor is safe because dotenv does not override variables already in process.env.
+const _bootstrapEnvPath = findConfig('.env');
+if (_bootstrapEnvPath) {
+  dotenv.config({ path: _bootstrapEnvPath });
+}
+
+// Mirror the GlobalConfig default (true): only suppress pino-pretty when the variable is
+// explicitly set to 'false'. Without this guard, pino unconditionally spawns a worker thread
+// for the pino-pretty transport regardless of log level or output destination.
+const _prettyLogsEnabled = process.env.PRETTY_LOGS_ENABLED?.toLowerCase() !== 'false';
+
 const mainLogger = pino({
   name: 'hedera-json-rpc-relay',
-  transport: {
-    target: 'pino-pretty',
-    options: {
-      colorize: true,
-      translateTime: true,
+  ...(_prettyLogsEnabled && {
+    transport: {
+      target: 'pino-pretty',
+      options: {
+        colorize: true,
+        translateTime: true,
+      },
     },
-  },
+  }),
 });
 const logger = mainLogger.child({ name: 'config-service' });
 

--- a/packages/relay/src/lib/clients/sdkClient.ts
+++ b/packages/relay/src/lib/clients/sdkClient.ts
@@ -143,7 +143,15 @@ export class SDKClient {
       client.setOperator(operator.accountId, operator.privateKey);
     }
 
-    const sdkLogger = new HederaLogger(LogLevel._fromString(sdkLogLevel)).setLogger(
+    // supplying '/dev/null' as logFile forces HederaLogger to construct its
+    // internal pino instance with pino.destination() (a SonicBoom stream) rather than a
+    // pino-pretty transport. Without this, HederaLogger unconditionally spawns a worker
+    // thread that persists for the process lifetime even though setLogger() immediately
+    // replaces the internal logger below. The '/dev/null' destination is never written to.
+    // TODO: Remove once @hashgraph/sdk exposes a no-op or silent construction option.
+    //       Upstream ticket https://github.com/hiero-ledger/hiero-sdk-js/issues/3891
+    //       Tech-debt ticket https://github.com/hiero-ledger/hiero-json-rpc-relay/issues/5148
+    const sdkLogger = new HederaLogger(LogLevel._fromString(sdkLogLevel), '/dev/null').setLogger(
       // @ts-ignore
       logger.child({ name: 'sdk-client' }, { level: sdkLogLevel }),
     );


### PR DESCRIPTION
### Description

Eliminates two unnecessary pino-pretty worker threads spawned at startup, reducing the V8 isolate count from 3 (1 main + 2 workers) to 1 and saving ~10 MB RSS permanently.

- **config-service:** The module-level pino logger was unconditionally configured with a `pino-pretty` transport before any `.env` was loaded. Dotenv is now bootstrapped early so the transport is only applied when `PRETTY_LOGS_ENABLED` is not `false`.
- **sdkClient:** `HederaLogger` spawns a pino-pretty worker thread in its constructor even when `setLogger()` immediately replaces the internal logger. Passing `'/dev/null'` as `logFile` forces the `pino.destination()` path instead, avoiding the worker entirely.

### Related issue(s)

Fixes #5138

### Testing Guide

To verify thread reduction, run
```bash
cd packages/server && npm_package_version=0.0.0 PRETTY_LOGS_ENABLED=false node --trace-gc dist/index.js
```
GC events should only appear from a single V8 isolate (main thread), confirming no worker threads are spawned. Revert the script change after verification.


To verify thread more than one thread, run
```bash
cd packages/server && npm_package_version=0.0.0 PRETTY_LOGS_ENABLED=true node --trace-gc dist/index.js
```
GC events should show more than 1 isolates.


### Additional work needed (optional)

- Upstream `@hashgraph/sdk` https://github.com/hiero-ledger/hiero-sdk-js/issues/3891: request a silent/no-op `Logger` construction option to remove the `'/dev/null'` workaround.
- Internal tech debt https://github.com/hiero-ledger/hiero-json-rpc-relay/issues/5148: remove the workaround in `sdkClient.ts` once the upstream SDK fix is available.

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
