### PR TITLE
perf: introduce worker context to reduce duplicate client instances

### DIFF
--- a/src/relay/lib/services/ethService/accountService/accountWorker.ts
+++ b/src/relay/lib/services/ethService/accountService/accountWorker.ts
@@ -1,46 +1,25 @@
 // SPDX-License-Identifier: Apache-2.0
-import pino from 'pino';
-
-import { ConfigService } from '../../../../../config-service/services';
 import { numberTo0x } from '../../../../formatters';
-import { MirrorNodeClient } from '../../../clients/mirrorNodeClient';
 import constants from '../../../constants';
-import { CacheClientFactory } from '../../../factories/cacheClientFactory';
-import { RegistryFactory } from '../../../factories/registryFactory';
 import { type RequestDetails } from '../../../types';
-import { LocalPendingTransactionStorage } from '../../transactionPoolService/LocalPendingTransactionStorage';
-import { TransactionPoolService } from '../../transactionPoolService/transactionPoolService';
+import { type WorkerContext } from '../../workersService/workerContext';
 import { wrapError } from '../../workersService/WorkersErrorUtils';
-import { CommonService } from '../ethCommonService/CommonService';
-import { AccountService } from './AccountService';
-
-const logger = pino({ level: ConfigService.get('LOG_LEVEL') || 'trace' });
-const register = RegistryFactory.getInstance();
-const cacheService = CacheClientFactory.create(logger, register);
-const mirrorNodeClient = new MirrorNodeClient(ConfigService.get('MIRROR_NODE_URL'), logger, register, cacheService);
-const commonService = new CommonService(mirrorNodeClient, logger, cacheService);
-// Can use LocalPendingTransactionStorage() as transactionPoolService is required in AccountService constructor but not used for getBalance
-const transactionPoolService = new TransactionPoolService(new LocalPendingTransactionStorage(), logger, register);
-const accountService = new AccountService(
-  cacheService,
-  commonService,
-  logger,
-  mirrorNodeClient,
-  transactionPoolService,
-);
 
 /**
  * Gets the balance of an account as of the given block from the mirror node.
  *
+ * @param {WorkerContext} ctx The shared worker context providing the clients and services
  * @param {string} account The account to get the balance from
  * @param {string} blockNumberOrTagOrHash The block number or tag or hash to get the balance from
  * @param {RequestDetails} requestDetails The request details for logging and tracking
  */
 export async function getBalance(
+  ctx: WorkerContext,
   account: string,
   blockNumberOrTagOrHash: string,
   requestDetails: RequestDetails,
 ): Promise<string> {
+  const { commonService, accountService, mirrorNodeClient, logger } = ctx;
   try {
     let blockNumber: number | null = null;
     let balanceFound = false;

--- a/src/relay/lib/services/ethService/accountService/accountWorker.ts
+++ b/src/relay/lib/services/ethService/accountService/accountWorker.ts
@@ -2,19 +2,19 @@
 import { numberTo0x } from '../../../../formatters';
 import constants from '../../../constants';
 import { type RequestDetails } from '../../../types';
-import { type WorkerContext } from '../../workersService/workerContext';
+import { type IWorkerContext } from '../../workersService/workerContext';
 import { wrapError } from '../../workersService/WorkersErrorUtils';
 
 /**
  * Gets the balance of an account as of the given block from the mirror node.
  *
- * @param {WorkerContext} ctx The shared worker context providing the clients and services
+ * @param {IWorkerContext} ctx The shared worker context providing the clients and services
  * @param {string} account The account to get the balance from
  * @param {string} blockNumberOrTagOrHash The block number or tag or hash to get the balance from
  * @param {RequestDetails} requestDetails The request details for logging and tracking
  */
 export async function getBalance(
-  ctx: WorkerContext,
+  ctx: IWorkerContext,
   account: string,
   blockNumberOrTagOrHash: string,
   requestDetails: RequestDetails,

--- a/src/relay/lib/services/ethService/blockService/blockWorker.ts
+++ b/src/relay/lib/services/ethService/blockService/blockWorker.ts
@@ -26,7 +26,7 @@ import {
   type RequestDetails,
 } from '../../../types';
 import { type IReceiptRlpInput } from '../../../types/IReceiptRlpInput';
-import { type WorkerContext } from '../../workersService/workerContext';
+import { type IWorkerContext } from '../../workersService/workerContext';
 import { wrapError } from '../../workersService/WorkersErrorUtils';
 
 interface IReceiptRootHashLog {
@@ -297,7 +297,7 @@ async function getRootHash(receipts: IReceiptRootHash[]): Promise<string> {
  * @returns A tuple of [fromAddressMap, toAddressMap], each mapping original address to its resolved EVM address
  */
 async function resolveContractResultAddresses(
-  ctx: WorkerContext,
+  ctx: IWorkerContext,
   contractResults: any[],
   requestDetails: RequestDetails,
 ): Promise<[Map<string, string>, Map<string, string>]> {
@@ -341,7 +341,7 @@ async function resolveContractResultAddresses(
 }
 
 async function prepareTransactionArray(
-  ctx: WorkerContext,
+  ctx: IWorkerContext,
   contractResults: MirrorNodeContractResult[],
   showDetails: boolean,
   requestDetails: RequestDetails,
@@ -366,7 +366,7 @@ async function prepareTransactionArray(
 }
 
 export async function getBlock(
-  ctx: WorkerContext,
+  ctx: IWorkerContext,
   blockHashOrNumber: string,
   showDetails: boolean,
   requestDetails: RequestDetails,
@@ -451,7 +451,7 @@ export async function getBlock(
 }
 
 export async function getBlockReceipts(
-  ctx: WorkerContext,
+  ctx: IWorkerContext,
   blockHashOrBlockNumber: string,
   requestDetails: RequestDetails,
 ): Promise<ITransactionReceipt[] | null> {
@@ -550,7 +550,7 @@ export async function getBlockReceipts(
  *   when running inside a worker thread, or propagates natively on the main thread.
  */
 export async function getRawReceipts(
-  ctx: WorkerContext,
+  ctx: IWorkerContext,
   blockHashOrBlockNumber: string,
   requestDetails: RequestDetails,
 ): Promise<string[]> {
@@ -607,7 +607,7 @@ export async function getRawReceipts(
  *   - `logsByHash`: Map of transaction hash → log entries for that tx
  */
 async function loadBlockExecutionData(
-  ctx: WorkerContext,
+  ctx: IWorkerContext,
   blockHashOrBlockNumber: string,
   requestDetails: RequestDetails,
 ): Promise<{

--- a/src/relay/lib/services/ethService/blockService/blockWorker.ts
+++ b/src/relay/lib/services/ethService/blockService/blockWorker.ts
@@ -3,18 +3,14 @@
 import { RLP } from '@ethereumjs/rlp';
 import { Trie } from '@ethereumjs/trie';
 import { bytesToInt, concatBytes, hexToBytes, intToBytes, intToHex } from '@ethereumjs/util';
-import pino from 'pino';
 
 import { ConfigService } from '../../../../../config-service/services';
 import { nanOrNumberTo0x, numberTo0x, prepend0x } from '../../../../formatters';
 import { LogsBloomUtils } from '../../../../logsBloomUtils';
 import { Utils } from '../../../../utils';
-import { MirrorNodeClient } from '../../../clients/mirrorNodeClient';
 import constants from '../../../constants';
 import { predefined } from '../../../errors/JsonRpcError';
 import { BlockFactory } from '../../../factories/blockFactory';
-import { CacheClientFactory } from '../../../factories/cacheClientFactory';
-import { RegistryFactory } from '../../../factories/registryFactory';
 import { createTransactionFromContractResult, TransactionFactory } from '../../../factories/transactionFactory';
 import {
   type IRegularTransactionReceiptParams,
@@ -30,28 +26,8 @@ import {
   type RequestDetails,
 } from '../../../types';
 import { type IReceiptRlpInput } from '../../../types/IReceiptRlpInput';
+import { type WorkerContext } from '../../workersService/workerContext';
 import { wrapError } from '../../workersService/WorkersErrorUtils';
-import { CommonService } from '../ethCommonService/CommonService';
-
-/**
- * Worker threads run in separate V8 Isolates with isolated memory heaps.
- * Complex objects (like network clients with sockets) cannot be shared by reference.
- * Therefore, we must instantiate separate clients for the worker.
- * Ref: https://nodejs.org/api/worker_threads.html#worker-threads
- */
-const logger = pino({ level: ConfigService.get('LOG_LEVEL') || 'trace' });
-const register = RegistryFactory.getInstance();
-const cacheService = CacheClientFactory.create(logger, register);
-const mirrorNodeClient = new MirrorNodeClient(
-  ConfigService.get('MIRROR_NODE_URL'),
-  logger,
-  register,
-  cacheService,
-  undefined,
-  undefined,
-  undefined,
-);
-const commonService = new CommonService(mirrorNodeClient, logger, cacheService);
 
 interface IReceiptRootHashLog {
   address: string;
@@ -315,14 +291,17 @@ async function getRootHash(receipts: IReceiptRootHash[]): Promise<string> {
  * the cap applies globally across both address types: as soon as any function finishes it picks
  * the next address immediately, keeping throughput maximised without ever exceeding the connection pool limit.
  *
+ * @param ctx - The shared worker context providing the clients and services
  * @param contractResults - Array of contract results whose addresses to resolve
  * @param requestDetails - Request details for logging and tracking
  * @returns A tuple of [fromAddressMap, toAddressMap], each mapping original address to its resolved EVM address
  */
 async function resolveContractResultAddresses(
+  ctx: WorkerContext,
   contractResults: any[],
   requestDetails: RequestDetails,
 ): Promise<[Map<string, string>, Map<string, string>]> {
+  const { commonService } = ctx;
   const concurrencyLimit = ConfigService.get('MIRROR_NODE_HTTP_MAX_SOCKETS');
 
   const seenFrom = new Set<string>();
@@ -362,6 +341,7 @@ async function resolveContractResultAddresses(
 }
 
 async function prepareTransactionArray(
+  ctx: WorkerContext,
   contractResults: MirrorNodeContractResult[],
   showDetails: boolean,
   requestDetails: RequestDetails,
@@ -371,7 +351,7 @@ async function prepareTransactionArray(
     return contractResults.map((cr) => cr.hash);
   }
 
-  const [fromAddressMap, toAddressMap] = await resolveContractResultAddresses(contractResults, requestDetails);
+  const [fromAddressMap, toAddressMap] = await resolveContractResultAddresses(ctx, contractResults, requestDetails);
 
   return contractResults
     .map((contractResult) => {
@@ -386,11 +366,13 @@ async function prepareTransactionArray(
 }
 
 export async function getBlock(
+  ctx: WorkerContext,
   blockHashOrNumber: string,
   showDetails: boolean,
   requestDetails: RequestDetails,
   chain: string,
 ): Promise<Block | null> {
+  const { commonService, mirrorNodeClient, logger } = ctx;
   try {
     const blockResponse: MirrorNodeBlock = await commonService.getHistoricalBlockResponse(
       requestDetails,
@@ -426,6 +408,7 @@ export async function getBlock(
     }
 
     let txArray: Transaction[] | string[] = await prepareTransactionArray(
+      ctx,
       contractResults,
       showDetails,
       requestDetails,
@@ -468,11 +451,17 @@ export async function getBlock(
 }
 
 export async function getBlockReceipts(
+  ctx: WorkerContext,
   blockHashOrBlockNumber: string,
   requestDetails: RequestDetails,
 ): Promise<ITransactionReceipt[] | null> {
+  const { commonService } = ctx;
   try {
-    const { block, contractResults, logsByHash } = await loadBlockExecutionData(blockHashOrBlockNumber, requestDetails);
+    const { block, contractResults, logsByHash } = await loadBlockExecutionData(
+      ctx,
+      blockHashOrBlockNumber,
+      requestDetails,
+    );
     if (!block) return null;
 
     if ((!contractResults || contractResults.length === 0) && logsByHash.size === 0) {
@@ -483,7 +472,7 @@ export async function getBlockReceipts(
       await commonService.getGasPriceInWeibars(requestDetails, block.timestamp.from.split('.')[0]),
     );
 
-    const [fromAddressMap, toAddressMap] = await resolveContractResultAddresses(contractResults, requestDetails);
+    const [fromAddressMap, toAddressMap] = await resolveContractResultAddresses(ctx, contractResults, requestDetails);
 
     const resolved = contractResults.map((contractResult) => {
       const logs = logsByHash.get(contractResult.hash) || [];
@@ -561,11 +550,16 @@ export async function getBlockReceipts(
  *   when running inside a worker thread, or propagates natively on the main thread.
  */
 export async function getRawReceipts(
+  ctx: WorkerContext,
   blockHashOrBlockNumber: string,
   requestDetails: RequestDetails,
 ): Promise<string[]> {
   try {
-    const { block, contractResults, logsByHash } = await loadBlockExecutionData(blockHashOrBlockNumber, requestDetails);
+    const { block, contractResults, logsByHash } = await loadBlockExecutionData(
+      ctx,
+      blockHashOrBlockNumber,
+      requestDetails,
+    );
     if (!block || ((!contractResults || contractResults.length === 0) && logsByHash.size === 0)) {
       return [];
     }
@@ -603,6 +597,7 @@ export async function getRawReceipts(
  * Fetches the block by hash or number, then in parallel loads contract results and logs
  * for the block's timestamp range. Logs are grouped by transaction hash for quick lookup.
  *
+ * @param ctx - The shared worker context providing the clients and services
  * @param blockHashOrBlockNumber - Block hash (0x-prefixed) or block number string
  * @param requestDetails - The request details for logging and tracking
  * @returns Promise resolving to `{ block, contractResults, logsByHash }`. If the block is
@@ -612,6 +607,7 @@ export async function getRawReceipts(
  *   - `logsByHash`: Map of transaction hash → log entries for that tx
  */
 async function loadBlockExecutionData(
+  ctx: WorkerContext,
   blockHashOrBlockNumber: string,
   requestDetails: RequestDetails,
 ): Promise<{
@@ -619,6 +615,7 @@ async function loadBlockExecutionData(
   contractResults: MirrorNodeContractResult[];
   logsByHash: Map<string, Log[]>;
 }> {
+  const { commonService, mirrorNodeClient } = ctx;
   const block = await commonService.getHistoricalBlockResponse(requestDetails, blockHashOrBlockNumber);
   if (!block) return { block: null, contractResults: [], logsByHash: new Map() };
 

--- a/src/relay/lib/services/ethService/ethCommonService/commonWorker.ts
+++ b/src/relay/lib/services/ethService/ethCommonService/commonWorker.ts
@@ -1,31 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import pino from 'pino';
-
-import { ConfigService } from '../../../../../config-service/services';
-import { MirrorNodeClient } from '../../../clients/mirrorNodeClient';
-import { CacheClientFactory } from '../../../factories/cacheClientFactory';
-import { RegistryFactory } from '../../../factories/registryFactory';
 import { type Log } from '../../../model';
 import { type RequestDetails } from '../../../types';
+import { type WorkerContext } from '../../workersService/workerContext';
 import { wrapError } from '../../workersService/WorkersErrorUtils';
-import { CommonService } from './CommonService';
-
-const logger = pino({ level: ConfigService.get('LOG_LEVEL') || 'trace' });
-const register = RegistryFactory.getInstance();
-const cacheService = CacheClientFactory.create(logger, register);
-const mirrorNodeClient = new MirrorNodeClient(
-  ConfigService.get('MIRROR_NODE_URL'),
-  logger,
-  register,
-  cacheService,
-  undefined,
-  undefined,
-  undefined,
-);
-const commonService = new CommonService(mirrorNodeClient, logger, cacheService);
 
 export async function getLogs(
+  ctx: WorkerContext,
   blockHash: string | null,
   fromBlock: string | 'latest',
   toBlock: string | 'latest',
@@ -33,6 +14,7 @@ export async function getLogs(
   topics: any[] | null,
   requestDetails: RequestDetails,
 ): Promise<Log[]> {
+  const { commonService } = ctx;
   try {
     const EMPTY_RESPONSE = [];
     const params: any = {};

--- a/src/relay/lib/services/ethService/ethCommonService/commonWorker.ts
+++ b/src/relay/lib/services/ethService/ethCommonService/commonWorker.ts
@@ -2,11 +2,11 @@
 
 import { type Log } from '../../../model';
 import { type RequestDetails } from '../../../types';
-import { type WorkerContext } from '../../workersService/workerContext';
+import { type IWorkerContext } from '../../workersService/workerContext';
 import { wrapError } from '../../workersService/WorkersErrorUtils';
 
 export async function getLogs(
-  ctx: WorkerContext,
+  ctx: IWorkerContext,
   blockHash: string | null,
   fromBlock: string | 'latest',
   toBlock: string | 'latest',

--- a/src/relay/lib/services/workersService/WorkersPool.ts
+++ b/src/relay/lib/services/workersService/WorkersPool.ts
@@ -8,7 +8,7 @@ import { ConfigService } from '../../../../config-service/services';
 import { MeasurableCache, MirrorNodeClient } from '../../clients';
 import { type ICacheClient } from '../../clients/cache/ICacheClient';
 import { RegistryFactory } from '../../factories/registryFactory';
-import { getWorkerContext, type WorkerContext } from './workerContext';
+import { getWorkerContext, type IWorkerContext } from './workerContext';
 import type { WorkerTask } from './workers';
 import { unwrapError } from './WorkersErrorUtils';
 
@@ -74,7 +74,7 @@ export class WorkersPool {
    *
    * Populated on the first invocation of {@link run} to avoid repeating the dynamic import on every call.
    */
-  private static handleTaskFn: ((task: WorkerTask, ctx: WorkerContext) => Promise<any>) | null = null;
+  private static handleTaskFn: ((task: WorkerTask, ctx: IWorkerContext) => Promise<any>) | null = null;
 
   /**
    * Updates a metric either by delegating the update to a worker thread

--- a/src/relay/lib/services/workersService/WorkersPool.ts
+++ b/src/relay/lib/services/workersService/WorkersPool.ts
@@ -8,6 +8,7 @@ import { ConfigService } from '../../../../config-service/services';
 import { MeasurableCache, MirrorNodeClient } from '../../clients';
 import { type ICacheClient } from '../../clients/cache/ICacheClient';
 import { RegistryFactory } from '../../factories/registryFactory';
+import { getWorkerContext, type WorkerContext } from './workerContext';
 import type { WorkerTask } from './workers';
 import { unwrapError } from './WorkersErrorUtils';
 
@@ -73,7 +74,7 @@ export class WorkersPool {
    *
    * Populated on the first invocation of {@link run} to avoid repeating the dynamic import on every call.
    */
-  private static handleTaskFn: ((task: WorkerTask) => Promise<any>) | null = null;
+  private static handleTaskFn: ((task: WorkerTask, ctx: WorkerContext) => Promise<any>) | null = null;
 
   /**
    * Updates a metric either by delegating the update to a worker thread
@@ -223,15 +224,11 @@ export class WorkersPool {
    * When the pool is enabled, the task is dispatched to a Piscina worker thread.
    *
    * When the pool is disabled, the task is executed locally on the main thread and entirely
-   * bypasses the worker pool. In this mode `mirrorNodeClient` and `cacheService` are not
-   * forwarded to the task handler — the worker modules maintain their own module-level
-   * instances initialised on first use.
+   * bypasses the worker pool.
    *
    * @param options - The task descriptor forwarded to the worker handler.
    * @param mirrorNodeClient - Mirror node client instance used to forward inter-thread metrics.
-   *   Unused when {@link WORKERS_POOL_ENABLED} is `false`.
    * @param cacheService - Cache service instance used to forward inter-thread metrics.
-   *   Unused when {@link WORKERS_POOL_ENABLED} is `false`.
    * @returns A promise that resolves to the task handler's return value.
    * @throws The original error from the task handler; reconstructed from its serialized form
    *   in worker mode, or native in local mode.
@@ -239,12 +236,12 @@ export class WorkersPool {
   static async run(options: WorkerTask, mirrorNodeClient: MirrorNodeClient, cacheService: ICacheClient): Promise<any> {
     if (!ConfigService.get('WORKERS_POOL_ENABLED')) {
       if (!this.handleTaskFn) {
-        // Dynamic import to defer loading worker modules and their dependencies until actually needed,
-        // ensuring any module-level instances are created once and reused across all local task executions.
+        // Dynamic import to defer loading worker modules and their dependencies until actually needed.
         const mod = await import('./workers');
         this.handleTaskFn = mod.default;
       }
-      return this.handleTaskFn(options);
+      // Reuse the shared per-thread cached context, built from the relay's client/cache on first use.
+      return this.handleTaskFn(options, getWorkerContext(mirrorNodeClient, cacheService));
     }
 
     this.mirrorNodeClient = mirrorNodeClient;

--- a/src/relay/lib/services/workersService/workerContext.ts
+++ b/src/relay/lib/services/workersService/workerContext.ts
@@ -24,9 +24,6 @@ export interface WorkerContext {
   accountService: AccountService;
 }
 
-/** Created once per thread and shared by every context on that thread. */
-const logger: Logger = pino({ level: ConfigService.get('LOG_LEVEL') || 'trace' });
-
 /**
  * Single per-thread cache for the worker context.
  */
@@ -51,6 +48,7 @@ export function createWorkerContext(
   transactionPoolService?: TransactionPoolService,
   accountService?: AccountService,
 ): WorkerContext {
+  const logger: Logger = pino({ level: ConfigService.get('LOG_LEVEL') || 'trace' });
   const register = RegistryFactory.getInstance();
   if (!cacheService) {
     cacheService = CacheClientFactory.create(logger, register);

--- a/src/relay/lib/services/workersService/workerContext.ts
+++ b/src/relay/lib/services/workersService/workerContext.ts
@@ -16,7 +16,7 @@ import { TransactionPoolService } from '../transactionPoolService/transactionPoo
 /**
  * Clients and services shared by every worker task within one execution context.
  */
-export interface WorkerContext {
+export interface IWorkerContext {
   logger: Logger;
   cacheService: ICacheClient;
   mirrorNodeClient: MirrorNodeClient;
@@ -27,10 +27,10 @@ export interface WorkerContext {
 /**
  * Single per-thread cache for the worker context.
  */
-let cachedContext: WorkerContext | null = null;
+let cachedContext: IWorkerContext | null = null;
 
 /**
- * Creates a {@link WorkerContext}. Each argument is reused if supplied and instantiated otherwise, so
+ * Creates a {@link IWorkerContext}. Each argument is reused if supplied and instantiated otherwise, so
  * callers pass whatever they want to share (e.g. the relay's client in local mode); with no client, a
  * self-contained context is built around a fresh one.
  *
@@ -39,7 +39,7 @@ let cachedContext: WorkerContext | null = null;
  * @param commonService - Existing common service to reuse; instantiated if omitted.
  * @param transactionPoolService - Existing transaction pool service to reuse; instantiated if omitted.
  * @param accountService - Existing account service to reuse; instantiated if omitted.
- * @returns A fully wired {@link WorkerContext}.
+ * @returns A fully wired {@link IWorkerContext}.
  */
 export function createWorkerContext(
   mirrorNodeClient?: MirrorNodeClient,
@@ -47,7 +47,7 @@ export function createWorkerContext(
   commonService?: CommonService,
   transactionPoolService?: TransactionPoolService,
   accountService?: AccountService,
-): WorkerContext {
+): IWorkerContext {
   const logger: Logger = pino({ level: ConfigService.get('LOG_LEVEL') || 'trace' });
   const register = RegistryFactory.getInstance();
   if (!cacheService) {
@@ -72,7 +72,7 @@ export function createWorkerContext(
 }
 
 /**
- * Returns the thread's cached {@link WorkerContext}, building it once via {@link createWorkerContext} on first
+ * Returns the thread's cached {@link IWorkerContext}, building it once via {@link createWorkerContext} on first
  * use. All arguments are forwarded to the builder on that first call and ignored thereafter.
  *
  * @param mirrorNodeClient - Existing client to reuse; omit on a worker thread to create one.
@@ -80,7 +80,7 @@ export function createWorkerContext(
  * @param commonService - Existing common service to reuse; instantiated if omitted.
  * @param transactionPoolService - Existing transaction pool service to reuse; instantiated if omitted.
  * @param accountService - Existing account service to reuse; instantiated if omitted.
- * @returns A fully wired {@link WorkerContext}.
+ * @returns A fully wired {@link IWorkerContext}.
  */
 export function getWorkerContext(
   mirrorNodeClient?: MirrorNodeClient,
@@ -88,7 +88,7 @@ export function getWorkerContext(
   commonService?: CommonService,
   transactionPoolService?: TransactionPoolService,
   accountService?: AccountService,
-): WorkerContext {
+): IWorkerContext {
   if (!cachedContext) {
     cachedContext = createWorkerContext(
       mirrorNodeClient,

--- a/src/relay/lib/services/workersService/workerContext.ts
+++ b/src/relay/lib/services/workersService/workerContext.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import pino, { type Logger } from 'pino';
+import { Registry } from 'prom-client';
+
+import { ConfigService } from '../../../../config-service/services';
+import { type ICacheClient } from '../../clients/cache/ICacheClient';
+import { MirrorNodeClient } from '../../clients/mirrorNodeClient';
+import { CacheClientFactory } from '../../factories/cacheClientFactory';
+import { RegistryFactory } from '../../factories/registryFactory';
+import { AccountService } from '../ethService/accountService/AccountService';
+import { CommonService } from '../ethService/ethCommonService/CommonService';
+import { LocalPendingTransactionStorage } from '../transactionPoolService/LocalPendingTransactionStorage';
+import { TransactionPoolService } from '../transactionPoolService/transactionPoolService';
+
+/**
+ * Clients and services shared by every worker task within one execution context.
+ */
+export interface WorkerContext {
+  logger: Logger;
+  cacheService: ICacheClient;
+  mirrorNodeClient: MirrorNodeClient;
+  commonService: CommonService;
+  accountService: AccountService;
+}
+
+/** Created once per thread and shared by every context on that thread. */
+const logger: Logger = pino({ level: ConfigService.get('LOG_LEVEL') || 'trace' });
+
+/**
+ * Single per-thread cache for the worker context.
+ *
+ * A module is instantiated once per thread, so this variable is effectively a per-thread singleton: each
+ * Piscina worker thread caches its own self-contained context, while the main thread (local execution mode)
+ * caches the relay-supplied one. The two never collide because a given thread only ever builds one shape.
+ */
+let cachedContext: WorkerContext | null = null;
+
+/**
+ * Creates a {@link WorkerContext}. Each argument is reused if supplied and instantiated otherwise, so
+ * callers pass whatever they want to share (e.g. the relay's client in local mode); with no client, a
+ * self-contained context is built around a fresh one.
+ *
+ * @param mirrorNodeClient - Existing client to reuse; omit on a worker thread to create one.
+ * @param cacheService - Existing cache to reuse; omit on a worker thread to create one.
+ * @param commonService - Existing common service to reuse; instantiated if omitted.
+ * @param transactionPoolService - Existing transaction pool service to reuse; instantiated if omitted.
+ * @param accountService - Existing account service to reuse; instantiated if omitted.
+ * @returns A fully wired {@link WorkerContext}.
+ */
+export function createWorkerContext(
+  mirrorNodeClient?: MirrorNodeClient,
+  cacheService?: ICacheClient,
+  commonService?: CommonService,
+  transactionPoolService?: TransactionPoolService,
+  accountService?: AccountService,
+): WorkerContext {
+  const register = RegistryFactory.getInstance();
+  if (!cacheService) {
+    cacheService = CacheClientFactory.create(logger, register);
+  }
+  if (!mirrorNodeClient) {
+    mirrorNodeClient = new MirrorNodeClient(ConfigService.get('MIRROR_NODE_URL'), logger, register, cacheService);
+  }
+  if (!commonService) {
+    commonService = new CommonService(mirrorNodeClient, logger, cacheService);
+  }
+  if (!transactionPoolService) {
+    // Can use LocalPendingTransactionStorage() as transactionPoolService is required in AccountService constructor but not used for getBalance.
+    // Passing a new Registry() instead of the global `register` from above because this dummy's constructor removes+re-registers txpool metrics — on the main thread (local mode) that would clobber the relay's live metrics on the shared registry.
+    transactionPoolService = new TransactionPoolService(new LocalPendingTransactionStorage(), logger, new Registry());
+  }
+  if (!accountService) {
+    accountService = new AccountService(cacheService, commonService, logger, mirrorNodeClient, transactionPoolService);
+  }
+
+  return { logger, cacheService, mirrorNodeClient, commonService, accountService };
+}
+
+/**
+ * Returns the thread's cached {@link WorkerContext}, building it once via {@link createWorkerContext} on first
+ * use. All arguments are forwarded to the builder on that first call and ignored thereafter.
+ *
+ * @param mirrorNodeClient - Existing client to reuse; omit on a worker thread to create one.
+ * @param cacheService - Existing cache to reuse; omit on a worker thread to create one.
+ * @param commonService - Existing common service to reuse; instantiated if omitted.
+ * @param transactionPoolService - Existing transaction pool service to reuse; instantiated if omitted.
+ * @param accountService - Existing account service to reuse; instantiated if omitted.
+ * @returns A fully wired {@link WorkerContext}.
+ */
+export function getWorkerContext(
+  mirrorNodeClient?: MirrorNodeClient,
+  cacheService?: ICacheClient,
+  commonService?: CommonService,
+  transactionPoolService?: TransactionPoolService,
+  accountService?: AccountService,
+): WorkerContext {
+  if (!cachedContext) {
+    cachedContext = createWorkerContext(
+      mirrorNodeClient,
+      cacheService,
+      commonService,
+      transactionPoolService,
+      accountService,
+    );
+  }
+  return cachedContext;
+}
+
+/** Clears the cached context so the next {@link getWorkerContext} call rebuilds it. */
+export function resetWorkerContext(): void {
+  cachedContext = null;
+}

--- a/src/relay/lib/services/workersService/workerContext.ts
+++ b/src/relay/lib/services/workersService/workerContext.ts
@@ -29,10 +29,6 @@ const logger: Logger = pino({ level: ConfigService.get('LOG_LEVEL') || 'trace' }
 
 /**
  * Single per-thread cache for the worker context.
- *
- * A module is instantiated once per thread, so this variable is effectively a per-thread singleton: each
- * Piscina worker thread caches its own self-contained context, while the main thread (local execution mode)
- * caches the relay-supplied one. The two never collide because a given thread only ever builds one shape.
  */
 let cachedContext: WorkerContext | null = null;
 

--- a/src/relay/lib/services/workersService/workers.ts
+++ b/src/relay/lib/services/workersService/workers.ts
@@ -4,7 +4,7 @@ import { type RequestDetails } from '../../types';
 import { getBalance } from '../ethService/accountService/accountWorker';
 import { getBlock, getBlockReceipts, getRawReceipts } from '../ethService/blockService/blockWorker';
 import { getLogs } from '../ethService/ethCommonService/commonWorker';
-import { getWorkerContext, type WorkerContext } from './workerContext';
+import { getWorkerContext, type IWorkerContext } from './workerContext';
 
 interface GetBlockTask {
   type: 'getBlock';
@@ -56,7 +56,7 @@ export type WorkerTask = GetLogsTask | GetBlockTask | GetBlockReceiptsTask | Get
  * @returns A promise that resolves to the handler's result.
  * @throws {Error} If `task.type` does not match any known task variant.
  */
-export default async function handleTask(task: WorkerTask, ctx?: WorkerContext): Promise<any> {
+export default async function handleTask(task: WorkerTask, ctx?: IWorkerContext): Promise<any> {
   // On a worker thread Piscina invokes this with no ctx; fall back to the shared per-thread cached context.
   if (!ctx) {
     ctx = getWorkerContext();

--- a/src/relay/lib/services/workersService/workers.ts
+++ b/src/relay/lib/services/workersService/workers.ts
@@ -4,6 +4,7 @@ import { type RequestDetails } from '../../types';
 import { getBalance } from '../ethService/accountService/accountWorker';
 import { getBlock, getBlockReceipts, getRawReceipts } from '../ethService/blockService/blockWorker';
 import { getLogs } from '../ethService/ethCommonService/commonWorker';
+import { getWorkerContext, type WorkerContext } from './workerContext';
 
 interface GetBlockTask {
   type: 'getBlock';
@@ -51,19 +52,26 @@ export type WorkerTask = GetLogsTask | GetBlockTask | GetBlockReceiptsTask | Get
  * thread when {@link WORKERS_POOL_ENABLED} is `false` (local execution mode).
  *
  * @param task - Discriminated-union descriptor for the task to execute.
+ * @param ctx - The shared worker context providing the clients and services
  * @returns A promise that resolves to the handler's result.
  * @throws {Error} If `task.type` does not match any known task variant.
  */
-export default async function handleTask(task: WorkerTask): Promise<any> {
+export default async function handleTask(task: WorkerTask, ctx?: WorkerContext): Promise<any> {
+  // On a worker thread Piscina invokes this with no ctx; fall back to the shared per-thread cached context.
+  if (!ctx) {
+    ctx = getWorkerContext();
+  }
+
   switch (task.type) {
     case 'getBlock':
-      return await getBlock(task.blockHashOrNumber, task.showDetails, task.requestDetails, task.chain);
+      return await getBlock(ctx, task.blockHashOrNumber, task.showDetails, task.requestDetails, task.chain);
     case 'getBlockReceipts':
-      return await getBlockReceipts(task.blockHashOrBlockNumber, task.requestDetails);
+      return await getBlockReceipts(ctx, task.blockHashOrBlockNumber, task.requestDetails);
     case 'getRawReceipts':
-      return await getRawReceipts(task.blockHashOrBlockNumber, task.requestDetails);
+      return await getRawReceipts(ctx, task.blockHashOrBlockNumber, task.requestDetails);
     case 'getLogs':
       return await getLogs(
+        ctx,
         task.blockHash,
         task.fromBlock,
         task.toBlock,
@@ -72,7 +80,7 @@ export default async function handleTask(task: WorkerTask): Promise<any> {
         task.requestDetails,
       );
     case 'getBalance':
-      return await getBalance(task.account, task.blockNumberOrTagOrHash, task.requestDetails);
+      return await getBalance(ctx, task.account, task.blockNumberOrTagOrHash, task.requestDetails);
 
     default:
       throw new Error(`Unknown task type: ${(task as any).type}`);

--- a/tests/relay/helpers.ts
+++ b/tests/relay/helpers.ts
@@ -6,15 +6,18 @@ import crypto from 'crypto';
 import { ethers } from 'ethers';
 import { type Logger } from 'pino';
 import type Piscina from 'piscina';
-import proxyquire from 'proxyquire';
 import * as sinon from 'sinon';
 
 import { ConfigService } from '../../src/config-service/services';
 import { type ConfigKey } from '../../src/config-service/services/globalConfig';
 import { numberTo0x, toHash32 } from '../../src/relay/formatters';
+import { type ICacheClient } from '../../src/relay/lib/clients/cache/ICacheClient';
+import { type MirrorNodeClient } from '../../src/relay/lib/clients/mirrorNodeClient';
 import { RedisClientManager } from '../../src/relay/lib/clients/redisClientManager';
 import constants from '../../src/relay/lib/constants';
-import type { WorkerTask } from '../../src/relay/lib/services/workersService/workers';
+import { type CommonService } from '../../src/relay/lib/services/ethService/ethCommonService/CommonService';
+import { createWorkerContext } from '../../src/relay/lib/services/workersService/workerContext';
+import handleTask, { type WorkerTask } from '../../src/relay/lib/services/workersService/workers';
 import { WorkersPool } from '../../src/relay/lib/services/workersService/WorkersPool';
 import { ConfigServiceTestHelper } from '../config-service/configServiceTestHelper';
 import { RedisInMemoryServer } from './redisInMemoryServer';
@@ -1129,26 +1132,12 @@ export const verifyResult = async <T>(
   }
 };
 
-export const mockWorkersPool = async (mirrorNodeInstance, commonService) => {
-  const deps = {
-    '../../../clients/mirrorNodeClient': {
-      MirrorNodeClient: class {
-        constructor() {
-          return mirrorNodeInstance;
-        }
-      },
-    },
-    '../ethCommonService/CommonService': {
-      CommonService: class {
-        constructor() {
-          return commonService;
-        }
-      },
-    },
-  };
-  const blockWorker = proxyquire('../../src/relay/lib/services/ethService/blockService/blockWorker', deps);
-  const commonWorker = proxyquire('../../src/relay/lib/services/ethService/ethCommonService/commonWorker', deps);
-  const accountWorker = proxyquire('../../src/relay/lib/services/ethService/accountService/accountWorker', deps);
+export const mockWorkersPool = async (
+  mirrorNodeInstance: MirrorNodeClient,
+  commonService: CommonService,
+  cacheService: ICacheClient,
+) => {
+  const ctx = createWorkerContext(mirrorNodeInstance, cacheService, commonService);
 
   if (!WorkersPool['_innerRun']) WorkersPool['_innerRun'] = WorkersPool['run'];
   WorkersPool['run'] = ConfigService.get('WORKERS_POOL_ENABLED')
@@ -1169,32 +1158,7 @@ export const mockWorkersPool = async (mirrorNodeInstance, commonService) => {
       // instances (JsonRpcError, MirrorNodeClientError) from the main-thread module graph,
       // guaranteeing instanceof checks downstream remain correct.
       try {
-        switch (task.type) {
-          case 'getBlock':
-            return await blockWorker.getBlock(
-              task.blockHashOrNumber,
-              task.showDetails,
-              task.requestDetails,
-              task.chain,
-            );
-          case 'getBlockReceipts':
-            return await blockWorker.getBlockReceipts(task.blockHashOrBlockNumber, task.requestDetails);
-          case 'getRawReceipts':
-            return await blockWorker.getRawReceipts(task.blockHashOrBlockNumber, task.requestDetails);
-          case 'getLogs':
-            return await commonWorker.getLogs(
-              task.blockHash,
-              task.fromBlock,
-              task.toBlock,
-              task.address,
-              task.topics,
-              task.requestDetails,
-            );
-          case 'getBalance':
-            return await accountWorker.getBalance(task.account, task.blockNumberOrTagOrHash, task.requestDetails);
-          default:
-            throw new Error(`Unsupported task type ${task.type}`);
-        }
+        return await handleTask(task, ctx);
       } catch (e) {
         throw new Error(JSON.stringify(e), { cause: e });
       }

--- a/tests/relay/lib/eth/eth_getBlockReceipts.spec.ts
+++ b/tests/relay/lib/eth/eth_getBlockReceipts.spec.ts
@@ -71,7 +71,7 @@ describe('@ethGetBlockReceipts using MirrorNode', async function () {
   const requestDetails = new RequestDetails({ requestId: 'eth_getBlockReceiptsTest', ipAddress: '0.0.0.0' });
 
   before(async () => {
-    await mockWorkersPool(mirrorNodeInstance, commonService);
+    await mockWorkersPool(mirrorNodeInstance, commonService, cacheService);
   });
 
   this.beforeEach(async () => {

--- a/tests/relay/lib/services/workersService/WorkersPool.spec.ts
+++ b/tests/relay/lib/services/workersService/WorkersPool.spec.ts
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 
 import { JsonRpcError, MirrorNodeClientError, predefined } from '../../../../../src/relay';
+import { resetWorkerContext } from '../../../../../src/relay/lib/services/workersService/workerContext';
 import { WorkersPool } from '../../../../../src/relay/lib/services/workersService/WorkersPool';
 import { overrideEnvsInMochaDescribe } from '../../../helpers';
 
@@ -22,6 +23,7 @@ describe('WorkersPool Test Suite', () => {
   beforeEach(() => {
     // Reset all static state before each test to prevent cross-test contamination.
     WorkersPool['handleTaskFn'] = null;
+    resetWorkerContext();
     WorkersPool['instance'] = undefined as any;
     (WorkersPool as any)['mirrorNodeClient'] = undefined;
     (WorkersPool as any)['cacheService'] = undefined;
@@ -49,7 +51,7 @@ describe('WorkersPool Test Suite', () => {
       const result = await WorkersPool.run(task, null as any, null as any);
 
       expect(handleTaskStub.calledOnce).to.be.true;
-      expect(handleTaskStub.calledWith(task)).to.be.true;
+      expect(handleTaskStub.calledWith(task, sinon.match.any)).to.be.true;
       expect(result).to.equal(expectedResult);
       expect(WorkersPool['instance']).to.be.undefined;
     });
@@ -112,9 +114,27 @@ describe('WorkersPool Test Suite', () => {
       await WorkersPool.run(task, fakeClient, fakeCacheService);
 
       // In local mode the static client/cache fields must remain untouched — the
-      // worker modules maintain their own module-level singletons.
+      // passed client/cache are reused to build the
+      // local worker context instead.
       expect((WorkersPool as any)['mirrorNodeClient']).to.be.undefined;
       expect((WorkersPool as any)['cacheService']).to.be.undefined;
+    });
+
+    it('should reuse the relay-provided client and services with no duplicate instances', async () => {
+      const handleTaskStub = sinon.stub().resolves(null);
+      WorkersPool['handleTaskFn'] = handleTaskStub;
+
+      const fakeClient = { label: 'relay-client' } as any;
+      const fakeCacheService = { label: 'relay-cache' } as any;
+      const task = { type: 'getRawReceipts' as const, blockHashOrBlockNumber: '0x1', requestDetails: {} as any };
+
+      await WorkersPool.run(task, fakeClient, fakeCacheService);
+
+      // The context handed to the handler must reuse the exact client/cache passed to run() —
+      // proving local mode opens no new MirrorNodeClient (and no new socket pools) on the main thread.
+      const ctx = handleTaskStub.firstCall.args[1];
+      expect(ctx.mirrorNodeClient).to.equal(fakeClient);
+      expect(ctx.cacheService).to.equal(fakeCacheService);
     });
   });
 

--- a/tests/relay/lib/services/workersService/workerContext.spec.ts
+++ b/tests/relay/lib/services/workersService/workerContext.spec.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from 'chai';
+import { Gauge } from 'prom-client';
+
+import { MirrorNodeClient } from '../../../../../src/relay/lib/clients/mirrorNodeClient';
+import { RegistryFactory } from '../../../../../src/relay/lib/factories/registryFactory';
+import { AccountService } from '../../../../../src/relay/lib/services/ethService/accountService/AccountService';
+import { CommonService } from '../../../../../src/relay/lib/services/ethService/ethCommonService/CommonService';
+import {
+  createWorkerContext,
+  getWorkerContext,
+  resetWorkerContext,
+} from '../../../../../src/relay/lib/services/workersService/workerContext';
+import { overrideEnvsInMochaDescribe } from '../../../helpers';
+
+describe('WorkerContext Test Suite', () => {
+  describe('createWorkerContext', () => {
+    overrideEnvsInMochaDescribe({ MIRROR_NODE_URL: 'http://localhost:5551' });
+
+    it('should reuse the supplied client + cache and wire the wrapper services around them', () => {
+      const mirrorNodeClient = { label: 'relay-client' } as any;
+      const cacheService = { label: 'relay-cache' } as any;
+
+      const ctx = createWorkerContext(mirrorNodeClient, cacheService);
+
+      expect(ctx.mirrorNodeClient).to.equal(mirrorNodeClient);
+      expect(ctx.cacheService).to.equal(cacheService);
+      expect(ctx.commonService).to.be.instanceOf(CommonService);
+      expect(ctx.accountService).to.be.instanceOf(AccountService);
+    });
+
+    it('should pass a new Registry instance to txpool service so it never clobbers the shared registry', () => {
+      const registry = RegistryFactory.getInstance(true);
+      const sentinel = new Gauge({ name: 'rpc_relay_txpool_pending_count', help: 'sentinel', registers: [registry] });
+
+      createWorkerContext({} as any, {} as any);
+
+      expect(registry.getSingleMetric('rpc_relay_txpool_pending_count')).to.equal(sentinel);
+      for (const name of [
+        'rpc_relay_txpool_operations_total',
+        'rpc_relay_txpool_storage_errors_total',
+        'rpc_relay_txpool_active_addresses',
+      ]) {
+        expect(registry.getSingleMetric(name), `${name} must not be on the shared registry`).to.be.undefined;
+      }
+    });
+
+    it('should build its own single client and wire the services around it when given no arguments', () => {
+      const ctx = createWorkerContext();
+
+      expect(ctx.mirrorNodeClient).to.be.instanceOf(MirrorNodeClient);
+      expect(ctx.commonService).to.be.instanceOf(CommonService);
+      expect(ctx.accountService).to.be.instanceOf(AccountService);
+    });
+  });
+
+  describe('getWorkerContext — single shared per-thread cache', () => {
+    afterEach(() => resetWorkerContext());
+
+    it('should build the context once and return the same instance on subsequent calls', () => {
+      const first = getWorkerContext({ label: 'client' } as any, { label: 'cache' } as any);
+      const second = getWorkerContext();
+
+      // Args on the second call are ignored — the first-built context is returned verbatim.
+      expect(second).to.equal(first);
+    });
+  });
+});


### PR DESCRIPTION
### Description

This PR reduces resource duplication in the worker pool. Previously each of the three worker modules (`accountWorker`, `blockWorker`, `commonWorker`) instantiated its own `MirrorNodeClient`, `CacheService`, and `Registry` at module load, producing a lot of `MirrorNodeClient` instances (each with its own socket pools) at peak. This consolidates construction into a single `createWorkerContext` builder that wires one client/cache set per execution context, plus a `getWorkerContext` cache that reuses it — one per worker thread, and the relay's own client/cache on the main thread in local mode (`WORKERS_POOL_ENABLED=false`). Worker functions become pure and receive the context as a parameter.

Because the builder now runs on the main thread in local mode, the throwaway `TransactionPoolService` (required by `AccountService`'s constructor but unused for these tasks) is given a `new Registry()` rather than the shared one, so its remove-then-register of txpool metrics can't clobber the relay's live metrics on the scraped registry.

### Related issue(s)

Fixes #5257

### Testing Guide

1.`npm run build-and-test` — project builds and all tests pass.

### Changes from original design (optional)

N/A

### Additional work needed (optional)

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
