### PR TITLE
fix: correct order of actions and improve dry run render (#5133)

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -12,8 +12,9 @@ on:
         required: true
       dry-run-enabled:
         description: 'Enable dry run mode'
+        type: boolean
         required: false
-        default: 'false'
+        default: true
 
 permissions:
   contents: read
@@ -73,16 +74,6 @@ jobs:
         with:
           ref: ${{ steps.resolve-tag.outputs.tag }}
 
-      - name: Verify package version matches tag
-        run: |
-          PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          TAG_VERSION="${{ steps.resolve-tag.outputs.version }}"
-
-          if [[ "$PACKAGE_VERSION" != "$TAG_VERSION" ]]; then
-            echo "::error::package.json version (${PACKAGE_VERSION}) does not match tag version (${TAG_VERSION})"
-            exit 1
-          fi
-
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -93,6 +84,16 @@ jobs:
         uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
         with:
           version: 1.7
+
+      - name: Verify package version matches tag
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${{ steps.resolve-tag.outputs.version }}"
+
+          if [[ "$PACKAGE_VERSION" != "$TAG_VERSION" ]]; then
+            echo "::error::package.json version (${PACKAGE_VERSION}) does not match tag version (${TAG_VERSION})"
+            exit 1
+          fi
 
       - name: Clean install (no scripts)
         run: npm ci --ignore-scripts
@@ -167,7 +168,7 @@ jobs:
         run: |
           args="--access=public --provenance --ignore-scripts"
 
-          if [[ "${{ inputs.dry-run-enabled || 'false' }}" == "true" ]]; then
+          if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
             args="${args} --dry-run"
           fi
 


### PR DESCRIPTION
### Description

We have to install node before we can use it.

Additionally: dry-run can be rendered as checkbox, no need to type true / false on each run,.

### Related issue(s)

Fixes #5133

### Testing Guide

1. Merge
2. Run action

### Changes from original design (optional)


N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
