### PR TITLE
chore: bump network versions and pin redis-memory-server

### DIFF
--- a/.github/workflows/acceptance-workflow.yml
+++ b/.github/workflows/acceptance-workflow.yml
@@ -114,7 +114,7 @@ jobs:
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.159.0' }}"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.160.1' }}"
             --values-file: .github/mirror-node-values.yaml
           EOF
 
@@ -133,7 +133,7 @@ jobs:
           MIRROR_NODE_PORT: 5551
           GRPC_LOCAL_PORT: 50211
         run: |
-          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.1' }} one-shot falcon deploy \
+          npx @hashgraph/solo@${{ inputs.soloVersion || '0.85.0' }} one-shot falcon deploy \
             --values-file .github/falcon.yml \
             --external-address 0.0.0.0 \
             --dev \

--- a/.github/workflows/acceptance-workflow.yml
+++ b/.github/workflows/acceptance-workflow.yml
@@ -114,7 +114,7 @@ jobs:
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.160.1' }}"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.159.0' }}"
             --values-file: .github/mirror-node-values.yaml
           EOF
 

--- a/.github/workflows/conformity-workflow.yml
+++ b/.github/workflows/conformity-workflow.yml
@@ -107,7 +107,7 @@ jobs:
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.160.1' }}"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.159.0' }}"
             --values-file: .github/mirror-node-values.yaml
           EOF
 

--- a/.github/workflows/conformity-workflow.yml
+++ b/.github/workflows/conformity-workflow.yml
@@ -107,7 +107,7 @@ jobs:
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.159.0' }}"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.160.1' }}"
             --values-file: .github/mirror-node-values.yaml
           EOF
 
@@ -126,7 +126,7 @@ jobs:
           MIRROR_NODE_PORT: 5551
           GRPC_LOCAL_PORT: 50211
         run: |
-          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.1' }} one-shot falcon deploy \
+          npx @hashgraph/solo@${{ inputs.soloVersion || '0.85.0' }} one-shot falcon deploy \
             --values-file .github/falcon.yml \
             --external-address 0.0.0.0 \
             --dev \

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -63,7 +63,7 @@ jobs:
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.160.1' }}"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.159.0' }}"
             --values-file: .github/mirror-node-values.yaml
           EOF
 

--- a/.github/workflows/dapp.yml
+++ b/.github/workflows/dapp.yml
@@ -53,17 +53,17 @@ jobs:
         run: |
           cat > .github/falcon.yml <<EOF
           network:
-            --release-tag: "v0.73.0"
+            --release-tag: "${{ inputs.networkTag || 'v0.75.1' }}"
             --node-aliases: "node1"
           setup:
-            --release-tag: "v0.73.0"
+            --release-tag: "${{ inputs.networkTag || 'v0.75.1' }}"
             --node-aliases: "node1"
           consensusNode:
             --node-aliases: "node1"
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "v0.159.0"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.160.1' }}"
             --values-file: .github/mirror-node-values.yaml
           EOF
 
@@ -82,7 +82,7 @@ jobs:
           MIRROR_NODE_PORT: 5551
           GRPC_LOCAL_PORT: 50211
         run: |
-          npx @hashgraph/solo@0.82.1 one-shot falcon deploy \
+          npx @hashgraph/solo@${{ inputs.soloVersion || '0.85.0' }} one-shot falcon deploy \
             --values-file .github/falcon.yml \
             --external-address 0.0.0.0 \
             --dev \

--- a/.github/workflows/dev-tool-workflow.yml
+++ b/.github/workflows/dev-tool-workflow.yml
@@ -85,7 +85,7 @@ jobs:
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.159.0' }}"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.160.1' }}"
             --values-file: .github/mirror-node-values.yaml
           EOF
 
@@ -94,7 +94,7 @@ jobs:
           MIRROR_NODE_PORT: 5551
           GRPC_LOCAL_PORT: 50211
         run: |
-          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.1' }} one-shot falcon deploy \
+          npx @hashgraph/solo@${{ inputs.soloVersion || '0.85.0' }} one-shot falcon deploy \
             --values-file .github/falcon.yml \
             --external-address 0.0.0.0 \
             --dev \

