### PR TITLE
Fix dependabot workflow

### DIFF
--- a/.github/workflows/acceptance-workflow.yml
+++ b/.github/workflows/acceptance-workflow.yml
@@ -153,8 +153,8 @@ jobs:
         env:
           TEST_WS_SERVER: ${{ inputs.test_ws_server }}
           SUBSCRIPTIONS_ENABLED: ${{ inputs.test_ws_server }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_PR_NUMBER: ${{ github.event.number }}
+          GITHUB_TOKEN: ${{ github.actor != 'dependabot[bot]' && secrets.GITHUB_TOKEN || '' }}
+          GITHUB_PR_NUMBER: ${{ github.actor != 'dependabot[bot]' && github.event.number || '' }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           OPERATOR_KEY: ${{ secrets.operator_key }}
           ON_VALID_JSON_RPC_HTTP_RESPONSE_STATUS_CODE: "${{ inputs.on_valid_json_rpc_http_response_status_code }}"

--- a/.github/workflows/acceptance-workflow.yml
+++ b/.github/workflows/acceptance-workflow.yml
@@ -144,6 +144,7 @@ jobs:
         run: docker run -d --name redis -p 6379:6379 redis:7-alpine
 
       - name: Run acceptance tests
+        if: github.actor != 'dependabot[bot]'
         run: |
             if [[ -n "$OPERATOR_KEY" ]] && [[ "$OPERATOR_KEY" != "" ]]; then
               echo "Overriding OPERATOR_KEY_MAIN with the secret value"
@@ -153,8 +154,8 @@ jobs:
         env:
           TEST_WS_SERVER: ${{ inputs.test_ws_server }}
           SUBSCRIPTIONS_ENABLED: ${{ inputs.test_ws_server }}
-          GITHUB_TOKEN: ${{ github.actor != 'dependabot[bot]' && secrets.GITHUB_TOKEN || '' }}
-          GITHUB_PR_NUMBER: ${{ github.actor != 'dependabot[bot]' && github.event.number || '' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_NUMBER: ${{ github.event.number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           OPERATOR_KEY: ${{ secrets.operator_key }}
           ON_VALID_JSON_RPC_HTTP_RESPONSE_STATUS_CODE: "${{ inputs.on_valid_json_rpc_http_response_status_code }}"


### PR DESCRIPTION
### Description

This PR fixes an issue where the acceptance workflow fails when triggered by Dependabot.

When workflows are executed by Dependabot, the `GITHUB_TOKEN` is restricted to read-only permissions. However, the acceptance test step still attempts operations that rely on write access, leading to predictable failures.

Since these steps are guaranteed to fail in this context, this PR updates the workflow to skip the acceptance test step when triggered by Dependabot.

---

### Related issue(s)

Fixes #5289

---

### Testing Guide

1. Trigger a Dependabot PR
2. Verify that the acceptance test step is **skipped** in the GitHub Actions run
3. Trigger a normal PR
4. Verify that the acceptance test step runs successfully

---

### Changes from original design (optional)

N/A

---

### Additional work needed (optional)

N/A

---

### Checklist

* [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
* [x] I've assigned a label to this PR and related issue(s) (if applicable)
* [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
* [ ] I've updated documentation (code comments, README, etc. if applicable)
* [x] I've done sufficient testing (unit, integration, etc.)
