### PR TITLE
fix(ci): update npm-package-artifact to tar src instead of packages

### DIFF
--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -81,7 +81,7 @@ jobs:
         run: echo "TAG=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
 
       - name: Produce artifact
-        run: tar -czf ${{ env.PACKAGE_NAME }}-v${{env.TAG}}.tgz -C ./packages . 
+        run: tar -czf ${{ env.PACKAGE_NAME }}-v${{env.TAG}}.tgz -C ./src .
 
       - name: Upload artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1


### PR DESCRIPTION
### Description

This PR fixes an issue where the `npm-package-artifact` job in `release-production.yml` fails on every tag push with `tar: packages: Cannot open: No such file or directory`. https://github.com/hiero-ledger/hiero-json-rpc-relay/actions/runs/26049421967/job/76583336229

The job was referencing `./packages`, which was removed when the lerna monorepo was consolidated into a single package in #5074. The fix updates the path to `./src`, which is the direct equivalent — containing the same sub-components (`config-service`, `relay`, `server`, `ws-server`) that previously lived under `packages/`.

### Related issue(s)

Fixes #5407
