### PR TITLE
chore: cherry pick fix: Fix arm64 Docker build crash by using bookworm-slim for build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # syntax=docker/dockerfile:1
 
 # ── Build ─────────────────────────────────────────────────────────────────────
-FROM node:22-alpine AS build
+# Use bookworm-slim (glibc) for the build stage to avoid QEMU/musl crashes
+# when cross-compiling for linux/arm64 on amd64 CI runners.
+FROM node:22-bookworm-slim AS build
 
 WORKDIR /home/node/app
 


### PR DESCRIPTION
### Description

Cherry Pick 

### Related issue(s)


Fixes #5152

### Testing Guide


1.
2.
3.

### Changes from original design (optional)

N/A

### Additional work needed (optional)



N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
