### PR TITLE
fix: improve Mirror Node startup retry to handle transient gateway errors

### DIFF
--- a/src/relay/lib/clients/mirrorNodeClient.ts
+++ b/src/relay/lib/clients/mirrorNodeClient.ts
@@ -584,13 +584,14 @@ export class MirrorNodeClient {
    * is ready to accept API requests.
    *
    * The probe targets `GET /health/readiness`, which the Mirror Node exposes specifically
-   * for infrastructure health checks (Kubernetes readiness probes). Any genuine HTTP
-   * response — including 4xx from reverse-proxy setups that block the path — is treated
-   * as confirmation that the server is reachable at the network level. Only network-layer
-   * failures (ECONNREFUSED, connection timeout) are surfaced as errors.
+   * for infrastructure health checks (Kubernetes readiness probes). Most HTTP responses
+   * are treated as confirmation that the server is reachable at the network level, with
+   * the exception of 502 (Bad Gateway), 503 (Service Unavailable), and 504 (Gateway
+   * Timeout), which are thrown as errors so the startup retry loop can handle them as
+   * transient unavailability.
    *
    * @throws {MirrorNodeClientError} When the server is not reachable due to a
-   *   network-level failure (ECONNREFUSED or connection timeout).
+   *   network-level failure (ECONNREFUSED, connection timeout, 502, 503, or 504).
    */
   public async checkServerReadiness(): Promise<void> {
     // When constructed with an injected Axios instance the base URL is unavailable;
@@ -603,12 +604,24 @@ export class MirrorNodeClient {
     try {
       await this.restClient.get(healthUrl);
     } catch (error: unknown) {
-      // Any genuine HTTP response (4xx, 5xx) confirms the server is reachable at the
-      // network level — only the application layer rejected the request.
-      const axiosError = error as { response?: unknown; code?: string; message?: string };
+      const axiosError = error as { response?: { status?: number }; code?: string; message?: string };
+
       if (axiosError.response) {
+        // HTTP response received, meaning network is up but might be temporarily unavailable due to migration process.
+        // Throw only for transient gateway errors (502/503/504); all other responses mean the server is reachable.
+        const httpStatus = axiosError.response.status ?? MirrorNodeClient.unknownServerErrorHttpStatusCode;
+        if (
+          httpStatus === MirrorNodeClientError.statusCodes.BAD_GATEWAY ||
+          httpStatus === MirrorNodeClientError.statusCodes.SERVICE_UNAVAILABLE ||
+          httpStatus === MirrorNodeClientError.statusCodes.GATEWAY_TIMEOUT
+        ) {
+          throw new MirrorNodeClientError(axiosError, httpStatus);
+        }
         return;
       }
+
+      // No HTTP response, meaning request never completed (ECONNREFUSED, ECONNABORTED, etc.).
+      // Map the axios error code to an internal pseudo-code and always throw.
       const statusCode =
         MirrorNodeClientError.ErrorCodes[axiosError.code ?? ''] ?? MirrorNodeClient.unknownServerErrorHttpStatusCode;
       throw new MirrorNodeClientError(axiosError, statusCode);

--- a/src/relay/lib/errors/MirrorNodeClientError.ts
+++ b/src/relay/lib/errors/MirrorNodeClientError.ts
@@ -18,6 +18,9 @@ export class MirrorNodeClientError extends Error {
     NOT_FOUND: 404,
     TOO_MANY_REQUESTS: 429,
     NO_CONTENT: 204,
+    BAD_GATEWAY: 502,
+    SERVICE_UNAVAILABLE: 503,
+    GATEWAY_TIMEOUT: 504,
   };
 
   static messages = {
@@ -54,8 +57,18 @@ export class MirrorNodeClientError extends Error {
     return this.statusCode === MirrorNodeClientError.ErrorCodes.ECONNABORTED;
   }
 
+  /**
+   * Returns true for transient conditions that are safe to retry during Mirror Node startup:
+   * ECONNREFUSED, connection timeout, 502 (Bad Gateway), 503 (Service Unavailable), 504 (Gateway Timeout).
+   */
   public isNetworkUnavailable(): boolean {
-    return this.statusCode === MirrorNodeClientError.ErrorCodes.ECONNREFUSED || this.isTimeout();
+    return (
+      this.statusCode === MirrorNodeClientError.ErrorCodes.ECONNREFUSED ||
+      this.isTimeout() ||
+      this.statusCode === MirrorNodeClientError.statusCodes.BAD_GATEWAY ||
+      this.statusCode === MirrorNodeClientError.statusCodes.SERVICE_UNAVAILABLE ||
+      this.statusCode === MirrorNodeClientError.statusCodes.GATEWAY_TIMEOUT
+    );
   }
 
   public isContractRevert() {

--- a/src/relay/lib/relay.ts
+++ b/src/relay/lib/relay.ts
@@ -433,9 +433,9 @@ export class Relay {
    * configured attempt budget is exhausted.
    *
    * Each attempt calls {@link MirrorNodeClient.checkServerReadiness}, which targets the
-   * dedicated `GET /health/readiness` endpoint. Any genuine HTTP response is treated as
-   * confirmation that the server is reachable; only network-level failures (ECONNREFUSED,
-   * connection timeout) trigger a retry.
+   * dedicated `GET /health/readiness` endpoint. Only transient network or service
+   * unavailability conditions (ECONNREFUSED, connection timeout, 502 Bad Gateway,
+   * 503 Service Unavailable, or 504 Gateway Timeout) trigger a retry; all other errors abort startup immediately.
    *
    * Attempts are bounded by `MIRROR_NODE_STARTUP_MAX_ATTEMPTS` (total attempt count).
    *

--- a/tests/relay/lib/mirrorNodeClient.spec.ts
+++ b/tests/relay/lib/mirrorNodeClient.spec.ts
@@ -2642,4 +2642,75 @@ describe('MirrorNodeClient', async function () {
       });
     });
   });
+
+  describe('checkServerReadiness', () => {
+    let readinessClient: MirrorNodeClient;
+    let readinessMock: MockAdapter;
+
+    before(() => {
+      // Create a client without an injected axios instance so restUrl is populated
+      // and checkServerReadiness performs a real probe.
+      readinessClient = new MirrorNodeClient(
+        'http://localhost:5551/api/v1',
+        logger.child({ name: 'mirror-node-readiness' }),
+        registry,
+        cacheService,
+      );
+      readinessMock = new MockAdapter((readinessClient as any).restClient);
+    });
+
+    afterEach(() => {
+      readinessMock.reset();
+    });
+
+    it('should resolve when the health endpoint returns 200', async () => {
+      readinessMock.onGet(/\/health\/readiness/).reply(200);
+      await expect(readinessClient.checkServerReadiness()).to.not.be.rejected;
+    });
+
+    it('should throw MirrorNodeClientError with status 503 when Mirror Node returns 503', async () => {
+      readinessMock.onGet(/\/health\/readiness/).reply(503);
+      const error = await readinessClient.checkServerReadiness().catch((e) => e);
+      expect(error).to.be.instanceOf(MirrorNodeClientError);
+      expect((error as MirrorNodeClientError).statusCode).to.equal(503);
+    });
+
+    it('should throw MirrorNodeClientError with status 502 when a gateway returns 502', async () => {
+      readinessMock.onGet(/\/health\/readiness/).reply(502);
+      const error = await readinessClient.checkServerReadiness().catch((e) => e);
+      expect(error).to.be.instanceOf(MirrorNodeClientError);
+      expect((error as MirrorNodeClientError).statusCode).to.equal(502);
+    });
+
+    it('should throw MirrorNodeClientError with status 504 when a gateway returns 504', async () => {
+      readinessMock.onGet(/\/health\/readiness/).reply(504);
+      const error = await readinessClient.checkServerReadiness().catch((e) => e);
+      expect(error).to.be.instanceOf(MirrorNodeClientError);
+      expect((error as MirrorNodeClientError).statusCode).to.equal(504);
+    });
+
+    it('should throw MirrorNodeClientError when the connection times out (no HTTP response)', async () => {
+      readinessMock.onGet(/\/health\/readiness/).timeout();
+      const error = await readinessClient.checkServerReadiness().catch((e) => e);
+      expect(error).to.be.instanceOf(MirrorNodeClientError);
+      // ECONNABORTED maps to the internal pseudo-code 504
+      expect((error as MirrorNodeClientError).statusCode).to.equal(MirrorNodeClientError.ErrorCodes.ECONNABORTED);
+    });
+
+    it('should throw MirrorNodeClientError when no HTTP response is received (network error)', async () => {
+      readinessMock.onGet(/\/health\/readiness/).networkError();
+      const error = await readinessClient.checkServerReadiness().catch((e) => e);
+      expect(error).to.be.instanceOf(MirrorNodeClientError);
+    });
+
+    it('should resolve when Mirror Node returns 500 (server reachable, non-transient error)', async () => {
+      readinessMock.onGet(/\/health\/readiness/).reply(500);
+      await expect(readinessClient.checkServerReadiness()).to.not.be.rejected;
+    });
+
+    it('should resolve when Mirror Node returns 404 (server reachable, non-transient error)', async () => {
+      readinessMock.onGet(/\/health\/readiness/).reply(404);
+      await expect(readinessClient.checkServerReadiness()).to.not.be.rejected;
+    });
+  });
 });

--- a/tests/relay/lib/relay.spec.ts
+++ b/tests/relay/lib/relay.spec.ts
@@ -259,5 +259,63 @@ describe('Relay', () => {
         });
       },
     );
