### PR TITLE
fix: add lower bound to getAccountPaginated to prevent PAGINATION_MAX for high-activity accounts

### DIFF
--- a/src/relay/lib/clients/mirrorNodeClient.ts
+++ b/src/relay/lib/clients/mirrorNodeClient.ts
@@ -676,16 +676,32 @@ export class MirrorNodeClient {
   }
 
   /**
-   * To be used to make paginated calls for the account information when the
-   * transaction count exceeds the constant `MIRROR_NODE_LIMIT_PARAM`.
+   * Fetches all account transactions newer than `lowerBoundTimestamp` by paginating
+   * the Mirror Node accounts endpoint. Used to reconstruct historical balances for
+   * blocks within the last ~15 minutes, where the `/balances` snapshot is not yet
+   * available.
+   *
+   * @param url - The Mirror Node `links.next` URL from the preceding account response,
+   *   used to extract the account ID and the upper-bound (`lte:`) timestamp cursor.
+   * @param requestDetails - Request metadata for logging and tracing.
+   * @param lowerBoundTimestamp - Hedera consensus timestamp (e.g. `"1779454079.000000000"`)
+   *   added as `timestamp=gte:` to bound pagination; typically `block.timestamp.to`.
    */
-  public async getAccountPaginated(url: string, requestDetails: RequestDetails): Promise<any> {
+  public async getAccountPaginated(
+    url: string,
+    requestDetails: RequestDetails,
+    lowerBoundTimestamp: string,
+  ): Promise<any> {
     const queryParamObject = {};
     const accountId = this.extractAccountIdFromUrl(url);
     const params = new URLSearchParams(url.split('?')[1]);
 
     this.setQueryParam(queryParamObject, 'limit', ConfigService.get('MIRROR_NODE_LIMIT_PARAM'));
     this.setQueryParam(queryParamObject, 'timestamp', params.get('timestamp'));
+    // scopes pagination to the lowerBoundTimestamp,
+    // preventing from walking the full account history up to MIRROR_NODE_ACCOUNT_TXS_PG_MAX pages.
+    this.setQueryParam(queryParamObject, 'timestamp', `gte:${lowerBoundTimestamp}`);
+
     const queryParams = this.getQueryParams(queryParamObject);
 
     return this.getPaginatedResults(

--- a/src/relay/lib/services/ethService/accountService/AccountService.ts
+++ b/src/relay/lib/services/ethService/accountService/AccountService.ts
@@ -182,7 +182,7 @@ export class AccountService implements IAccountService {
     const nextPageTimeMarker = nextPageParams.get('timestamp');
     // if nextPageTimeMarker is greater than the block.timestamp.to, then we need to paginate to get the transactions for the block.timestamp.to
     if (nextPageTimeMarker && nextPageTimeMarker?.split(':')[1] >= block.timestamp.to) {
-      pagedTransactions = await this.mirrorNodeClient.getAccountPaginated(nextPage, requestDetails);
+      pagedTransactions = await this.mirrorNodeClient.getAccountPaginated(nextPage, requestDetails, block.timestamp.to);
     }
     // if nextPageTimeMarker is less than the block.timestamp.to, then just run the getBalanceAtBlockTimestamp function in this case as well.
 

--- a/tests/relay/lib/eth/eth_getBalance.spec.ts
+++ b/tests/relay/lib/eth/eth_getBalance.spec.ts
@@ -583,23 +583,27 @@ describe('@ethGetBalance using MirrorNode', async function () {
         }),
       );
 
-      restMock.onGet(`accounts/${CONTRACT_ID_1}?limit=100&timestamp=lt:1651550575.060890941`).reply(
-        200,
-        JSON.stringify({
-          account: CONTRACT_ID_1,
-          balance: {
-            balance: balance3,
-            timestamp: '1651550587.060890941',
-          },
-          transactions: [
-            buildCryptoTransferTransaction('0.0.98', CONTRACT_ID_1, 200, { timestamp: '1651550574.060890964' }),
-            buildCryptoTransferTransaction('0.0.98', CONTRACT_ID_1, 50, { timestamp: '1651550573.060890958' }),
-          ],
-          links: {
-            next: null,
-          },
-        }),
-      );
+      restMock
+        .onGet(
+          `accounts/${CONTRACT_ID_1}?limit=100&timestamp=lt:1651550575.060890941&timestamp=gte:1651550565.060890941`,
+        )
+        .reply(
+          200,
+          JSON.stringify({
+            account: CONTRACT_ID_1,
+            balance: {
+              balance: balance3,
+              timestamp: '1651550587.060890941',
+            },
+            transactions: [
+              buildCryptoTransferTransaction('0.0.98', CONTRACT_ID_1, 200, { timestamp: '1651550574.060890964' }),
+              buildCryptoTransferTransaction('0.0.98', CONTRACT_ID_1, 50, { timestamp: '1651550573.060890958' }),
+            ],
+            links: {
+              next: null,
+            },
+          }),
+        );
 
       const latestBlock = {
         ...DEFAULT_BLOCK,
@@ -652,23 +656,27 @@ describe('@ethGetBalance using MirrorNode', async function () {
         }),
       );
 
-      restMock.onGet(`accounts/${CONTRACT_ID_1}?limit=100&timestamp=lt:1651550575.060890941`).reply(
-        200,
-        JSON.stringify({
-          account: CONTRACT_ID_1,
-          balance: {
-            balance: balance3,
-            timestamp: '1651550587.060890941',
-          },
-          transactions: [
-            buildCryptoTransferTransaction('0.0.98', CONTRACT_ID_1, 200, { timestamp: '1651550574.060890964' }),
-            buildCryptoTransferTransaction(CONTRACT_ID_1, '0.0.98', 50, { timestamp: '1651550573.060890958' }),
-          ],
-          links: {
-            next: null,
-          },
-        }),
-      );
+      restMock
+        .onGet(
+          `accounts/${CONTRACT_ID_1}?limit=100&timestamp=lt:1651550575.060890941&timestamp=gte:1651550565.060890941`,
+        )
+        .reply(
+          200,
+          JSON.stringify({
+            account: CONTRACT_ID_1,
+            balance: {
+              balance: balance3,
+              timestamp: '1651550587.060890941',
+            },
+            transactions: [
+              buildCryptoTransferTransaction('0.0.98', CONTRACT_ID_1, 200, { timestamp: '1651550574.060890964' }),
+              buildCryptoTransferTransaction(CONTRACT_ID_1, '0.0.98', 50, { timestamp: '1651550573.060890958' }),
+            ],
+            links: {
+              next: null,
+            },
+          }),
+        );
 
       const latestBlock = {
         ...DEFAULT_BLOCK,
@@ -688,6 +696,72 @@ describe('@ethGetBalance using MirrorNode', async function () {
 
       const resBalance = await ethImpl.getBalance(CONTRACT_ID_1, '1', requestDetails);
       const historicalBalance = numberTo0x(BigInt(balance3 - 80) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
+      expect(resBalance).to.equal(historicalBalance);
+    });
+
+    it('blockNumber is in the latest 15 minutes and pagination is scoped to block.timestamp.to as lower bound to avoid walking full account history', async () => {
+      // Without the gte: lower bound, getAccountPaginated pages through the entire account history
+      // and throws PAGINATION_MAX for high-activity accounts even when only a small window is needed.
+      const blockTimestampTo = '1651550565.060890941';
+      const recentBlockWithinLastfifteen = {
+        ...DEFAULT_BLOCK,
+        number: 1,
+        timestamp: {
+          from: '1651550564.060890921',
+          to: blockTimestampTo,
+        },
+      };
+      restMock.onGet(`blocks/1`).reply(200, JSON.stringify(recentBlockWithinLastfifteen));
+      restMock.onGet(`accounts/${CONTRACT_ID_1}?limit=100`).reply(
+        200,
+        JSON.stringify({
+          account: CONTRACT_ID_1,
+          balance: {
+            balance: balance3,
+            timestamp: '1651550587.060890941',
+          },
+          transactions: [
+            buildCryptoTransferTransaction('0.0.98', CONTRACT_ID_1, 100, { timestamp: '1651550587.060890964' }),
+          ],
+          links: {
+            next: `/api/v1/accounts/${CONTRACT_ID_1}?limit=100&timestamp=lt:1651550575.060890941`,
+          },
+        }),
+      );
+
+      // The paginated URL must include gte:blockTimestampTo so MN scopes results to the relevant
+      // window only — preventing a full history walk that would hit MIRROR_NODE_ACCOUNT_TXS_PG_MAX.
+      restMock
+        .onGet(
+          `accounts/${CONTRACT_ID_1}?limit=100&timestamp=lt:1651550575.060890941&timestamp=gte:${blockTimestampTo}`,
+        )
+        .reply(
+          200,
+          JSON.stringify({
+            account: CONTRACT_ID_1,
+            balance: { balance: balance3, timestamp: '1651550587.060890941' },
+            transactions: [
+              buildCryptoTransferTransaction('0.0.98', CONTRACT_ID_1, 50, { timestamp: '1651550566.060890941' }),
+            ],
+            links: { next: null },
+          }),
+        );
+
+      restMock.onGet(BLOCKS_LIMIT_ORDER_URL).reply(
+        200,
+        JSON.stringify({
+          blocks: [
+            {
+              ...DEFAULT_BLOCK,
+              number: 4,
+              timestamp: { from: '1651550595.060890941', to: '1651550597.060890941' },
+            },
+          ],
+        }),
+      );
+
+      const resBalance = await ethImpl.getBalance(CONTRACT_ID_1, '1', requestDetails);
+      const historicalBalance = numberTo0x(BigInt(balance3 - 150) * TINYBAR_TO_WEIBAR_COEF_BIGINT);
       expect(resBalance).to.equal(historicalBalance);
     });
 

--- a/tests/server/acceptance/rpc_batch3.spec.ts
+++ b/tests/server/acceptance/rpc_batch3.spec.ts
@@ -1327,4 +1327,21 @@ describe('@api-batch-3 RPC Server Acceptance Tests', function () {
       generateTest(method, params);
     }
   });
+
+  it('should return balance for eth_getBalance called with a block number within the last 15 minutes', async function () {
+    const blocksRes = await mirrorNode.get('/blocks?limit=1&order=desc');
+    const latestBlock = blocksRes.blocks[0];
+
+    // 5 blocks back: blockDiff=5 > latestBlockTolerance(1), so delta path is taken.
+    // At ~2s/block this is ~10s old, well within the 900s BALANCES_UPDATE_INTERVAL.
+    const targetBlockNumber = latestBlock.number - 5;
+
+    const balance = await relay.call(RelayCalls.ETH_ENDPOINTS.ETH_GET_BALANCE, [
+      accounts[0].address,
+      numberTo0x(targetBlockNumber),
+    ]);
+
+    expect(balance).to.not.be.null;
+    expect(balance).to.match(/^0x[0-9a-f]+$/i);
+  });
 });


### PR DESCRIPTION
### Description

Fixes `eth_getBalance` failing with "exceeded maximum Mirror Node pagination count (100)" for high-activity accounts when querying a block within the last ~15 minutes. For recent blocks, the relay cannot use the `/balances` snapshot endpoint and instead reconstructs the historical balance by walking the account's transaction history backward from the current balance. Without a lower bound, this walk covers the account's entire history and easily hits `MIRROR_NODE_ACCOUNT_TXS_PG_MAX` (100 pages) even when only a small time window is relevant.

Key changes:
- Added `lowerBoundTimestamp` parameter to `getAccountPaginated()` in `MirrorNodeClient`
- Passes `block.timestamp.to` as a `timestamp=gte:` lower bound, scoping pagination to the relevant time window instead of the full account history

### Related issue(s)

Fixes #5440

### Testing Guide

1. Configure relay with `MIRROR_NODE_LIMIT_PARAM=10` and `MIRROR_NODE_ACCOUNT_TXS_PG_MAX=100`.
2. Identify a high-activity account (many transactions) on testnet/mainnet.
3. Call `eth_getBalance` with that account and a block number whose timestamp is within the last 15 minutes.
4. Before this fix: the call fails with `PAGINATION_MAX` if the account has more than `MIRROR_NODE_LIMIT_PARAM * MIRROR_NODE_ACCOUNT_TXS_PG_MAX` historical transactions. After this fix: the call succeeds because pagination is bounded to the block's time window.
5. Run unit tests: `npm run test` in `packages/relay`.

### Changes from original design (optional)

N/A

### Additional work needed (optional)

N/A

### Checklist

- [x] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [x] I've assigned a label to this PR and related issue(s) (if applicable)
- [x] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)