### PR TITLE
fix: changed assertion for gasUsed to match blockGasLimit implementation (#5189)

### DIFF
--- a/tests/server/helpers/assertions.ts
+++ b/tests/server/helpers/assertions.ts
@@ -7,6 +7,7 @@ import { ethers } from 'ethers';
 import { ConfigService } from '../../../src/config-service/services';
 import { JsonRpcError, predefined } from '../../../src/relay';
 import { numberTo0x } from '../../../src/relay/formatters';
+import { obtainBlockGasLimit } from '../../../src/relay/lib/config/blockGasLimit';
 import constants from '../../../src/relay/lib/constants';
 import RelayAssertions from '../../relay/assertions';
 
@@ -25,7 +26,6 @@ export default class Assertions {
   static defaultGasPrice = 710_000_000_000;
   static datedGasPrice = 570_000_000_000;
   static updatedGasPrice = 640_000_000_000;
-  static maxBlockGasLimit = 30_000_000;
   static defaultGasUsed = 0.5;
 
   public static readonly gasPriceDeviation = ConfigService.get('TEST_GAS_PRICE_DEVIATION');
@@ -97,9 +97,10 @@ export default class Assertions {
     expect(relayResponse.logsBloom, "Assert block: 'logsBloom' should equal mirrorNode response").to.eq(
       mirrorNodeResponse.logs_bloom === Assertions.emptyHex ? constants.EMPTY_BLOOM : mirrorNodeResponse.logs_bloom,
     );
-    expect(relayResponse.gasLimit, "Assert block: 'gasLimit' should equal 'maxBlockGasLimit'").to.equal(
-      ethers.toQuantity(Assertions.maxBlockGasLimit),
-    );
+    expect(
+      relayResponse.gasLimit,
+      "Assert block: 'gasLimit' should equal block gas limit for the given HAPI version",
+    ).to.eq(ethers.toQuantity(obtainBlockGasLimit(mirrorNodeResponse.hapi_version)));
 
     // Assert dynamic values
     expect(relayResponse.hash, "Assert block: 'hash' should equal mirrorNode response").to.be.equal(


### PR DESCRIPTION
### Description

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

This PR fixes an issue where acceptance test assertions were hardcoding blockGasLimit to 30_000_000 instead of deriving it dynamically based on the HAPI version of the block being tested.

The static Assertions.maxBlockGasLimit = 30_000_000 constant has been removed. The block assertion for gasLimit now calls obtainBlockGasLimit(mirrorNodeResponse.hapi_version), which returns the correct gas limit for the HAPI version the block was produced under. This makes the test suite correct across network upgrades where the block gas limit changes.

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #5189 

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1. Run the acceptance test suite covering block-related assertions:
    - `npx mocha tests/server/acceptance/rpc_batch1.spec.ts`
2. Verify that block gasLimit assertions pass on nodes running different HAPI versions without needing to hardcode the expected value.
3. Confirm that the removed Assertions.maxBlockGasLimit constant is not referenced anywhere else in the test suite.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
