### PR TITLE
chore: Cherry pick "feat: add startupProbe to relay and websocket Helm charts to reduce startup time (#5207)"

### DIFF
--- a/charts/hedera-json-rpc-relay-websocket/templates/deployment.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         ports: {{- toYaml .Values.ports | nindent 12 }}
         livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
         readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
+        startupProbe: {{- toYaml .Values.startupProbe | nindent 12 }}
         resources: {{- toYaml .Values.resources | nindent 12 }}
         securityContext:
           {{- toYaml .Values.securityContext | nindent 12 }}

--- a/charts/hedera-json-rpc-relay-websocket/values.yaml
+++ b/charts/hedera-json-rpc-relay-websocket/values.yaml
@@ -111,7 +111,6 @@ livenessProbe:
   httpGet:
     path: /health/liveness
     port: metrics
-  initialDelaySeconds: 20
   periodSeconds: 10
   timeoutSeconds: 5
 
@@ -173,8 +172,15 @@ readinessProbe:
   httpGet:
     path: /health/readiness
     port: metrics
-  initialDelaySeconds: 20
   timeoutSeconds: 5
+
+startupProbe:
+  failureThreshold: 20
+  httpGet:
+    path: /health/readiness
+    port: metrics
+  periodSeconds: 1
+  timeoutSeconds: 1
 
 terminationGracePeriodSeconds: 60
 

--- a/charts/hedera-json-rpc-relay/templates/deployment.yaml
+++ b/charts/hedera-json-rpc-relay/templates/deployment.yaml
@@ -44,6 +44,7 @@ spec:
             name: {{ .Values.ports.name  }}
         livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
         readinessProbe: {{- toYaml .Values.readinessProbe | nindent 12 }}
+        startupProbe: {{- toYaml .Values.startupProbe | nindent 12 }}
         resources: {{- toYaml .Values.resources | nindent 12 }}      
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/hedera-json-rpc-relay/values.yaml
+++ b/charts/hedera-json-rpc-relay/values.yaml
@@ -190,7 +190,6 @@ livenessProbe:
   httpGet:
     path: /health/liveness
     port: jsonrpcrelay
-  initialDelaySeconds: 20
   periodSeconds: 10
   timeoutSeconds: 5
 
@@ -254,8 +253,15 @@ readinessProbe:
   httpGet:
     path: /health/readiness
     port: jsonrpcrelay
-  initialDelaySeconds: 20
   timeoutSeconds: 5
+
+startupProbe:
+  failureThreshold: 20
+  httpGet:
+    path: /health/readiness
+    port: jsonrpcrelay
+  periodSeconds: 1
+  timeoutSeconds: 1
 
 test:
   enabled: false


### PR DESCRIPTION
### Description

This PR cherry picks feat: add startupProbe to relay and websocket Helm charts to reduce startup time (#5207) to 0.76

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #5206