### PR TITLE
feat: updates Dockerfile to use bookworm for build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker/dockerfile:1
 
 # ── Build ─────────────────────────────────────────────────────────────────────
-FROM node:22-alpine AS build
+# Use bookworm-slim (glibc) for the build stage to avoid QEMU/musl crashes
+# when cross-compiling for linux/arm64 on amd64 CI runners.
+FROM node:22-bookworm-slim AS build
 
 WORKDIR /home/node/app
 


### PR DESCRIPTION
### Description

Dockerfile now uses bookworm for build stage and alpine for runtime stage, allowing it to pass the runners during release while keeping the memory optimization during runtime

### Related issue(s)

Fixes #5152 

### Testing Guide

Verify builds pass

### Changes from original design (optional)

N/A

### Additional work needed (optional)

N/A

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
