### PR TITLE
feat: aligned tests with new mirror node WRONG_NONCE handling (#5060)

### DIFF
--- a/tests/server/acceptance/rpc_batch1.spec.ts
+++ b/tests/server/acceptance/rpc_batch1.spec.ts
@@ -1221,19 +1221,11 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
             // wait for at least one block time
             await new Promise((r) => setTimeout(r, 2100));
 
-            // currently, there is no way to fetch WRONG_NONCE transactions via MN or on `eth_getTransactionReceipt` by evm hash
-            // eth_sendRawTransaction returns always an evm hash, so as end-users we don't have the transaction id
-
-            // the WRONG_NONCE transactions are filtered out from MN /api/v1/contract/results/<evm_tx_hash>
-            // and /api/v1/transactions/<evm_hash> doesn't exist (only /api/v1/transactions/<transaction_id>
-
-            // the only thing we can rely on right now is the "not found" status that is returned on /api/v1/contracts/results/<evm_hash> by evm tx hash
-            const receipts = await Promise.allSettled(
-              txHashes.map((hash) => mirrorNode.get(`/contracts/results/${hash}`)),
-            );
-            const rejected = receipts.filter((receipt) => receipt.status === 'rejected');
-            expect(rejected).to.not.be.empty;
-            rejected.forEach((reject) => expect(reject.reason.response.status).to.equal(404));
+            // WRONG_NONCE transactions are recorded in /api/v1/contracts/results/<evm_tx_hash>
+            // with result: 'WRONG_NONCE'
+            const results = await Promise.all(txHashes.map((hash) => mirrorNode.get(`/contracts/results/${hash}`)));
+            const wrongNonceResults = results.filter((result) => result.result === 'WRONG_NONCE');
+            expect(wrongNonceResults).to.not.be.empty;
           });
         });
 
@@ -1262,9 +1254,8 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
                 // wait for at least one block time
                 await new Promise((r) => setTimeout(r, 2100));
 
-                await expect(mirrorNode.get(`/contracts/results/${txHash}`)).to.eventually.be.rejected.and.satisfy(
-                  (err: any) => err.response.status === 404,
-                );
+                const mnResult = await mirrorNode.get(`/contracts/results/${txHash}`);
+                expect(mnResult.result).to.equal('WRONG_NONCE');
               });
             });
           });


### PR DESCRIPTION
### Description

This PR fixes acceptance tests that broke due to a behavioural change in mirror node: `WRONG_NONCE` transactions are now recorded in `/api/v1/contracts/results/<evm_tx_hash>` with `result: "WRONG_NONCE"` and `status: "0x0"`, whereas previously these requests returned 404.

Two tests in `rpc_batch1.spec.ts` are updated:

- **`should fail with WRONG_NONCE when multiple transactions have been sent simultaneously`**: replaced `Promise.allSettled` + 404-rejection filter with `Promise.all` + direct `result === 'WRONG_NONCE'` filter, and removed the now-obsolete comment block explaining the old limitation.
- **`should fail with WRONG_NONCE when a transaction with [label] has been sent`** (parametrized): replaced the `expect(...).to.eventually.be.rejected` + 404 assertion with a straightforward `expect(mnResult.result).to.equal('WRONG_NONCE')`.


<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

#5060

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1. Run `npm run acceptancetest:api_batch1 -- --grep "should fail with WRONG_NONCE"` against a solo node backed by mirror node v0.151.0+.
2. Confirm all three WRONG_NONCE test cases pass — the mirror node returns a 200 response with `result: 'WRONG_NONCE'` instead of 404.


### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
