### PR TITLE
fix: pass Redis client to WS server in acceptance test setup

### DIFF
--- a/tests/acceptance-runner.ts
+++ b/tests/acceptance-runner.ts
@@ -11,6 +11,7 @@ import chaiAsPromised from 'chai-as-promised';
 import pino from 'pino';
 
 import { ConfigService } from '../src/config-service/services';
+import { RedisClientManager } from '../src/relay/lib/clients/redisClientManager';
 import constants from '../src/relay/lib/constants';
 import { setServerTimeout } from '../src/server/koaJsonRpc/lib/utils';
 import { initializeServer } from '../src/server/server';
@@ -202,7 +203,14 @@ export function registerAcceptanceSuite(options: AcceptanceSuiteOptions): void {
       const shouldStartWs = wsServer === 'always' || (wsServer === 'config' && ConfigService.get('TEST_WS_SERVER'));
       if (shouldStartWs) {
         logger.info(`Start ws-server on port ${constants.WEB_SOCKET_PORT}`);
-        const { app: wsApp } = await initializeWsServer(wsServer === 'always' ? relay : undefined);
+        const redisClient = RedisClientManager.isRedisEnabled()
+          ? await RedisClientManager.getClient(logger)
+          : undefined;
+        const { app: wsApp } = await initializeWsServer(
+          wsServer === 'always' ? relay : undefined,
+          undefined,
+          redisClient,
+        );
         global.socketServer = wsApp.listen({ port: constants.WEB_SOCKET_PORT });
       }
     }


### PR DESCRIPTION
### Description

When `wsServer === 'always'`, `acceptance-runner.ts` passes `relay` to `initializeWsServer`. A guard inside `initializeWsServer` skips Redis init when `sharedRelay` is present, leaving `redisClient` undefined and causing `RateLimitStoreFactory` to fall back to `LruRateLimitStore`. The HTTP server gets `RedisRateLimitStore`; the two transports track counters independently, breaking every cross-transport assertion.

Fix: fetch the Redis singleton upfront and pass it explicitly as the third arg to `initializeWsServer`, mirroring what `src/index.ts` already does in production. When Redis is disabled, `redisClient` is `undefined` and both transports fall back to LRU as before.

### Related issue(s)

Fixes #5452

### Testing Guide

1. Set `REDIS_ENABLED=true` and `REDIS_URL` in `.env` with a reachable Redis instance
2. Run `npm run acceptancetest:protocol-eth-plain`
3. All tests in `tests/protocol/rateLimiterRedis.spec.ts` pass (previously failing at lines 68, 83, 98, 147)

### Changes from original design (optional)

N/A

### Additional work needed (optional)

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)