### PR TITLE
chore(ci): bump dev-tool workflow Go version to 1.25

### DIFF
--- a/.github/workflows/dev-tool-workflow.yml
+++ b/.github/workflows/dev-tool-workflow.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: "1.24.0"
+          go-version: "1.25.0"
 
       - name: Install packages
         run: npm ci


### PR DESCRIPTION
### Description

This PR bumps the Go toolchain version in the reusable dev-tool CI workflow (`.github/workflows/dev-tool-workflow.yml`) from `1.24.0` to `1.25.0`.

### Related issue(s)

Fixes #5542

### Testing Guide

1. Merge this PR to `main`.
2. Comment `@dependabot rebase` on #5540 so it re-runs against the updated Go version.
3. Confirm the **Golang HTTP** and **Golang WSS** dev-tool jobs pass on #5540.

### Changes from original design (optional)

N/A

### Additional work needed (optional)

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
