### PR TITLE
feat: change name of ms storing metric and fix its buckets (#5231)

### DIFF
--- a/src/relay/lib/services/workersService/WorkersPool.ts
+++ b/src/relay/lib/services/workersService/WorkersPool.ts
@@ -180,13 +180,15 @@ export class WorkersPool {
       registers: [registry],
     });
 
-    const workerQueueWaitTimeName = 'rpc_relay_worker_queue_wait_time_seconds';
+    const workerQueueWaitTimeName = 'rpc_relay_worker_queue_wait_time_milliseconds';
     registry.removeSingleMetric(workerQueueWaitTimeName);
     this.workerQueueWaitTimeHistogram = new Histogram({
       name: workerQueueWaitTimeName,
       help: 'Time tasks have spent waiting in queue.',
       registers: [registry],
-      buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 15, 20, 25, 30, 35, 40, 50, 60],
+      buckets: [
+        5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 15000, 20000, 25000, 30000, 35000, 40000, 50000, 60000,
+      ],
     });
 
     const workerPoolUtilizationName = 'rpc_relay_worker_pool_utilization';


### PR DESCRIPTION
### Description

Our metric rpc_relay_worker_queue_wait_time_seconds stores value in milliseconds. For clarity we can use metric:
rpc_relay_worker_queue_wait_time_milliseconds instead. (buckets are also fixed to better mach true values collected by thus metric)

### Related issue(s)


Fixes #5231

### Testing Guide

1. Adjust dashboards.
2. Make sure displayed value remains the same.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

After accepting this change all of the dashboard currently using metric rpc_relay_worker_queue_wait_time_seconds to use rpc_relay_worker_queue_wait_time_milliseconds metric instead (no other change is needed, change can be applied in the json config right away for all of the metric occurrences).

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
