### PR TITLE
feat: support unencoded access_list format from MirrorNode

### DIFF
--- a/src/relay/lib/factories/transactionFactory.ts
+++ b/src/relay/lib/factories/transactionFactory.ts
@@ -11,7 +11,15 @@ import {
   trimPrecedingZeros,
 } from '../../formatters';
 import constants from '../constants';
-import { AuthorizationListEntry, Log, Transaction, Transaction1559, Transaction2930, Transaction7702 } from '../model';
+import {
+  AccessListEntry,
+  AuthorizationListEntry,
+  Log,
+  Transaction,
+  Transaction1559,
+  Transaction2930,
+  Transaction7702,
+} from '../model';
 
 // TransactionFactory is a factory class that creates a Transaction object based on the type of transaction.
 export class TransactionFactory {
@@ -22,19 +30,19 @@ export class TransactionFactory {
       case 1:
         return new Transaction2930({
           ...fields,
-          accessList: [],
+          accessList: fields.accessList ?? [],
         }); // eip 2930 fields
       case 2:
         return new Transaction1559({
           ...fields,
-          accessList: [],
+          accessList: fields.accessList ?? [],
           maxPriorityFeePerGas: formatGasFee(fields.maxPriorityFeePerGas),
           maxFeePerGas: formatGasFee(fields.maxFeePerGas),
         }); // eip 1559 fields
       case 4:
         return new Transaction7702({
           ...fields,
-          accessList: [],
+          accessList: fields.accessList ?? [],
           maxPriorityFeePerGas: formatGasFee(fields.maxPriorityFeePerGas),
           maxFeePerGas: formatGasFee(fields.maxFeePerGas),
           authorizationList: formatAuthorizationList(fields.authorizationList),
@@ -109,6 +117,44 @@ const formatAuthorizationList = (authorizationList: any): AuthorizationListEntry
     : [];
 
 /**
+ * Normalizes the MirrorNode access_list field into the standard AccessListEntry[] format.
+ *
+ * Handles both the current encoded format and the future unencoded format:
+ *   - Encoded (string): "0x" → [], non-empty hex strings → [] (not decoded; real EIP-2930
+ *     access lists are rejected by Hedera as NOT_YET_IMPLEMENTED, so this case should not
+ *     occur in practice)
+ *   - Unencoded (array): [{address, storage_keys}] → [{address, storageKeys}]
+ *     (normalizes MirrorNode snake_case to the standard camelCase format)
+ *   - Null/undefined: → []
+ *
+ * @param {any} accessList - The raw access_list field from the MirrorNode contract result.
+ * @returns {AccessListEntry[]} A normalized access list. Returns an empty array if input is
+ *          null, undefined, an empty hex string, or an unrecognized format.
+ */
+const formatAccessList = (accessList: any): AccessListEntry[] => {
+  // Null, undefined, or empty hex string → empty array
+  if (!accessList || accessList === '0x') return [];
+
+  // Already an array (unencoded format from MirrorNode)
+  if (Array.isArray(accessList)) {
+    return accessList
+      .filter((entry: any) => entry !== null && entry !== undefined && typeof entry === 'object')
+      .map((entry: any) => ({
+        address: entry.address ?? constants.ZERO_ADDRESS_HEX,
+        // MirrorNode uses snake_case "storage_keys", normalize to camelCase "storageKeys"
+        storageKeys: entry.storageKeys ?? entry.storage_keys ?? [],
+      }));
+  }
+
+  // String but not "0x" — an RLP-encoded access list.
+  // Real EIP-2930 access lists are rejected by Hedera (NOT_YET_IMPLEMENTED),
+  // so non-empty encoded strings should not occur in practice. Return [].
+  if (typeof accessList === 'string') return [];
+
+  return [];
+};
+
+/**
  * Formats a gas fee value into a 0x-prefixed hex string.
  *
  * @param {any} gasFee - The raw gas price value (hex or number).
@@ -153,6 +199,7 @@ export const createTransactionFromContractResult = (cr: any): Transaction | null
 
   return TransactionFactory.createTransactionByType(cr.type, {
     ...commonFields,
+    accessList: formatAccessList(cr.access_list),
     maxPriorityFeePerGas: cr.max_priority_fee_per_gas,
     maxFeePerGas: cr.max_fee_per_gas,
     authorizationList: cr.authorization_list,

--- a/src/relay/lib/types/mirrorNode.ts
+++ b/src/relay/lib/types/mirrorNode.ts
@@ -260,8 +260,16 @@ export interface MirrorNodeContractResult {
   status: string;
   /** The failed contract init code, if applicable, otherwise null. */
   failed_initcode: string | null;
-  /** The access list for EIP-2930 transactions. */
-  access_list: string;
+  /**
+   * The access list for EIP-2930 transactions.
+   *
+   * May be returned in one of two formats:
+   *   - Encoded (current): An RLP-encoded hex string (e.g., "0x")
+   *   - Unencoded (future): An array of objects with address and storage_keys
+   *
+   * @see https://github.com/hiero-ledger/hiero-mirror-node/issues/13343
+   */
+  access_list: string | Array<{ address: string; storage_keys: string[] }> | null;
   /** The total gas used in the block. */
   block_gas_used: number;
   /** The chain ID of the network. */

--- a/tests/relay/lib/factories/transactionFactory.spec.ts
+++ b/tests/relay/lib/factories/transactionFactory.spec.ts
@@ -44,11 +44,24 @@ describe('TransactionFactory', () => {
       expect(tx).to.not.have.property('accessList');
     });
 
-    it('should create an access list (type 1) Transaction2930 with empty accessList', () => {
+    it('should create an access list (type 1) Transaction2930 with provided accessList', () => {
+      const accessList = [{ address: '0x1234567890abcdef1234567890abcdef12345678', storageKeys: [] }];
       const tx = TransactionFactory.createTransactionByType(1, {
         ...baseFields,
         type: '0x1',
-        accessList: ['should be ignored'],
+        accessList,
+      });
+
+      expect(tx).to.not.equal(null);
+      expect(tx!.type).to.equal('0x1');
+      expect(tx).to.have.property('accessList').that.deep.eq(accessList);
+      expect(tx!.from).to.equal(baseFields.from);
+    });
+
+    it('should create an access list (type 1) Transaction2930 with empty accessList when none provided', () => {
+      const tx = TransactionFactory.createTransactionByType(1, {
+        ...baseFields,
+        type: '0x1',
       });
 
       expect(tx).to.not.equal(null);
@@ -57,11 +70,27 @@ describe('TransactionFactory', () => {
       expect(tx!.from).to.equal(baseFields.from);
     });
 
-    it('should create an EIP-1559 (type 2) Transaction1559 with sanitized fees and empty accessList', () => {
+    it('should create an EIP-1559 (type 2) Transaction1559 with provided accessList and sanitized fees', () => {
+      const accessList = [{ address: '0x1234567890abcdef1234567890abcdef12345678', storageKeys: ['0xabc'] }];
       const tx = TransactionFactory.createTransactionByType(2, {
         ...baseFields,
         type: '0x2',
-        accessList: ['should be ignored'],
+        accessList,
+        maxPriorityFeePerGas: null,
+        maxFeePerGas: '0x00000059',
+      });
+
+      expect(tx).to.not.equal(null);
+      expect(tx!.type).to.equal('0x2');
+      expect(tx).have.property('accessList').that.deep.eq(accessList);
+      expect(tx).to.have.property('maxPriorityFeePerGas').that.equals(constants.ZERO_HEX);
+      expect(tx).to.have.property('maxFeePerGas').that.equals('0x59');
+    });
+
+    it('should create an EIP-1559 (type 2) Transaction1559 with empty accessList when none provided', () => {
+      const tx = TransactionFactory.createTransactionByType(2, {
+        ...baseFields,
+        type: '0x2',
         maxPriorityFeePerGas: null,
         maxFeePerGas: '0x00000059',
       });
@@ -470,6 +499,156 @@ describe('TransactionFactory', () => {
       const [out] = formatAuthorizationList(input);
 
       expect(out).to.have.property('extraField').equal('keep-me');
+    });
+  });
+
+  describe('formatAccessList', () => {
+    /**
+     * Test helper that exposes the private formatAccessList logic.
+     *
+     * Routes the provided `input` through `createTransactionFromContractResult`
+     * using a mocked EIP-1559 transaction payload (type = 2), then extracts
+     * the resulting `accessList`.
+     */
+    const formatAccessList = (input: any): any =>
+      createTransactionFromContractResult({
+        amount: 0,
+        from: '0x05fba803be258049a27b820088bab1cad2058871',
+        function_parameters: '0x08090033',
+        gas_used: 400000,
+        gas_limit: 500_000,
+        to: '0x0000000000000000000000000000000000000409',
+        hash: '0xfc4ab7133197016293d2e14e8cf9c5227b07357e6385184f1cd1cb40d783cfbd',
+        block_hash:
+          '0xb0f10139fa0bf9e66402c8c0e5ed364e07cf83b3726c8045fabf86a07f4887130e4650cb5cf48a9f6139a805b78f0312',
+        block_number: 528,
+        transaction_index: 9,
+        chain_id: '0x12a',
+        gas_price: '0x',
+        max_fee_per_gas: '0xcf38224400',
+        max_priority_fee_per_gas: '0x',
+        r: '0x2af9d41244c702764ed86c5b9f1a734b075b91c4d9c65e78bc584b0e35181e42',
+        s: '0x3f0a6baa347876e08c53ffc70619ba75881841885b2bd114dbb1905cd57112a5',
+        type: 2,
+        v: 1,
+        nonce: 2,
+        access_list: input,
+      })!['accessList'];
+
+    it('returns empty array for "0x" (empty hex string)', () => {
+      const out = formatAccessList('0x');
+      expect(out).to.deep.equal([]);
+    });
+
+    it('returns empty array for null', () => {
+      const out = formatAccessList(null);
+      expect(out).to.deep.equal([]);
+    });
+
+    it('returns empty array for undefined', () => {
+      const out = formatAccessList(undefined);
+      expect(out).to.deep.equal([]);
+    });
+
+    it('returns empty array for empty array', () => {
+      const out = formatAccessList([]);
+      expect(out).to.deep.equal([]);
+    });
+
+    it('returns empty array for non-empty hex string (unsupported encoded format)', () => {
+      const out = formatAccessList('0xf87cf87a940000000000000000000000000000000000000409');
+      expect(out).to.deep.equal([]);
+    });
+
+    it('normalizes unencoded format with snake_case storage_keys to camelCase storageKeys', () => {
+      const input = [
+        {
+          address: '0x0000000000000000000000000000000000000409',
+          storage_keys: [
+            '0x0000000000000000000000000000000000000000000000000000000000000001',
+            '0x0000000000000000000000000000000000000000000000000000000000000002',
+          ],
+        },
+      ];
+
+      const out = formatAccessList(input);
+
+      expect(out).to.have.length(1);
+      expect(out[0]).to.deep.equal({
+        address: '0x0000000000000000000000000000000000000409',
+        storageKeys: [
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+          '0x0000000000000000000000000000000000000000000000000000000000000002',
+        ],
+      });
+    });
+
+    it('passes through already-normalized camelCase storageKeys', () => {
+      const input = [
+        {
+          address: '0x0000000000000000000000000000000000000409',
+          storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000001'],
+        },
+      ];
+
+      const out = formatAccessList(input);
+
+      expect(out).to.have.length(1);
+      expect(out[0]).to.deep.equal({
+        address: '0x0000000000000000000000000000000000000409',
+        storageKeys: ['0x0000000000000000000000000000000000000000000000000000000000000001'],
+      });
+    });
+
+    it('filters out null, undefined, and non-object items from array', () => {
+      const input = [
+        null,
+        undefined,
+        123,
+        'abc',
+        true,
+        { address: '0x0000000000000000000000000000000000000409', storage_keys: [] },
+      ];
+
+      const out = formatAccessList(input);
+
+      expect(out).to.have.length(1);
+      expect(out[0].address).to.equal('0x0000000000000000000000000000000000000409');
+    });
+
+    it('falls back to zero address and empty storageKeys for missing fields', () => {
+      const input = [{}];
+
+      const out = formatAccessList(input);
+
+      expect(out).to.have.length(1);
+      expect(out[0].address).to.equal('0x0000000000000000000000000000000000000000');
+      expect(out[0].storageKeys).to.deep.equal([]);
+    });
+
+    it('handles multiple entries with mixed formats', () => {
+      const input = [
+        {
+          address: '0x1111111111111111111111111111111111111111',
+          storage_keys: ['0xaaa'],
+        },
+        {
+          address: '0x2222222222222222222222222222222222222222',
+          storageKeys: ['0xbbb'],
+        },
+      ];
+
+      const out = formatAccessList(input);
+
+      expect(out).to.have.length(2);
+      expect(out[0]).to.deep.equal({
+        address: '0x1111111111111111111111111111111111111111',
+        storageKeys: ['0xaaa'],
+      });
+      expect(out[1]).to.deep.equal({
+        address: '0x2222222222222222222222222222222222222222',
+        storageKeys: ['0xbbb'],
+      });
     });
   });
 });


### PR DESCRIPTION
## Description

Adds dual-format support for the `access_list` field from the MirrorNode `/contracts/results` endpoint. The MirrorNode is transitioning from returning `access_list` as an RLP-encoded hex string (e.g., `"0x"`) to an unencoded array of objects (`[{address, storage_keys}]`) per hiero-ledger/hiero-mirror-node#13343.

This PR ensures the relay handles both formats seamlessly during and after the transition.

## Changes

### `src/relay/lib/factories/transactionFactory.ts`
- Added `formatAccessList()` normalizer — handles both encoded (`"0x"`) and unencoded (`[{address, storage_keys}]`) formats, normalizing snake_case `storage_keys` to camelCase `storageKeys`
- Updated `createTransactionByType()` — changed hardcoded `accessList: []` to `accessList: fields.accessList ?? []` for types 1, 2, and 4
- Updated `createTransactionFromContractResult()` — now calls `formatAccessList(cr.access_list)`

### `src/relay/lib/types/mirrorNode.ts`
- Widened `access_list` type from `string` to `string | Array<{ address: string; storage_keys: string[] }> | null`

### `tests/relay/lib/factories/transactionFactory.spec.ts`
- Added 10 new unit tests for `formatAccessList`
- Updated 2 existing tests to reflect new behavior

## Backward Compatibility

| MirrorNode `access_list` value | Relay `accessList` result | Status |
|-------------------------------|--------------------------|--------|
| `"0x"` (current) | `[]` | ✅ No change |
| `null` | `[]` | ✅ No change |
| `[]` | `[]` | ✅ No change |
| `[{address, storage_keys}]` (future) | `[{address, storageKeys}]` | ✅ New |

## Related Issues

- Related to hiero-ledger/hiero-mirror-node#13343

## Tests

- [x] 36/36 factory tests passing
- [x] 10 new unit tests for `formatAccessList`
- [x] No regressions in existing tests
Signed-off-by: Manmath Mohanty <manmath.2006n@gmail.com>