### PR TITLE
fix: unify nonce error codes to -32000

### DIFF
--- a/src/relay/lib/errors/JsonRpcError.ts
+++ b/src/relay/lib/errors/JsonRpcError.ts
@@ -104,14 +104,14 @@ export const predefined = {
       code: -32602,
       message: `Missing value for required parameter ${index}`,
     }),
-  NONCE_TOO_LOW: (nonce, currentNonce): JsonRpcError =>
+  NONCE_TOO_LOW: (nonce: number, currentNonce: number): JsonRpcError =>
     new JsonRpcError({
-      code: 32001,
+      code: -32000,
       message: `Nonce too low. Provided nonce: ${nonce}, current nonce: ${currentNonce}`,
     }),
-  NONCE_TOO_HIGH: (nonce, currentNonce): JsonRpcError =>
+  NONCE_TOO_HIGH: (nonce: number, currentNonce: number): JsonRpcError =>
     new JsonRpcError({
-      code: 32002,
+      code: -32000,
       message: `Nonce too high. Provided nonce: ${nonce}, current nonce: ${currentNonce}`,
     }),
   NO_MINING_WORK: new JsonRpcError({

--- a/tests/relay/lib/errors/JsonRpcError.spec.ts
+++ b/tests/relay/lib/errors/JsonRpcError.spec.ts
@@ -221,5 +221,21 @@ describe('Errors', () => {
         });
       });
     });
+
+    it('every predefined error uses a negative code', () => {
+      const positiveCodeExceptions = ['CONTRACT_REVERT'];
+      const dummyArgs: unknown[] = ['1', 1, '1', 1];
+
+      const positiveCodes = Object.entries(predefined)
+        .filter(([name]) => !positiveCodeExceptions.includes(name))
+        .map(([name, entry]) => {
+          const error =
+            typeof entry === 'function' ? (entry as (...args: unknown[]) => JsonRpcError)(...dummyArgs) : entry;
+          return { name, code: error.code };
+        })
+        .filter(({ code }) => code >= 0);
+
+      expect(positiveCodes).to.deep.eq([], `these predefined errors must use negative JSON-RPC codes`);
+    });
   });
 });

--- a/tests/relay/lib/eth/eth_sendRawTransaction.spec.ts
+++ b/tests/relay/lib/eth/eth_sendRawTransaction.spec.ts
@@ -1099,8 +1099,7 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
             .to.be.rejectedWith(JsonRpcError)
             .and.eventually.satisfy(
               (error: JsonRpcError) =>
-                expect(error.code).to.equal(predefined.NONCE_TOO_HIGH(10, 5).code) &&
-                expect(error.message).to.include('Nonce too high'),
+                expect(error.code).to.equal(-32000) && expect(error.message).to.include('Nonce too high'),
             );
 
           // Verify accounts endpoint WAS called to get current nonce
@@ -1131,8 +1130,7 @@ describe('@ethSendRawTransaction eth_sendRawTransaction spec', async function ()
             .to.be.rejectedWith(JsonRpcError)
             .and.eventually.satisfy(
               (error: JsonRpcError) =>
-                expect(error.code).to.equal(predefined.NONCE_TOO_LOW(3, 8).code) &&
-                expect(error.message).to.include('Nonce too low'),
+                expect(error.code).to.equal(-32000) && expect(error.message).to.include('Nonce too low'),
             );
 
           // Verify accounts endpoint WAS called to get current nonce

--- a/tests/relay/lib/precheck.spec.ts
+++ b/tests/relay/lib/precheck.spec.ts
@@ -617,6 +617,7 @@ describe('Precheck', async function () {
         expectedError();
       } catch (e: any) {
         expect(e).to.eql(predefined.NONCE_TOO_LOW(parsedTx.nonce, mirrorAccount.ethereum_nonce));
+        expect(e.code).to.eq(-32000);
       }
     });
 


### PR DESCRIPTION
### Description

This PR fixes an issue where `NONCE_TOO_LOW` and `NONCE_TOO_HIGH` were defined with **positive** JSON-RPC error codes (`32001` / `32002`). Clients that classify errors by code (viem, web3.js, wallets, custom retry logic) cannot recognize a positive code and fall back to a generic error, so callers can't branch on "is this a nonce error?".

Both errors now use **`-32000`**, matching geth, Besu, Alchemy and QuickNode. The too-low/too-high distinction is carried by the message, which is what ethers and viem already match on. Messages are unchanged.

Also adds a regression test asserting no `predefined.*` error uses a positive code, with `CONTRACT_REVERT` (`code: 3`, the Ethereum execution-reverted convention) as the single documented exception — this is the test class that would have caught the original dropped minus sign.

### Related issue(s)

Fixes #5609

### Testing Guide

1. Send a transaction via `eth_sendRawTransaction` with a nonce **below** the account's current nonce.

   **Before:** `{ "error": { "code": 32001, "message": "Nonce too low. Provided nonce: 0, current nonce: 5" } }`
   **After:** `{ "error": { "code": -32000, "message": "Nonce too low. Provided nonce: 0, current nonce: 5" } }`

2. Send a transaction with a nonce **far above** the current nonce (requires `USE_ASYNC_TX_PROCESSING=false`) and confirm `code: -32000` with `"Nonce too high. …"`.

3. Run the unit tests covering both paths — the precheck path and the post-consensus `WRONG_NONCE` path:

   ```bash
   npx ts-mocha --recursive 'tests/relay/lib/errors/JsonRpcError.spec.ts' 'tests/relay/lib/precheck.spec.ts' --exit
   npx ts-mocha --recursive 'tests/relay/lib/eth/eth_sendRawTransaction.spec.ts' --exit
   ```

