### PR TITLE
fix: replace LPOS with LRANGE for Redis version compatibility in lock queue membership check

### DIFF
--- a/src/relay/lib/services/lockService/RedisLockStrategy.ts
+++ b/src/relay/lib/services/lockService/RedisLockStrategy.ts
@@ -83,8 +83,8 @@ export class RedisLockStrategy implements LockStrategy {
         const now = process.hrtime.bigint();
         if (Number(now - lastMembershipCheckAt) / 1e6 >= this.membershipCheckIntervalMs) {
           lastMembershipCheckAt = now;
-          const position = await this.redisClient.lPos(queueKey, sessionKey);
-          if (position === null) {
+          const queue = await this.redisClient.lRange(queueKey, 0, -1);
+          if (!queue.includes(sessionKey)) {
             await this.redisClient.lPush(queueKey, sessionKey);
             this.lockMetricsService.recordQueueRejoin(this.type);
             this.logger.debug('Session not in queue; rejoined: address=%s, sessionKey=%s', address, sessionKey);

--- a/tests/relay/lib/services/lockService/RedisLockStrategy.spec.ts
+++ b/tests/relay/lib/services/lockService/RedisLockStrategy.spec.ts
@@ -31,7 +31,7 @@ describe('RedisLockStrategy Test Suite', function () {
     mockRedisClient = {
       lPush: sinon.stub(),
       lIndex: sinon.stub(),
-      lPos: sinon.stub(),
+      lRange: sinon.stub(),
       set: sinon.stub(),
       lRem: sinon.stub(),
       lLen: sinon.stub(),
@@ -39,9 +39,9 @@ describe('RedisLockStrategy Test Suite', function () {
       exists: sinon.stub(),
     } as any;
 
-    // Default: session is present in the queue (at position 0). Individual tests
-    // override with `.resolves(null)` to exercise the rejoin path.
-    mockRedisClient.lPos.resolves(0);
+    // Default: session is present in the queue. Individual tests override with
+    // `.resolves([])` to exercise the rejoin path.
+    mockRedisClient.lRange.resolves(['test-session-key']);
 
     // Create a mock metrics service
     mockMetricsService = {
@@ -565,12 +565,12 @@ describe('RedisLockStrategy Test Suite', function () {
     // without waiting LOCK_QUEUE_MEMBERSHIP_CHECK_INTERVAL_MS of wall clock per test.
     overrideEnvsInMochaDescribe({ LOCK_QUEUE_MEMBERSHIP_CHECK_INTERVAL_MS: 0 });
 
-    it('should rejoin the queue when lPos reports the session is missing', async () => {
+    it('should rejoin the queue when lRange reports the session is missing', async () => {
       const sessionKey = 'test-session-key';
 
       mockRedisClient.lPush.resolves(1);
       // First iteration: session is missing, rejoin. Second iteration: present at head.
-      mockRedisClient.lPos.onFirstCall().resolves(null).onSecondCall().resolves(0);
+      mockRedisClient.lRange.onFirstCall().resolves([]).onSecondCall().resolves([sessionKey]);
       mockRedisClient.lIndex.resolves(sessionKey);
       mockRedisClient.set.resolves('OK');
       mockRedisClient.lRem.resolves(1);
@@ -583,7 +583,7 @@ describe('RedisLockStrategy Test Suite', function () {
       expect(result).to.not.be.undefined;
       expect(result!.sessionKey).to.equal(sessionKey);
 
-      // Should have pushed twice. Once to join, once to rejoin
+      // Should have pushed twice: once to join, once to rejoin.
       expect(mockRedisClient.lPush.callCount).to.equal(2);
       expect(mockMetricsService.recordQueueRejoin.calledOnceWith('redis')).to.be.true;
     });
@@ -592,10 +592,10 @@ describe('RedisLockStrategy Test Suite', function () {
       const sessionKey = 'test-session-key';
 
       mockRedisClient.lPush.resolves(1);
-      // Two consecutive "not in queue" responses, then present
-      mockRedisClient.lPos.onCall(0).resolves(null).onCall(1).resolves(null).onCall(2).resolves(0);
+      // Two consecutive "not in queue" responses, then present.
+      mockRedisClient.lRange.onCall(0).resolves([]).onCall(1).resolves([]).onCall(2).resolves([sessionKey]);
       // Simulate Redis being reset: lIndex reports an empty queue on the first
-      // two iterations (so the loop doesn't acquire and lPos runs again next
+      // two iterations (so the loop doesn't acquire and lRange runs again next
       // iteration), then we are at the head and acquire on the third.
       mockRedisClient.lIndex.onCall(0).resolves(null).onCall(1).resolves(null).onCall(2).resolves(sessionKey);
       mockRedisClient.set.resolves('OK');
@@ -611,11 +611,11 @@ describe('RedisLockStrategy Test Suite', function () {
       expect(mockMetricsService.recordQueueRejoin.callCount).to.equal(2);
     });
 
-    it('should not record a rejoin when lPos returns a valid position', async () => {
+    it('should not record a rejoin when lRange returns the session', async () => {
       const sessionKey = 'test-session-key';
 
       mockRedisClient.lPush.resolves(1);
-      mockRedisClient.lPos.resolves(0);
+      mockRedisClient.lRange.resolves([sessionKey]);
       mockRedisClient.lIndex.resolves(sessionKey);
       mockRedisClient.set.resolves('OK');
       mockRedisClient.lRem.resolves(1);
@@ -631,11 +631,11 @@ describe('RedisLockStrategy Test Suite', function () {
   });
 
   describe('Queue membership check interval', () => {
-    it('should not call lPos on the happy path before the interval elapses', async () => {
+    it('should not call lRange on the happy path before the interval elapses', async () => {
       const sessionKey = 'test-session-key';
 
       // Default LOCK_QUEUE_MEMBERSHIP_CHECK_INTERVAL_MS (10s) — well above
-      // the time a single mocked iteration takes — so lPos must be skipped.
+      // the time a single mocked iteration takes — so lRange must be skipped.
       mockRedisClient.lPush.resolves(1);
       mockRedisClient.lIndex.resolves(sessionKey);
       mockRedisClient.set.resolves('OK');
@@ -647,7 +647,7 @@ describe('RedisLockStrategy Test Suite', function () {
       const result = await redisLockStrategy.acquireLock(testAddress);
 
       expect(result).to.not.be.undefined;
-      expect(mockRedisClient.lPos.called).to.be.false;
+      expect(mockRedisClient.lRange.called).to.be.false;
       expect(mockMetricsService.recordQueueRejoin.called).to.be.false;
     });
   });


### PR DESCRIPTION
### Description

Cherry-pick of #5513 onto `release/0.78`.

Replaces the `lPos` Redis command with `lRange(0, -1)` + `includes` in the periodic queue membership check inside `RedisLockStrategy`. The `LPOS` command was introduced in Redis 6.0.6; mainnet is running an older version that rejects it with `ERR unknown command LPOS`, causing 180 lock acquisition failures in production over 56 hours. Every failure silently broke nonce ordering for the affected sender.

`LRANGE` is available since Redis 1.0.0 and is semantically equivalent for a membership boolean at typical queue depths (< 10 entries).

### Related issue(s)

Fixes #5512

### Testing Guide

1. Confirm unit tests pass: `npx c8 ts-mocha tests/relay/lib/services/lockService/RedisLockStrategy.spec.ts`
2. Verify the `rpc_relay_lock_acquisitions_total{status="fail"}` alert stops firing on mainnet after deployment

### Changes from original design (optional)

N/A

### Additional work needed (optional)

Redis version compatibility regression testing is tracked in #5511.

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)