### PR TITLE
fix: do not cache latest-state ACCOUNT entities in resolveEntityType

### DIFF
--- a/src/relay/lib/clients/mirrorNodeClient.ts
+++ b/src/relay/lib/clients/mirrorNodeClient.ts
@@ -1540,12 +1540,7 @@ export class MirrorNodeClient {
   getQueryParams(params: object) {
     let paramString = '';
     for (const [key, value] of Object.entries(params)) {
-      let additionalString = '';
-      if (Array.isArray(value)) {
-        additionalString = value.map((v) => `${key}=${v}`).join('&');
-      } else {
-        additionalString = `${key}=${value}`;
-      }
+      const additionalString = Array.isArray(value) ? value.map((v) => `${key}=${v}`).join('&') : `${key}=${value}`;
       paramString += paramString === '' ? `?${additionalString}` : `&${additionalString}`;
     }
     return paramString;
@@ -1991,7 +1986,16 @@ export class MirrorNodeClient {
       type,
       entity: data.value,
     };
-    await this.cacheService.set(cachedLabel, response, callerName);
+
+    // An account's EIP-7702 / HIP-1340 delegation designator (`delegation_address`) is mutable: an EOA can set,
+    // change, or clear its delegation at any time. Caching a latest-state ACCOUNT entity would therefore serve a
+    // stale `delegation_address` to `eth_getCode` and hide delegation changes until the TTL expires. Contracts,
+    // tokens, and schedules are immutable, and historical (timestamped) account lookups reflect fixed state, so
+    // those remain safe to cache.
+    if (type !== constants.TYPE_ACCOUNT || timestamp) {
+      await this.cacheService.set(cachedLabel, response, callerName);
+    }
+
     return response;
   }
 

--- a/src/relay/lib/clients/mirrorNodeClient.ts
+++ b/src/relay/lib/clients/mirrorNodeClient.ts
@@ -863,7 +863,6 @@ export class MirrorNodeClient {
     return null;
   }
 
-  //
   public async getContractResult(transactionIdOrHash: string, requestDetails: RequestDetails) {
     const cacheKey = `${constants.CACHE_KEY.GET_CONTRACT_RESULT}.${transactionIdOrHash}`;
     const cachedResponse = await this.cacheService.getAsync(cacheKey, MirrorNodeClient.GET_CONTRACT_RESULT_ENDPOINT);

--- a/src/relay/lib/clients/mirrorNodeClient.ts
+++ b/src/relay/lib/clients/mirrorNodeClient.ts
@@ -863,6 +863,7 @@ export class MirrorNodeClient {
     return null;
   }
 
+  //
   public async getContractResult(transactionIdOrHash: string, requestDetails: RequestDetails) {
     const cacheKey = `${constants.CACHE_KEY.GET_CONTRACT_RESULT}.${transactionIdOrHash}`;
     const cachedResponse = await this.cacheService.getAsync(cacheKey, MirrorNodeClient.GET_CONTRACT_RESULT_ENDPOINT);
@@ -1890,7 +1891,15 @@ export class MirrorNodeClient {
       callerName,
     );
     if (cachedResponse) {
-      return cachedResponse;
+      // Transitional read-guard, symmetric to the write-guard below. A pre-fix deployment — or a shared Redis cache
+      // during a rolling upgrade — may still hold latest-state ACCOUNT entries written before the write-guard
+      // existed. Their mutable `delegation_address` (EIP-7702 / HIP-1340) could be stale, so ignore such entries and
+      // re-resolve from the mirror node. Historical (timestamped) entries and non-account types are immutable and
+      // safe to return.
+      // TODO(#5471): remove this read-guard once all caches have cycled past CACHE_TTL after the fix is deployed.
+      if (cachedResponse.type !== constants.TYPE_ACCOUNT || timestamp) {
+        return cachedResponse;
+      }
     }
 
     const buildPromise = (fn) =>

--- a/tests/relay/lib/mirrorNodeClient.spec.ts
+++ b/tests/relay/lib/mirrorNodeClient.spec.ts
@@ -1638,6 +1638,34 @@ describe('MirrorNodeClient', async function () {
       expect(second!.type).to.eq('ACCOUNT');
       expect(second!.entity.delegation_address).to.eq(accountWithDelegation.delegation_address);
     });
+
+    it('ignores pre-fix cached latest `ACCOUNT` entries on read and re-resolves them (transitional read-guard)', async () => {
+      const accountEntityId = '0.0.1014';
+      const delegationAddress = '0xf25f35d571f4d032fcf24f9090d5af67c0ae4512';
+      const staleCachedLabel = `${constants.CACHE_KEY.RESOLVE_ENTITY_TYPE}_${mockData.accountEvmAddress}`;
+
+      // Simulate a stale entry written before the write-guard existed: a latest-state ACCOUNT with no delegation.
+      await cacheService.set(
+        staleCachedLabel,
+        { type: constants.TYPE_ACCOUNT, entity: { ...mockData.account, delegation_address: '0x' } },
+        constants.ETH_GET_CODE,
+      );
+
+      mock.onGet(`contracts/${mockData.accountEvmAddress}`).reply(404, JSON.stringify(mockData.notFound));
+      mock.onGet(`tokens/${accountEntityId}`).reply(404, JSON.stringify(mockData.notFound));
+      mock
+        .onGet(`accounts/${mockData.accountEvmAddress}${noTransactions}`)
+        .reply(200, JSON.stringify({ ...mockData.account, delegation_address: delegationAddress }));
+
+      // The read-guard must skip the stale cached ACCOUNT and re-resolve from the mirror node.
+      const result = await mirrorNodeInstance.resolveEntityType(
+        mockData.accountEvmAddress,
+        constants.ETH_GET_CODE,
+        requestDetails,
+      );
+      expect(result!.type).to.eq('ACCOUNT');
+      expect(result!.entity.delegation_address).to.eq(delegationAddress);
+    });
   });
 
   describe('getTransactionById', async () => {

--- a/tests/relay/lib/mirrorNodeClient.spec.ts
+++ b/tests/relay/lib/mirrorNodeClient.spec.ts
@@ -1566,6 +1566,78 @@ describe('MirrorNodeClient', async function () {
       expect(entityType!.type).to.eq('SCHEDULE');
       expect(entityType!.entity.schedule_id).to.eq(scheduleId);
     });
+
+    it('does not cache latest `ACCOUNT` results so EIP-7702 delegation changes are not hidden', async () => {
+      const accountEntityId = '0.0.1014';
+      const delegationAddress = '0xf25f35d571f4d032fcf24f9090d5af67c0ae4512';
+      const accountWithoutDelegation = { ...mockData.account, delegation_address: '0x' };
+      const accountWithDelegation = { ...mockData.account, delegation_address: delegationAddress };
+
+      mock.onGet(`contracts/${mockData.accountEvmAddress}`).reply(404, JSON.stringify(mockData.notFound));
+      mock.onGet(`tokens/${accountEntityId}`).reply(404, JSON.stringify(mockData.notFound));
+      mock
+        .onGet(`accounts/${mockData.accountEvmAddress}${noTransactions}`)
+        .replyOnce(200, JSON.stringify(accountWithoutDelegation));
+      mock
+        .onGet(`accounts/${mockData.accountEvmAddress}${noTransactions}`)
+        .replyOnce(200, JSON.stringify(accountWithDelegation));
+
+      const first = await mirrorNodeInstance.resolveEntityType(
+        mockData.accountEvmAddress,
+        constants.ETH_GET_CODE,
+        requestDetails,
+      );
+      expect(first!.type).to.eq('ACCOUNT');
+      expect(first!.entity.delegation_address).to.eq('0x');
+
+      // The second lookup must re-fetch from the mirror node (not the cache) and reflect the new delegation.
+      const second = await mirrorNodeInstance.resolveEntityType(
+        mockData.accountEvmAddress,
+        constants.ETH_GET_CODE,
+        requestDetails,
+      );
+      expect(second!.type).to.eq('ACCOUNT');
+      expect(second!.entity.delegation_address).to.eq(delegationAddress);
+    });
+
+    it('caches historical (timestamped) `ACCOUNT` results since past state is immutable', async () => {
+      const accountEntityId = '0.0.1014';
+      const timestamp = '1780495075.931109906';
+      const accountWithDelegation = {
+        ...mockData.account,
+        delegation_address: '0xf25f35d571f4d032fcf24f9090d5af67c0ae4512',
+      };
+
+      mock
+        .onGet(`contracts/${mockData.accountEvmAddress}?timestamp=${timestamp}`)
+        .reply(404, JSON.stringify(mockData.notFound));
+      mock.onGet(`tokens/${accountEntityId}`).reply(404, JSON.stringify(mockData.notFound));
+      mock
+        .onGet(`accounts/${mockData.accountEvmAddress}?timestamp=${timestamp}&transactions=false`)
+        .replyOnce(200, JSON.stringify(accountWithDelegation));
+
+      const first = await mirrorNodeInstance.resolveEntityType(
+        mockData.accountEvmAddress,
+        constants.ETH_GET_CODE,
+        requestDetails,
+        [constants.TYPE_CONTRACT, constants.TYPE_ACCOUNT, constants.TYPE_TOKEN],
+        undefined,
+        timestamp,
+      );
+      expect(first!.type).to.eq('ACCOUNT');
+
+      // Second lookup is served from cache (the `accounts` endpoint only had a single `replyOnce` handler).
+      const second = await mirrorNodeInstance.resolveEntityType(
+        mockData.accountEvmAddress,
+        constants.ETH_GET_CODE,
+        requestDetails,
+        [constants.TYPE_CONTRACT, constants.TYPE_ACCOUNT, constants.TYPE_TOKEN],
+        undefined,
+        timestamp,
+      );
+      expect(second!.type).to.eq('ACCOUNT');
+      expect(second!.entity.delegation_address).to.eq(accountWithDelegation.delegation_address);
+    });
   });
 
   describe('getTransactionById', async () => {


### PR DESCRIPTION
### Description

This PR fixes an issue where `eth_getCode` returns stale bytecode (`0x`) for an EIP-7702 / HIP-1340 delegated EOA after a set-code transaction updates its `delegation_address`.

`resolveEntityType` caches the full Mirror Node entity (including `delegation_address`) under a key scoped to the address alone, with the default CACHE_TTL of 1 hour. Because an EOA's delegation can be set, changed, or cleared at any time, a stale cached entry hides the change until the TTL expires, causing `eth_getCode` to return `0x` instead of `0xef0100<addr>`.

Fix: skip writing to cache when the resolved entity type is `ACCOUNT` and no explicit `timestamp` is provided (latest/current state). Contracts, tokens, and schedules are immutable and remain safe to cache. Historical account lookups (those carrying a `timestamp`, used by `debug` trace resolution) also remain cached because past state is fixed.

### Related issue(s)

Fixes #5463

### Testing Guide

1. Set up a local Hedera network with Pectra feature branches (consensus node `feature/hedera-evm-pectra-support-v2`, mirror node from `mn-values.yaml`, relay on this branch).
2. Run the failing execution-spec test:
   ```bash
   uv run execute remote -rA --verbose --fork=Prague \
     --rpc-endpoint=http://localhost:37546/ \
     --rpc-seed-key=0xde78ff4e5e77ec2bf28ef7b446d4bec66e06d39b6e6967864b2bf3d6153f3e68 \
     --rpc-chain-id=298 \
     --default-gas-price=710_000_000_000 \
     "tests/prague/eip7702_set_code_tx/test_set_code_txs.py::test_set_code_to_sstore[fork_Prague-state_test-stop-tx_value_0-one_wei_balance_authority]"
   ```
3. Confirm the test passes and `eth_getCode` returns `0xef010080<addr>` (not `0x`) for the delegated EOA.
4. Run unit tests: `TS_NODE_COMPILER_OPTIONS='{"ignoreDeprecations":"6.0"}' npx ts-mocha --recursive 'tests/relay/lib/mirrorNodeClient.spec.ts' --grep "resolveEntityType" --exit` — all 9 cases should pass, including the two new ones.

### Changes from original design (optional)

N/A

### Additional work needed (optional)

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
