### PR TITLE
chore: update solo version to 0.82.1

### DIFF
--- a/.github/workflows/acceptance-workflow.yml
+++ b/.github/workflows/acceptance-workflow.yml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Start the solo node
         run: |
-          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.0' }} one-shot falcon deploy \
+          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.1' }} one-shot falcon deploy \
             --values-file .github/falcon.yml \
             --dev \
             --deploy-explorer=false \

--- a/.github/workflows/conformity-workflow.yml
+++ b/.github/workflows/conformity-workflow.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Start the solo node
         run: |
-          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.0' }} one-shot falcon deploy \
+          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.1' }} one-shot falcon deploy \
             --values-file .github/falcon.yml \
             --dev \
             --deploy-explorer=false \

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Start the solo node
         run: |
-          npx @hashgraph/solo@0.82.0 one-shot falcon deploy \
+          npx @hashgraph/solo@0.82.1 one-shot falcon deploy \
             --values-file .github/falcon.yml \
             --dev \
             --deploy-explorer=false \

--- a/.github/workflows/dev-tool-workflow.yml
+++ b/.github/workflows/dev-tool-workflow.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Start the solo node
         run: |
-          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.0' }} one-shot falcon deploy \
+          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.1' }} one-shot falcon deploy \
             --values-file .github/falcon.yml \
             --dev \
             --deploy-explorer=false \

--- a/.github/workflows/hoppscotch.yml
+++ b/.github/workflows/hoppscotch.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Start the solo node
         run: |
-          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.0' }} one-shot falcon deploy \
+          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.1' }} one-shot falcon deploy \
             --values-file .github/falcon.yml \
             --dev \
             --deploy-explorer=false \

--- a/.github/workflows/release-acceptance.yml
+++ b/.github/workflows/release-acceptance.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Start the solo node
         run: |
-          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.0' }} one-shot falcon deploy \
+          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.1' }} one-shot falcon deploy \
             --values-file .github/falcon.yml \
             --dev \
             --deploy-explorer=false \

--- a/.github/workflows/subgraph.yml
+++ b/.github/workflows/subgraph.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Start the solo node
         working-directory: .
         run: |
-          npx @hashgraph/solo@0.82.0 one-shot falcon deploy \
+          npx @hashgraph/solo@0.82.1 one-shot falcon deploy \
             --values-file .github/falcon.yml \
             --dev \
             --deploy-explorer=false \


### PR DESCRIPTION
## Summary
- Bumps the Solo CLI version from `0.82.0` to `0.82.1` across `acceptance-workflow.yml`, `conformity-workflow.yml`, `dapp.yml`, `dev-tool-workflow.yml`, `hoppscotch.yml`, `release-acceptance.yml`, and `subgraph.yml` (fallback default in five of the files; hardcoded literal in `dapp.yml`/`subgraph.yml`).