### PR TITLE
fix: add EIP-3860 initcode size precheck in eth_sendRawTransaction

### DIFF
--- a/src/relay/lib/constants.ts
+++ b/src/relay/lib/constants.ts
@@ -106,8 +106,9 @@ export default {
   // EIP-7623: Calldata floor pricing constants
   TOTAL_COST_FLOOR_PER_TOKEN: 10,
 
-  // EIP-3860: Initcode cost for contract creation
+  // EIP-3860: Initcode cost and size limit for contract creation
   INITCODE_WORD_COST: 2,
+  MAX_INITCODE_SIZE: 49152,
 
   // EIP-7702: Authorization list cost for type 4 transactions
   PER_EMPTY_ACCOUNT_COST: 25_000,

--- a/src/relay/lib/errors/JsonRpcError.ts
+++ b/src/relay/lib/errors/JsonRpcError.ts
@@ -277,6 +277,11 @@ export const predefined = {
       code: -32201,
       message: `Oversized data: call data size ${actualSize}, call data size limit ${expectedSize}`,
     }),
+  INITCODE_SIZE_LIMIT_EXCEEDED: (actualSize: number, expectedSize: number) =>
+    new JsonRpcError({
+      code: -32201,
+      message: `Oversized data: initcode size ${actualSize}, initcode size limit ${expectedSize}`,
+    }),
   BATCH_REQUESTS_DISABLED: new JsonRpcError({
     code: -32202,
     message: 'Batch requests are disabled',

--- a/src/relay/lib/precheck.ts
+++ b/src/relay/lib/precheck.ts
@@ -69,6 +69,7 @@ export class Precheck {
    */
   validateBasicPropertiesStateless(parsedTx: Transaction) {
     this.callDataSize(parsedTx);
+    this.initcodeSize(parsedTx);
     this.transactionSize(parsedTx);
     this.transactionType(parsedTx);
     this.gasLimit(parsedTx);
@@ -370,6 +371,23 @@ export class Precheck {
     const callDataSizeLimit = constants.CALL_DATA_SIZE_LIMIT;
     if (totalCallDataSizeInBytes > callDataSizeLimit) {
       throw predefined.CALL_DATA_SIZE_LIMIT_EXCEEDED(totalCallDataSizeInBytes, callDataSizeLimit);
+    }
+  }
+
+  /**
+   * Validates that the initcode size does not exceed the EIP-3860 limit for contract creation transactions.
+   * Only applies when `tx.to` is null (i.e. the transaction is a contract deployment).
+   * The data field of a contract creation transaction IS the initcode.
+   *
+   * @param tx - The transaction to validate.
+   * @throws {JsonRpcError} If the initcode size exceeds the EIP-3860 limit of 49152 bytes.
+   * @see https://eips.ethereum.org/EIPS/eip-3860
+   */
+  initcodeSize(tx: Transaction): void {
+    if (tx.to !== null) return;
+    const initcodeSizeInBytes = tx.data.replace('0x', '').length / 2;
+    if (initcodeSizeInBytes > constants.MAX_INITCODE_SIZE) {
+      throw predefined.INITCODE_SIZE_LIMIT_EXCEEDED(initcodeSizeInBytes, constants.MAX_INITCODE_SIZE);
     }
   }
 

--- a/tests/relay/lib/precheck.spec.ts
+++ b/tests/relay/lib/precheck.spec.ts
@@ -939,6 +939,77 @@ describe('Precheck', async function () {
     });
   });
 
+  describe('initcodeSize', function () {
+    const createContractCreationTx = async (dataSize: number) => {
+      const wallet = ethers.Wallet.createRandom();
+      const txParams = {
+        value: ONE_TINYBAR_IN_WEI_HEX,
+        gasPrice: defaultGasPrice,
+        gasLimit: defaultGasLimit,
+        chainId: defaultChainId,
+        nonce: 5,
+        data: '0x' + '00'.repeat(dataSize),
+      };
+      const signed = await wallet.signTransaction(txParams);
+      return ethers.Transaction.from(signed);
+    };
+
+    const createRegularTx = async (dataSize: number) => {
+      const wallet = ethers.Wallet.createRandom();
+      const txParams = {
+        value: ONE_TINYBAR_IN_WEI_HEX,
+        gasPrice: defaultGasPrice,
+        gasLimit: defaultGasLimit,
+        chainId: defaultChainId,
+        nonce: 5,
+        to: contractAddress1,
+        data: '0x' + '00'.repeat(dataSize),
+      };
+      const signed = await wallet.signTransaction(txParams);
+      return ethers.Transaction.from(signed);
+    };
+
+    it('should accept contract creation with initcode exactly at the limit', async () => {
+      const tx = await createContractCreationTx(constants.MAX_INITCODE_SIZE);
+      expect(() => precheck.initcodeSize(tx)).not.to.throw();
+    });
+
+    it('should reject contract creation with initcode exceeding the limit', async () => {
+      const tx = await createContractCreationTx(constants.MAX_INITCODE_SIZE + 1);
+      try {
+        precheck.initcodeSize(tx);
+        expect('Transaction should have been rejected').to.be.false;
+      } catch (error) {
+        expect(error).to.be.an.instanceOf(JsonRpcError);
+        const expectedError = predefined.INITCODE_SIZE_LIMIT_EXCEEDED(
+          constants.MAX_INITCODE_SIZE + 1,
+          constants.MAX_INITCODE_SIZE,
+        );
+        expect(error).to.deep.equal(expectedError);
+      }
+    });
+
+    it('should not apply the initcode limit to regular call transactions', async () => {
+      const tx = await createRegularTx(constants.MAX_INITCODE_SIZE + 1);
+      expect(() => precheck.initcodeSize(tx)).not.to.throw();
+    });
+
+    it('should reject oversized initcode via validateBasicPropertiesStateless', async () => {
+      const tx = await createContractCreationTx(constants.MAX_INITCODE_SIZE + 1);
+      try {
+        precheck.validateBasicPropertiesStateless(tx);
+        expect('Transaction should have been rejected').to.be.false;
+      } catch (error) {
+        expect(error).to.be.an.instanceOf(JsonRpcError);
+        const expectedError = predefined.INITCODE_SIZE_LIMIT_EXCEEDED(
+          constants.MAX_INITCODE_SIZE + 1,
+          constants.MAX_INITCODE_SIZE,
+        );
+        expect(error).to.deep.equal(expectedError);
+      }
+    });
+  });
+
   describe('transactionType', async function () {
     const defaultTx = {
       value: ONE_TINYBAR_IN_WEI_HEX,


### PR DESCRIPTION
### Description
  
  This PR adds a stateless precheck for EIP-3860 initcode size limits in `eth_sendRawTransaction`. Contract creation transactions with initcode exceeding 49152
  bytes are now rejected at the relay level before being submitted to the consensus node, returning a structured JSON-RPC error instead of letting the
  transaction fail on-chain with `CONTRACT_SIZE_LIMIT_EXCEEDED`.

  ### Related issue(s)

  Fixes #5495

  ### Testing Guide

  1. Run unit tests: `npx ts-mocha 'tests/relay/lib/precheck.spec.ts'`
  2. Send a contract creation transaction (`to=null`) with initcode of exactly 49152 bytes — transaction should be accepted.
  3. Send a contract creation transaction (`to=null`) with initcode of 49153 bytes or more — relay should return an `INITCODE_SIZE_LIMIT_EXCEEDED` error
  immediately without submitting to the consensus node.
  4. Send a regular call transaction (`to` set) with data exceeding 49152 bytes — transaction should be accepted (initcode limit does not apply).

  ### Changes from original design (optional)
  
  N/A

  ### Additional work needed (optional)

  N/A