--- a/.github/workflows/dev-tool-workflow.yml
+++ b/.github/workflows/dev-tool-workflow.yml
@@ -85,7 +85,7 @@ jobs:
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.160.1' }}"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.159.0' }}"
             --values-file: .github/mirror-node-values.yaml
           EOF
 

--- a/.github/workflows/hoppscotch.yml
+++ b/.github/workflows/hoppscotch.yml
@@ -80,7 +80,7 @@ jobs:
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.159.0' }}"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.160.1' }}"
             --values-file: .github/mirror-node-values.yaml
           EOF
 
@@ -99,7 +99,7 @@ jobs:
           MIRROR_NODE_PORT: 5551
           GRPC_LOCAL_PORT: 50211
         run: |
-          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.1' }} one-shot falcon deploy \
+          npx @hashgraph/solo@${{ inputs.soloVersion || '0.85.0' }} one-shot falcon deploy \
             --values-file .github/falcon.yml \
             --external-address 0.0.0.0 \
             --dev \

--- a/.github/workflows/hoppscotch.yml
+++ b/.github/workflows/hoppscotch.yml
@@ -80,7 +80,7 @@ jobs:
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.160.1' }}"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.159.0' }}"
             --values-file: .github/mirror-node-values.yaml
           EOF
 

--- a/.github/workflows/release-acceptance.yml
+++ b/.github/workflows/release-acceptance.yml
@@ -93,7 +93,7 @@ jobs:
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.159.0' }}"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.160.1' }}"
             --values-file: .github/mirror-node-values.yaml
           EOF
 
@@ -112,7 +112,7 @@ jobs:
           MIRROR_NODE_PORT: 5551
           GRPC_LOCAL_PORT: 50211
         run: |
-          npx @hashgraph/solo@${{ inputs.soloVersion || '0.82.1' }} one-shot falcon deploy \
+          npx @hashgraph/solo@${{ inputs.soloVersion || '0.85.0' }} one-shot falcon deploy \
             --values-file .github/falcon.yml \
             --external-address 0.0.0.0 \
             --dev \

--- a/.github/workflows/release-acceptance.yml
+++ b/.github/workflows/release-acceptance.yml
@@ -93,7 +93,7 @@ jobs:
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.160.1' }}"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.159.0' }}"
             --values-file: .github/mirror-node-values.yaml
           EOF
 

--- a/.github/workflows/subgraph.yml
+++ b/.github/workflows/subgraph.yml
@@ -59,17 +59,17 @@ jobs:
         run: |
           cat > .github/falcon.yml <<EOF
           network:
-            --release-tag: "v0.73.0"
+            --release-tag: "${{ inputs.networkTag || 'v0.75.1' }}"
             --node-aliases: "node1"
           setup:
-            --release-tag: "v0.73.0"
+            --release-tag: "${{ inputs.networkTag || 'v0.75.1' }}"
             --node-aliases: "node1"
           consensusNode:
             --node-aliases: "node1"
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "v0.159.0"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.160.1' }}"
             --values-file: .github/mirror-node-values.yaml
           EOF
 
@@ -89,7 +89,7 @@ jobs:
           MIRROR_NODE_PORT: 5551
           GRPC_LOCAL_PORT: 50211
         run: |
-          npx @hashgraph/solo@0.82.1 one-shot falcon deploy \
+          npx @hashgraph/solo@${{ inputs.soloVersion || '0.85.0' }} one-shot falcon deploy \
             --values-file .github/falcon.yml \
             --external-address 0.0.0.0 \
             --dev \

--- a/.github/workflows/subgraph.yml
+++ b/.github/workflows/subgraph.yml
@@ -69,7 +69,7 @@ jobs:
           mirrorNode:
             --enable-ingress: true
             --pinger: true
-            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.160.1' }}"
+            --mirror-node-version: "${{ inputs.mirrorTag || 'v0.159.0' }}"
             --values-file: .github/mirror-node-values.yaml
           EOF
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "bin": {
     "hiero-relay": "./bin/hiero-relay.js"
   },
+  "redisMemoryServer": {
+    "version": "7.4.5"
+  },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@octokit/core": "^6.1.6",


### PR DESCRIPTION
Bumps solo to 0.85.0, consensus node to v0.75.1, and mirror node to v0.160.1 across all network-spinning CI workflows, and pins redis-memory-server to redis 7.4.5.

Fixes: #5615