### PR TITLE
fix: disable exponential notation on json-bigint BigNumber instance

### DIFF
--- a/src/relay/lib/bigNumberConfig.ts
+++ b/src/relay/lib/bigNumberConfig.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import BigNumber from 'bignumber.js';
+
+/**
+ * Mirror Node REST responses can contain integers larger than JavaScript's safe
+ * range (e.g. the wei `value`/`amount` fields). `mirrorNodeClient` parses those
+ * with `json-bigint`, which turns them into `bignumber.js` `BigNumber` instances
+ * to preserve precision.
+ *
+ * By default bignumber.js renders a value whose exponent is >= 21 in exponential
+ * notation, so `new BigNumber('1e21').toString()` is `"1e+21"`. That bites us on
+ * the Redis cache path: `RedisCache` serializes cached Mirror Node objects with
+ * native `JSON.stringify` (which invokes `BigNumber.prototype.toJSON`) on set and
+ * `JSON.parse` on get, so the field comes back as the string `"1e+21"`. Formatters
+ * such as `nanOrNumberInt64To0x` then call `BigInt("1e+21")`, which throws and
+ * surfaces as an HTTP 500 on `eth_getTransactionByHash` / `debug_traceTransaction`.
+ * (The in-memory LRU cache stores objects by reference and never serializes, so it
+ * sidesteps this — the bug is Redis-only.)
+ *
+ * Setting `EXPONENTIAL_AT` to its maximum (1e9, the documented "never use
+ * exponential" value) makes `toString`/`toJSON` always emit full decimal digits, so
+ * the round-trip yields `"1000000000000000000000"` and `BigInt(...)` succeeds. EVM
+ * `value` is a uint256 (max ~1.16e77), so any threshold below ~78 would still break
+ * real values; 1e9 clears that range with a wide margin.
+ *
+ * IMPORTANT: this configures the bignumber.js instance that `json-bigint` uses. Two
+ * major versions are installed — `json-bigint` resolves the hoisted top-level
+ * `bignumber.js` (v9), while the Hedera SDK carries its own nested v10. `import
+ * BigNumber from 'bignumber.js'` resolves to the same v9 instance json-bigint
+ * `require`s, so the config takes effect; the SDK's v10 (used for Hbar/amount math)
+ * is left untouched, keeping the blast radius to Mirror Node response parsing.
+ *
+ * This module is imported for its side effect by `mirrorNodeClient`, guaranteeing
+ * the configuration is applied before the first response is parsed, on every
+ * entrypoint (HTTP, WS) and in tests.
+ */
+BigNumber.config({ EXPONENTIAL_AT: 1e9 });

--- a/src/relay/lib/clients/mirrorNodeClient.ts
+++ b/src/relay/lib/clients/mirrorNodeClient.ts
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
+// Side-effect import: configures the json-bigint bignumber.js instance before any response is parsed.
+import '../bigNumberConfig';
+
 import Axios, { type AxiosInstance, type AxiosRequestConfig, type AxiosResponse } from 'axios';
 import axiosRetry from 'axios-retry';
 import { install as betterLookupInstall } from 'better-lookup';

--- a/tests/relay/lib/bigNumberConfig.spec.ts
+++ b/tests/relay/lib/bigNumberConfig.spec.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Importing the production module applies the bignumber.js configuration as a
+// side effect, exactly as mirrorNodeClient does before it parses any response.
+import '../../../src/relay/lib/bigNumberConfig';
+
+import BigNumber from 'bignumber.js';
+import { expect } from 'chai';
+import JSONBigInt from 'json-bigint';
+
+import { nanOrNumberInt64To0x } from '../../../src/relay/formatters';
+
+describe('bigNumberConfig', () => {
+  it('renders large integers without exponential notation', () => {
+    // Under the bignumber.js default this would serialize as "1e+21".
+    expect(new BigNumber('1e21').toJSON()).to.equal('1000000000000000000000');
+    expect(new BigNumber('1e21').toString()).to.equal('1000000000000000000000');
+    // EVM `value` is a uint256 (max ~1.16e77); the threshold must clear that whole range.
+    expect(new BigNumber('1e40').toString()).to.equal('1' + '0'.repeat(40));
+  });
+
+  it('keeps a large Mirror Node amount intact across the json-bigint parse + Redis JSON round-trip', () => {
+    // Mirror Node returns large integers as raw JSON numbers; mirrorNodeClient parses them with json-bigint.
+    const parsed = JSONBigInt.parse('{"amount":1000000000000000000000}');
+    // RedisCache serializes with native JSON.stringify on set and JSON.parse on get.
+    const roundTripped = JSON.parse(JSON.stringify(parsed));
+    // debug.ts formats the amount with nanOrNumberInt64To0x, which calls BigInt() on the value.
+    expect(nanOrNumberInt64To0x(roundTripped.amount)).to.equal('0x3635c9adc5dea00000');
+  });
+});


### PR DESCRIPTION
### Description

This PR fixes an issue where `eth_getTransactionByHash` and `debug_traceTransaction` return HTTP 500 for transactions whose `value`/`amount` is `>= 1e21` (e.g. 1000+ HBAR expressed in weibars).

Mirror Node returns such values as large JSON integers, which `json-bigint` parses into `bignumber.js` `BigNumber` objects to preserve precision. When the response is cached in Redis, `RedisCache` serializes it with native `JSON.stringify` (which calls `BigNumber.prototype.toJSON`) on set and `JSON.parse` on get. Under the bignumber.js default, any value with exponent `>= 21` serializes in exponential notation, so the field round-trips through Redis as the string `"1e+21"`. Formatters such as `nanOrNumberInt64To0x` then call `BigInt("1e+21")`, which throws and surfaces as a 500.

The fix configures the bignumber.js instance that `json-bigint` uses with `EXPONENTIAL_AT: 1e9`, so large integers always serialize as full decimal digits and the round-trip is lossless. The config is applied in a small side-effect module (`src/relay/lib/bigNumberConfig.ts`) imported by `MirrorNodeClient` before any response is parsed.

Notes for reviewers:

- The in-memory LRU cache stores objects by reference and never serializes, so it was never affected. The bug only reproduced with Redis enabled.
- Two `bignumber.js` majors are installed. `json-bigint` uses the hoisted v9, while the Hedera SDK uses its own nested v10. The config targets the v9 instance `json-bigint` uses, leaving the SDK's amount math untouched.

### Related issue(s)

Fixes #5460

### Testing Guide

1. Automated: run the new regression test, which exercises the parse to Redis JSON round-trip to formatter path:
   ```bash
   npx ts-mocha ./tests/relay/lib/bigNumberConfig.spec.ts --exit
   ```
   A `1e21` amount round-trips to `1000000000000000000000` and formats to `0x3635c9adc5dea00000` instead of throwing `Cannot convert 1e+21 to a BigInt`.
2. Manual (Redis): with `REDIS_ENABLED=true`, call `eth_getTransactionByHash` (or `debug_traceTransaction`) for a transaction whose `value` is `>= 1e21` weibars (1000 HBAR or more). Call it twice so the second request is served from the Redis cache.
3. Before this change the cache-hit call returns HTTP 500; after it, the call returns the correct value.

### Changes from original design (optional)

N/A

### Additional work needed (optional)

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
