### PR TITLE
fix: guard getHistoricalBlockResponse against empty mirror node blocks

### DIFF
--- a/src/relay/lib/services/ethService/ethCommonService/CommonService.ts
+++ b/src/relay/lib/services/ethService/ethCommonService/CommonService.ts
@@ -13,7 +13,12 @@ import { JsonRpcError, predefined } from '../../../errors/JsonRpcError';
 import { MirrorNodeClientError } from '../../../errors/MirrorNodeClientError';
 import { SDKClientError } from '../../../errors/SDKClientError';
 import { Log } from '../../../model';
-import { type IAccountInfo, type MirrorNodeContractLog, type RequestDetails } from '../../../types';
+import {
+  type IAccountInfo,
+  type MirrorNodeBlock,
+  type MirrorNodeContractLog,
+  type RequestDetails,
+} from '../../../types';
 import { WorkersPool } from '../../workersService/WorkersPool';
 import { type ICommonService } from './ICommonService';
 
@@ -322,11 +327,24 @@ export class CommonService implements ICommonService {
     return await this.mirrorNodeClient.getBlock(blockNumberOrTagOrHash, requestDetails);
   }
 
-  private async getLatestBlockFromMirrorNode(requestDetails: RequestDetails): Promise<any> {
+  /**
+   * Fetches the latest block from the mirror node.
+   *
+   * Acts as the single source of truth for "latest" within this service: callers that need either the
+   * latest block object or just its number should go through here so the empty/null mirror-node response
+   * is handled in one place. The mirror node can transiently return an empty `blocks` array (e.g. right
+   * after a network reset, or against a freshly deployed mirror node that has not finished its initial
+   * sync); in those cases this method throws `COULD_NOT_RETRIEVE_LATEST_BLOCK` rather than letting an
+   * undefined block propagate to callers and crash with a `TypeError`.
+   *
+   * @param requestDetails - request metadata used for logging and tracing
+   * @returns the latest mirror node block
+   * @throws {JsonRpcError} `COULD_NOT_RETRIEVE_LATEST_BLOCK` when the mirror node returns no blocks
+   */
+  private async getLatestBlockFromMirrorNode(requestDetails: RequestDetails): Promise<MirrorNodeBlock> {
     const blocksResponse = await this.mirrorNodeClient.getLatestBlock(requestDetails);
-    const blocks = blocksResponse !== null ? blocksResponse.blocks : null;
-    if (Array.isArray(blocks) && blocks.length > 0) {
-      return blocks[0];
+    if (Array.isArray(blocksResponse?.blocks) && blocksResponse.blocks.length > 0) {
+      return blocksResponse.blocks[0];
     }
 
     throw predefined.COULD_NOT_RETRIEVE_LATEST_BLOCK;

--- a/src/relay/lib/services/ethService/ethCommonService/CommonService.ts
+++ b/src/relay/lib/services/ethService/ethCommonService/CommonService.ts
@@ -351,7 +351,10 @@ export class CommonService implements ICommonService {
   }
 
   /**
-   * Gets the most recent block number.
+   * Gets the most recent block number from the mirror node (the `latest` block).
+   *
+   * @param {RequestDetails} requestDetails - Request metadata used for logging and tracing.
+   * @returns {Promise<string>} The block number as a 0x-prefixed hexadecimal string (JSON-RPC quantity).
    */
   public async getLatestBlockNumber(requestDetails: RequestDetails): Promise<string> {
     const latestBlock = await this.getLatestBlockFromMirrorNode(requestDetails);

--- a/src/relay/lib/services/ethService/ethCommonService/CommonService.ts
+++ b/src/relay/lib/services/ethService/ethCommonService/CommonService.ts
@@ -301,16 +301,14 @@ export class CommonService implements ICommonService {
 
     const blockNumber = Number(blockNumberOrTagOrHash);
     if (blockNumberOrTagOrHash != null && blockNumberOrTagOrHash.length < 32 && !isNaN(blockNumber)) {
-      const latestBlockResponse = await this.mirrorNodeClient.getLatestBlock(requestDetails);
-      const latestBlock = latestBlockResponse.blocks[0];
+      const latestBlock = await this.getLatestBlockFromMirrorNode(requestDetails);
       if (blockNumber > latestBlock.number + this.maxBlockRange) {
         return null;
       }
     }
 
     if (blockNumberOrTagOrHash == null || this.blockTagIsLatestOrPending(blockNumberOrTagOrHash)) {
-      const latestBlockResponse = await this.mirrorNodeClient.getLatestBlock(requestDetails);
-      return latestBlockResponse.blocks[0];
+      return await this.getLatestBlockFromMirrorNode(requestDetails);
     }
 
     if (blockNumberOrTagOrHash === constants.BLOCK_EARLIEST) {
@@ -324,17 +322,22 @@ export class CommonService implements ICommonService {
     return await this.mirrorNodeClient.getBlock(blockNumberOrTagOrHash, requestDetails);
   }
 
+  private async getLatestBlockFromMirrorNode(requestDetails: RequestDetails): Promise<any> {
+    const blocksResponse = await this.mirrorNodeClient.getLatestBlock(requestDetails);
+    const blocks = blocksResponse !== null ? blocksResponse.blocks : null;
+    if (Array.isArray(blocks) && blocks.length > 0) {
+      return blocks[0];
+    }
+
+    throw predefined.COULD_NOT_RETRIEVE_LATEST_BLOCK;
+  }
+
   /**
    * Gets the most recent block number.
    */
   public async getLatestBlockNumber(requestDetails: RequestDetails): Promise<string> {
-    const blocksResponse = await this.mirrorNodeClient.getLatestBlock(requestDetails);
-    const blocks = blocksResponse !== null ? blocksResponse.blocks : null;
-    if (Array.isArray(blocks) && blocks.length > 0) {
-      return numberTo0x(blocks[0].number);
-    }
-
-    throw predefined.COULD_NOT_RETRIEVE_LATEST_BLOCK;
+    const latestBlock = await this.getLatestBlockFromMirrorNode(requestDetails);
+    return numberTo0x(latestBlock.number);
   }
 
   public genericErrorHandler(error: any, logMessage?: string): void {

--- a/tests/relay/lib/services/ethService/ethCommonService/commonService.spec.ts
+++ b/tests/relay/lib/services/ethService/ethCommonService/commonService.spec.ts
@@ -154,4 +154,55 @@ describe('CommonService', () => {
       );
     });
   });
+
+  describe('getLatestBlockNumber', () => {
+    const requestDetails = new RequestDetails({ requestId: 'test-request-id', ipAddress: '0.0.0.0' });
+    const LATEST_BLOCK_QUERY = 'blocks?limit=1&order=desc';
+
+    let commonService: CommonService;
+    let restMock: MockAdapter;
+
+    beforeEach(() => {
+      const logger = pino({ level: 'silent' });
+      const registry = new Registry();
+      const cacheService = CacheClientFactory.create(logger, registry);
+      const mirrorNodeClient = new MirrorNodeClient(
+        ConfigService.get('MIRROR_NODE_URL'),
+        logger.child({ name: 'mirror-node' }),
+        registry,
+        cacheService,
+      );
+      restMock = new MockAdapter(mirrorNodeClient.getMirrorNodeRestInstance(), { onNoMatch: 'throwException' });
+      commonService = new CommonService(mirrorNodeClient, logger, cacheService);
+    });
+
+    afterEach(() => {
+      restMock.restore();
+      sinon.restore();
+    });
+
+    it('returns the latest block number in 0x form when the mirror node returns a block', async () => {
+      restMock.onGet(LATEST_BLOCK_QUERY).reply(200, JSON.stringify({ blocks: [{ number: 643209 }] }));
+
+      const result = await commonService.getLatestBlockNumber(requestDetails);
+
+      expect(result).to.equal('0x9d089');
+    });
+
+    it('throws COULD_NOT_RETRIEVE_LATEST_BLOCK when the blocks array is empty', async () => {
+      restMock.onGet(LATEST_BLOCK_QUERY).reply(200, JSON.stringify({ blocks: [] }));
+
+      await expect(commonService.getLatestBlockNumber(requestDetails)).to.be.rejectedWith(
+        predefined.COULD_NOT_RETRIEVE_LATEST_BLOCK.message,
+      );
+    });
+
+    it('throws COULD_NOT_RETRIEVE_LATEST_BLOCK when the mirror node returns 404', async () => {
+      restMock.onGet(LATEST_BLOCK_QUERY).reply(404, JSON.stringify({}));
+
+      await expect(commonService.getLatestBlockNumber(requestDetails)).to.be.rejectedWith(
+        predefined.COULD_NOT_RETRIEVE_LATEST_BLOCK.message,
+      );
+    });
+  });
 });

--- a/tests/relay/lib/services/ethService/ethCommonService/commonService.spec.ts
+++ b/tests/relay/lib/services/ethService/ethCommonService/commonService.spec.ts
@@ -1,11 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { expect } from 'chai';
+import MockAdapter from 'axios-mock-adapter';
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import pino from 'pino';
+import { Registry } from 'prom-client';
 import sinon from 'sinon';
+
+chai.use(chaiAsPromised);
 
 import { ConfigService } from '../../../../../../src/config-service/services';
 import { prepend0x } from '../../../../../../src/relay/formatters';
+import { MirrorNodeClient } from '../../../../../../src/relay/lib/clients';
+import { predefined } from '../../../../../../src/relay/lib/errors/JsonRpcError';
+import { CacheClientFactory } from '../../../../../../src/relay/lib/factories/cacheClientFactory';
 import { CommonService } from '../../../../../../src/relay/lib/services';
+import { RequestDetails } from '../../../../../../src/relay/lib/types';
 
 describe('CommonService', () => {
   describe('getPaymasterIfTxCanBeSubsidized', async () => {
@@ -99,6 +109,49 @@ describe('CommonService', () => {
       const result = CommonService.getPaymasterIfTxCanBeSubsidized(null);
 
       expect(result).to.equal(null);
+    });
+  });
+
+  describe('getHistoricalBlockResponse', () => {
+    const requestDetails = new RequestDetails({ requestId: 'test-request-id', ipAddress: '0.0.0.0' });
+    const LATEST_BLOCK_QUERY = 'blocks?limit=1&order=desc';
+
+    let commonService: CommonService;
+    let restMock: MockAdapter;
+
+    beforeEach(() => {
+      const logger = pino({ level: 'silent' });
+      const registry = new Registry();
+      const cacheService = CacheClientFactory.create(logger, registry);
+      const mirrorNodeClient = new MirrorNodeClient(
+        ConfigService.get('MIRROR_NODE_URL'),
+        logger.child({ name: 'mirror-node' }),
+        registry,
+        cacheService,
+      );
+      restMock = new MockAdapter(mirrorNodeClient.getMirrorNodeRestInstance(), { onNoMatch: 'throwException' });
+      commonService = new CommonService(mirrorNodeClient, logger, cacheService);
+    });
+
+    afterEach(() => {
+      restMock.restore();
+      sinon.restore();
+    });
+
+    it('throws COULD_NOT_RETRIEVE_LATEST_BLOCK when range check finds an empty blocks array', async () => {
+      restMock.onGet(LATEST_BLOCK_QUERY).reply(200, JSON.stringify({ blocks: [] }));
+
+      await expect(commonService.getHistoricalBlockResponse(requestDetails, '0x9d089', true)).to.be.rejectedWith(
+        predefined.COULD_NOT_RETRIEVE_LATEST_BLOCK.message,
+      );
+    });
+
+    it('throws COULD_NOT_RETRIEVE_LATEST_BLOCK when latest tag is requested and blocks array is empty', async () => {
+      restMock.onGet(LATEST_BLOCK_QUERY).reply(200, JSON.stringify({ blocks: [] }));
+
+      await expect(commonService.getHistoricalBlockResponse(requestDetails, 'latest', true)).to.be.rejectedWith(
+        predefined.COULD_NOT_RETRIEVE_LATEST_BLOCK.message,
+      );
     });
   });
 });


### PR DESCRIPTION
### Description

This PR adds a defensive check when the mirror node briefly returns { blocks: [] } (e.g. during a previewnet reset or sync gap), getHistoricalBlockResponse crashed with "Cannot read properties of undefined (reading 'number')" while reading latestBlockResponse.blocks[0].number. Apply the same defensive guard already used by getLatestBlockNumber and throw COULD_NOT_RETRIEVE_LATEST_BLOCK instead of crashing.

### Related issue(s)

Fixes #5350 

### Testing Guide

1.
2.
3.

### Changes from original design (optional)

N/A

### Additional work needed (optional)


N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