+
+    withOverriddenEnvsInMochaTest(
+      { MIRROR_NODE_STARTUP_MAX_ATTEMPTS: 3, MIRROR_NODE_STARTUP_RETRY_DELAY_MS: 10 },
+      () => {
+        it('should retry when Mirror Node returns 503 Service Unavailable during startup', async function () {
+          const serviceUnavailableError = new MirrorNodeClientError({ message: 'Service Unavailable' }, 503);
+          checkServerReadinessStub.onCall(0).rejects(serviceUnavailableError);
+          checkServerReadinessStub.onCall(1).rejects(serviceUnavailableError);
+          checkServerReadinessStub.onCall(2).resolves();
+
+          await expect(relay.initializeRelay()).to.not.be.rejected;
+          expect(checkServerReadinessStub.callCount).to.equal(3);
+        });
+      },
+    );
+
+    withOverriddenEnvsInMochaTest(
+      { MIRROR_NODE_STARTUP_MAX_ATTEMPTS: 2, MIRROR_NODE_STARTUP_RETRY_DELAY_MS: 10 },
+      () => {
+        it('should reject when Mirror Node keeps returning 503 after exhausting all attempts', async function () {
+          const serviceUnavailableError = new MirrorNodeClientError({ message: 'Service Unavailable' }, 503);
+          checkServerReadinessStub.rejects(serviceUnavailableError);
+
+          await expect(relay.initializeRelay()).to.be.rejected;
+          expect(checkServerReadinessStub.callCount).to.equal(2);
+        });
+      },
+    );
+
+    withOverriddenEnvsInMochaTest(
+      { MIRROR_NODE_STARTUP_MAX_ATTEMPTS: 3, MIRROR_NODE_STARTUP_RETRY_DELAY_MS: 10 },
+      () => {
+        it('should retry when Mirror Node returns 502 Bad Gateway during startup', async function () {
+          const badGatewayError = new MirrorNodeClientError({ message: 'Bad Gateway' }, 502);
+          checkServerReadinessStub.onCall(0).rejects(badGatewayError);
+          checkServerReadinessStub.onCall(1).rejects(badGatewayError);
+          checkServerReadinessStub.onCall(2).resolves();
+
+          await expect(relay.initializeRelay()).to.not.be.rejected;
+          expect(checkServerReadinessStub.callCount).to.equal(3);
+        });
+      },
+    );
+
+    withOverriddenEnvsInMochaTest(
+      { MIRROR_NODE_STARTUP_MAX_ATTEMPTS: 3, MIRROR_NODE_STARTUP_RETRY_DELAY_MS: 10 },
+      () => {
+        it('should retry when Mirror Node returns 504 Gateway Timeout during startup', async function () {
+          const gatewayTimeoutError = new MirrorNodeClientError({ message: 'Gateway Timeout' }, 504);
+          checkServerReadinessStub.onCall(0).rejects(gatewayTimeoutError);
+          checkServerReadinessStub.onCall(1).rejects(gatewayTimeoutError);
+          checkServerReadinessStub.onCall(2).resolves();
+
+          await expect(relay.initializeRelay()).to.not.be.rejected;
+          expect(checkServerReadinessStub.callCount).to.equal(3);
+        });
+      },
+    );
   });
 });


### PR DESCRIPTION
### Description

Improves the Mirror Node startup retry logic to handle transient gateway errors. Previously only connection-level failures (ECONNREFUSED, timeout) were retried. This PR extends coverage to 502, 503, and 504 HTTP responses, which are common when a Mirror Node or its proxy is still initializing, or server is up but its migration process is still running.

**Key changes:**

- `checkServerReadiness` now throws `MirrorNodeClientError` for 502, 503, and 504 responses instead of silently treating them as "reachable"
- `isNetworkUnavailable()` extended to include 502 (Bad Gateway), 503 (Service Unavailable), and 504 (Gateway Timeout), making them retriable in the startup loop alongside existing ECONNREFUSED and connection timeout handling
- 500 and 501 intentionally excluded: 500 indicates a server bug (fail fast), 501 is permanent (retrying will never succeed)

### Related issue(s)

Fixes #5214

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
