### PR TITLE
ci: skip codecov and test report publishing for dependabot runs (#5289)

### DIFF
--- a/.github/workflows/acceptance-workflow.yml
+++ b/.github/workflows/acceptance-workflow.yml
@@ -175,14 +175,14 @@ jobs:
           path: test-*.xml
 
       - name: Upload coverage report
-        if: ${{ !cancelled() && always() }}
+        if: ${{ github.actor != 'dependabot[bot]' && !cancelled() && always() }}
         run: bash .github/scripts/codecov-upload.sh
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Publish Test Report
         uses: step-security/publish-unit-test-result-action@7dff603bf17ef13dee847147bef8d7cd1728b566 # v2.22.0
-        if: ${{ !cancelled() }}
+        if: ${{ github.actor != 'dependabot[bot]' && !cancelled() }}
         with:
           check_name: '' # Set to empty to disable check run
           comment_mode: off

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -54,7 +54,7 @@ jobs:
 
   publish_results:
     name: Publish Results
-    if: ${{ !cancelled() }}
+    if: ${{ github.actor != 'dependabot[bot]' && !cancelled() }}
     needs: [acceptance_tests]
     runs-on: hiero-smart-contracts-linux-medium
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Upload coverage report
-        if: ${{ !cancelled() && always() }}
+        if: ${{ github.actor != 'dependabot[bot]' && !cancelled() && always() }}
         run: bash .github/scripts/codecov-upload.sh
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
### Description

Skip coverage upload and test result publishing for Dependabot-triggered GitHub Actions runs.

Dependabot runs use a read-only GITHUB_TOKEN, so publishing test results is expected to fail. We now avoid starting those steps/jobs altogether, including the acceptance results aggregation job.

### Related issue(s)

Fixes #5289

### Testing Guide

1. wait for dependabot to start its pipeline - verify all tests passed (green check mark) - after merging this PR....

### Changes from original design (optional)

N/A

### Additional work needed (optional)

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
