### PR TITLE
fix: clear WebSocket ping interval on connection close (#5233)

### DIFF
--- a/src/ws-server/utils/utils.ts
+++ b/src/ws-server/utils/utils.ts
@@ -53,7 +53,7 @@ export const handleConnectionClose = async (
     clearInterval(ctx.websocket.pingIntervalId);
   }
   if (ctx.websocket?.inactivityTTL) {
-    clearInterval(ctx.websocket.inactivityTTL);
+    clearTimeout(ctx.websocket.inactivityTTL);
   }
 
   // terminate connection

--- a/src/ws-server/utils/utils.ts
+++ b/src/ws-server/utils/utils.ts
@@ -52,6 +52,9 @@ export const handleConnectionClose = async (
   if (ctx.websocket?.pingIntervalId) {
     clearInterval(ctx.websocket.pingIntervalId);
   }
+  if (ctx.websocket?.inactivityTTL) {
+    clearInterval(ctx.websocket.inactivityTTL);
+  }
 
   // terminate connection
   ctx.websocket.terminate();

--- a/src/ws-server/utils/utils.ts
+++ b/src/ws-server/utils/utils.ts
@@ -48,6 +48,11 @@ export const handleConnectionClose = async (
   // Update the connection duration histogram with the calculated duration
   wsMetricRegistry.getHistogram('connectionDuration').observe(durationInSeconds);
 
+  // clear timers to prevent orphaned resources
+  if (ctx.websocket?.pingIntervalId) {
+    clearInterval(ctx.websocket.pingIntervalId);
+  }
+
   // terminate connection
   ctx.websocket.terminate();
 };

--- a/src/ws-server/webSocketServer.ts
+++ b/src/ws-server/webSocketServer.ts
@@ -267,7 +267,7 @@ export async function initializeWsServer(
     });
 
     if (pingInterval > 0) {
-      setInterval(async () => {
+      ctx.websocket.pingIntervalId = setInterval(async () => {
         ctx.websocket.send(JSON.stringify(jsonRespResult(null, null)));
       }, pingInterval);
     }

--- a/tests/ws-server/unit/utils.spec.ts
+++ b/tests/ws-server/unit/utils.spec.ts
@@ -213,7 +213,7 @@ describe('Utilities unit tests', async function () {
 
       it('should clear the ping interval when closing a connection', async () => {
         const intervalId = setInterval(() => {}, 100000);
-        const ctxWithPing: any = {
+        const ctxWithPing = {
           websocket: {
             id: 'mock-id',
             terminate: sinon.spy(),
@@ -227,8 +227,55 @@ describe('Utilities unit tests', async function () {
         expect(ctxWithPing.websocket.terminate.calledOnce).to.be.true;
       });
 
+      it('should clear the inactivity TTL when closing a connection', async () => {
+        const inactivityTTL = setInterval(() => {}, 100000);
+        const ctxWithInactivityTTL = {
+          websocket: {
+            id: 'mock-id',
+            terminate: sinon.spy(),
+            inactivityTTL,
+          },
+        };
+
+        await handleConnectionClose(
+          ctxWithInactivityTTL,
+          subscriptionService,
+          limiterStub,
+          wsMetricRegistryStub,
+          startTime,
+        );
+
+        expect(clearIntervalSpy.calledWith(inactivityTTL)).to.be.true;
+        expect(ctxWithInactivityTTL.websocket.terminate.calledOnce).to.be.true;
+      });
+
+      it('should clear both ping interval and inactivity TTL when closing a connection', async () => {
+        const pingIntervalId = setInterval(() => {}, 100000);
+        const inactivityTTL = setInterval(() => {}, 100000);
+        const ctxWithBothTimers = {
+          websocket: {
+            id: 'mock-id',
+            terminate: sinon.spy(),
+            pingIntervalId,
+            inactivityTTL,
+          },
+        };
+
+        await handleConnectionClose(
+          ctxWithBothTimers,
+          subscriptionService,
+          limiterStub,
+          wsMetricRegistryStub,
+          startTime,
+        );
+
+        expect(clearIntervalSpy.calledWith(pingIntervalId)).to.be.true;
+        expect(clearIntervalSpy.calledWith(inactivityTTL)).to.be.true;
+        expect(ctxWithBothTimers.websocket.terminate.calledOnce).to.be.true;
+      });
+
       it('should handle missing timers gracefully', async () => {
-        const ctxWithoutTimers: any = {
+        const ctxWithoutTimers = {
           websocket: {
             id: 'mock-id',
             terminate: sinon.spy(),

--- a/tests/ws-server/unit/utils.spec.ts
+++ b/tests/ws-server/unit/utils.spec.ts
@@ -183,6 +183,70 @@ describe('Utilities unit tests', async function () {
     it('should terminate the websocket connection', async () => {
       expect(ctxStub.websocket.terminate.calledOnce).to.be.true;
     });
+
+    describe('timer cleanup', () => {
+      let relayStub: sinon.SinonStubbedInstance<Relay>;
+      let limiterStub: sinon.SinonStubbedInstance<ConnectionLimiter>;
+      let wsMetricRegistryStub: sinon.SinonStubbedInstance<WsMetricRegistry>;
+      let startTime: [number, number];
+      let subscriptionService: SubscriptionService;
+      let clearIntervalSpy: sinon.SinonSpy;
+
+      beforeEach(() => {
+        relayStub = sinon.createStubInstance(Relay);
+        relayStub.eth.returns(sinon.createStubInstance(EthImpl));
+        limiterStub = sinon.createStubInstance(ConnectionLimiter);
+        wsMetricRegistryStub = sinon.createStubInstance(WsMetricRegistry);
+        wsMetricRegistryStub.getCounter.returns({ inc: sinon.stub() } as unknown as Counter);
+        wsMetricRegistryStub.getHistogram.returns({
+          observe: sinon.stub(),
+          startTimer: sinon.stub(),
+        } as unknown as Histogram);
+        startTime = process.hrtime();
+        subscriptionService = new SubscriptionService(relayStub, logger, registry);
+        clearIntervalSpy = sinon.spy(global, 'clearInterval');
+      });
+
+      afterEach(() => {
+        clearIntervalSpy.restore();
+      });
+
+      it('should clear the ping interval when closing a connection', async () => {
+        const intervalId = setInterval(() => {}, 100000);
+        const ctxWithPing: any = {
+          websocket: {
+            id: 'mock-id',
+            terminate: sinon.spy(),
+            pingIntervalId: intervalId,
+          },
+        };
+
+        await handleConnectionClose(ctxWithPing, subscriptionService, limiterStub, wsMetricRegistryStub, startTime);
+
+        expect(clearIntervalSpy.calledWith(intervalId)).to.be.true;
+        expect(ctxWithPing.websocket.terminate.calledOnce).to.be.true;
+      });
+
+      it('should handle missing timers gracefully', async () => {
+        const ctxWithoutTimers: any = {
+          websocket: {
+            id: 'mock-id',
+            terminate: sinon.spy(),
+          },
+        };
+
+        await handleConnectionClose(
+          ctxWithoutTimers,
+          subscriptionService,
+          limiterStub,
+          wsMetricRegistryStub,
+          startTime,
+        );
+
+        expect(clearIntervalSpy.notCalled).to.be.true;
+        expect(ctxWithoutTimers.websocket.terminate.calledOnce).to.be.true;
+      });
+    });
   });
 
   describe('getMultipleAddressesEnabled', () => {

--- a/tests/ws-server/unit/utils.spec.ts
+++ b/tests/ws-server/unit/utils.spec.ts
@@ -191,6 +191,7 @@ describe('Utilities unit tests', async function () {
       let startTime: [number, number];
       let subscriptionService: SubscriptionService;
       let clearIntervalSpy: sinon.SinonSpy;
+      let clearTimeoutSpy: sinon.SinonSpy;
 
       beforeEach(() => {
         relayStub = sinon.createStubInstance(Relay);
@@ -205,10 +206,12 @@ describe('Utilities unit tests', async function () {
         startTime = process.hrtime();
         subscriptionService = new SubscriptionService(relayStub, logger, registry);
         clearIntervalSpy = sinon.spy(global, 'clearInterval');
+        clearTimeoutSpy = sinon.spy(global, 'clearTimeout');
       });
 
       afterEach(() => {
         clearIntervalSpy.restore();
+        clearTimeoutSpy.restore();
       });
 
       it('should clear the ping interval when closing a connection', async () => {
@@ -228,7 +231,7 @@ describe('Utilities unit tests', async function () {
       });
 
       it('should clear the inactivity TTL when closing a connection', async () => {
-        const inactivityTTL = setInterval(() => {}, 100000);
+        const inactivityTTL = setTimeout(() => {}, 100000);
         const ctxWithInactivityTTL = {
           websocket: {
             id: 'mock-id',
@@ -245,13 +248,13 @@ describe('Utilities unit tests', async function () {
           startTime,
         );
 
-        expect(clearIntervalSpy.calledWith(inactivityTTL)).to.be.true;
+        expect(clearTimeoutSpy.calledWith(inactivityTTL)).to.be.true;
         expect(ctxWithInactivityTTL.websocket.terminate.calledOnce).to.be.true;
       });
 
       it('should clear both ping interval and inactivity TTL when closing a connection', async () => {
         const pingIntervalId = setInterval(() => {}, 100000);
-        const inactivityTTL = setInterval(() => {}, 100000);
+        const inactivityTTL = setTimeout(() => {}, 100000);
         const ctxWithBothTimers = {
           websocket: {
             id: 'mock-id',
@@ -270,7 +273,7 @@ describe('Utilities unit tests', async function () {
         );
 
         expect(clearIntervalSpy.calledWith(pingIntervalId)).to.be.true;
-        expect(clearIntervalSpy.calledWith(inactivityTTL)).to.be.true;
+        expect(clearTimeoutSpy.calledWith(inactivityTTL)).to.be.true;
         expect(ctxWithBothTimers.websocket.terminate.calledOnce).to.be.true;
       });
 

--- a/tests/ws-server/unit/webSocketServer.spec.ts
+++ b/tests/ws-server/unit/webSocketServer.spec.ts
@@ -258,4 +258,15 @@ describe('webSocketServer websocket handling', () => {
     const { args } = sendToClientStub.getCall(0);
     expect(Array.isArray(args[2])).to.be.true;
   });
+
+  it('should set up ping interval when WS_PING_INTERVAL > 0', async () => {
+    const setIntervalSpy = sinon.spy(global, 'setInterval');
+    const ws = await openWsServerAndUpdateSockets(server, sockets);
+
+    // The server-side 'connection' handler runs synchronously on upgrade,
+    // so by the time the client 'open' event fires setInterval has been called.
+    expect(setIntervalSpy.called).to.be.true;
+    setIntervalSpy.restore();
+    await ws.close();
+  });
 });


### PR DESCRIPTION
### Description

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

This PR fixes a resource leak where the `setInterval` used for WebSocket ping messages was never cleared when a connection closed. Each closed connection left an orphaned interval running indefinitely, accumulating over time and consuming memory/CPU.

The fix stores the interval ID on `ctx.websocket.pingIntervalId` when created in `initializeWsServer`, then calls `clearInterval` in `handleConnectionClose` before terminating the socket.

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #5233

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1. Run the WebSocket server unit tests:
``` bash
npm run test:ws-server
```
2. Verify the `timer cleanup` tests in `utils.spec.ts` pass. They assert `clearInterval` is called with the correct interval ID on close, and that missing timers are handled gracefully.
3. Verify the `should set up ping interval when WS_PING_INTERVAL > 0` test in `webSocketServer.spec.ts` passes. It asserts `setInterval` is called during connection setup when `WS_PING_INTERVAL > 0`.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

- `inactivityTTL` (`setTimeout` in `connectionLimiter.ts:startInactivityTTLTimer`) is also not cleared on connection close, only on activity reset. This is a separate potential leak that should be evaluated in a follow-up.

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
