### PR TITLE
feat: add startupProbe to relay and websocket Helm charts to reduce startup time

### DIFF
--- a/charts/hedera-json-rpc-relay-websocket/templates/deployment.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/templates/deployment.yaml
@@ -40,6 +40,7 @@ spec:
         ports: {{- toYaml .Values.ports | nindent 12 }}
         livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
         readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
+        startupProbe: {{- toYaml .Values.startupProbe | nindent 12 }}
         resources: {{- toYaml .Values.resources | nindent 12 }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/hedera-json-rpc-relay-websocket/values.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/values.yaml
@@ -115,7 +115,6 @@ livenessProbe:
   httpGet:
     path: /health/liveness
     port: metrics
-  initialDelaySeconds: 20
   periodSeconds: 10
   timeoutSeconds: 5
 
@@ -177,8 +176,15 @@ readinessProbe:
   httpGet:
     path: /health/readiness
     port: metrics
-  initialDelaySeconds: 20
   timeoutSeconds: 5
+
+startupProbe:
+  failureThreshold: 20
+  httpGet:
+    path: /health/readiness
+    port: metrics
+  periodSeconds: 1
+  timeoutSeconds: 1
 
 terminationGracePeriodSeconds: 60
 

--- a/charts/hedera-json-rpc-relay/templates/deployment.yaml
+++ b/charts/hedera-json-rpc-relay/templates/deployment.yaml
@@ -44,6 +44,7 @@ spec:
             name: {{ .Values.ports.name  }}
         livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
         readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
+        startupProbe: {{- toYaml .Values.startupProbe | nindent 12 }}
         resources: {{- toYaml .Values.resources | nindent 12 }}      
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hedera-json-rpc-relay/values.yaml
+++ b/charts/hedera-json-rpc-relay/values.yaml
@@ -194,7 +194,6 @@ livenessProbe:
   httpGet:
     path: /health/liveness
     port: jsonrpcrelay
-  initialDelaySeconds: 20
   periodSeconds: 10
   timeoutSeconds: 5
 
@@ -258,8 +257,15 @@ readinessProbe:
   httpGet:
     path: /health/readiness
     port: jsonrpcrelay
-  initialDelaySeconds: 20
   timeoutSeconds: 5
+
+startupProbe:
+  failureThreshold: 20
+  httpGet:
+    path: /health/readiness
+    port: jsonrpcrelay
+  periodSeconds: 1
+  timeoutSeconds: 1
 
 test:
   enabled: false


### PR DESCRIPTION
### Description

This PR adds a `startupProbe` to both relay Helm charts to eliminate the fixed 20s blind wait on startup. The relay is ready in under 1 second, so `initialDelaySeconds: 20` on liveness/readiness probes was the primary source of deployment delay. The `startupProbe` now gates probe execution on actual readiness, reducing Solo startup time

**Key changes:**

- Added `startupProbe` (polls `/health/readiness` every 1s, 20-failure threshold) to `hedera-json-rpc-relay` and `hedera-json-rpc-relay-websocket`
- Removed `initialDelaySeconds` from `livenessProbe` and `readinessProbe` in both charts

### Related issue(s)

Fixes #5206

### Testing Guide

1. Deploy relay via Solo: `solo relay node add --deployment <name> --relay-chart-dir <path/to/charts>`
2. Observe `Check relay is ready` step completes in ~1s (was ~19s before)
3. Confirm startupProbe is applied: `kubectl get pod <relay-pod> -n <namespace> -o jsonpath='{.spec.containers[0].startupProbe}'`

### Changes from original design (optional)

N/A

### Additional work needed (optional)

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
