### PR TITLE
feat: cherry pick `eth_getTransactionReceipt` for reverted child transaction should return null #5661 status to 0.78

### DIFF
--- a/src/relay/lib/clients/mirrorNodeClient.ts
+++ b/src/relay/lib/clients/mirrorNodeClient.ts
@@ -59,6 +59,19 @@ export const isImmatureContractRecord = (
   record != null &&
   (record.transaction_index == null || record.block_number == null || record.block_hash === constants.EMPTY_HEX);
 
+/**
+ * Whether a Mirror Node contract-result record belongs to a child  transaction rather than to a
+ * top-level ethereum one.
+ *
+ * Ethereum has no notion of a child transaction: an inner call has no hash and no receipt of its own, so
+ * these records are reported as not found rather than as a rejection.
+ *
+ * @param record - The contract result record to classify; null/undefined is not a child record.
+ * @returns True when the record carries neither an ethereum nonce nor a signature recovery id.
+ */
+export const isChildContractRecord = (record?: { nonce?: number | null; v?: number | null } | null): boolean =>
+  record != null && record.nonce == null && record.v == null;
+
 export class MirrorNodeClient {
   private static readonly GET_BLOCK_ENDPOINT = 'blocks/';
   private static readonly GET_BLOCKS_ENDPOINT = 'blocks';
@@ -998,6 +1011,16 @@ export class MirrorNodeClient {
             if (this.logger.isLevelEnabled('debug')) {
               this.logger.debug(
                 `Contract result was rejected before EVM execution and will never be part of a block; skipping immature-record polling: contract_result=%s`,
+                JSON.stringify(contractObject),
+              );
+            }
+            continue;
+          }
+
+          if (isChildContractRecord(contractObject)) {
+            if (this.logger.isLevelEnabled('debug')) {
+              this.logger.debug(
+                `Contract result belongs to a child transaction and is never assigned an index; skipping polling: contract_result=%s`,
                 JSON.stringify(contractObject),
               );
             }

--- a/src/relay/lib/services/ethService/transactionService/TransactionService.ts
+++ b/src/relay/lib/services/ethService/transactionService/TransactionService.ts
@@ -9,7 +9,11 @@ import { ConfigService } from '../../../../../config-service/services';
 import { numberTo0x, toHash32 } from '../../../../formatters';
 import { Utils } from '../../../../utils';
 import type { ICacheClient } from '../../../clients/cache/ICacheClient';
-import { isImmatureContractRecord, type MirrorNodeClient } from '../../../clients/mirrorNodeClient';
+import {
+  isChildContractRecord,
+  isImmatureContractRecord,
+  type MirrorNodeClient,
+} from '../../../clients/mirrorNodeClient';
 import constants from '../../../constants';
 import { JsonRpcError, predefined } from '../../../errors/JsonRpcError';
 import { SDKClientError } from '../../../errors/SDKClientError';
@@ -297,6 +301,14 @@ export class TransactionService implements ITransactionService {
       // execution: no block linkage will ever be filled in, so no receipt can be built. Surface the
       // rejection with its details instead of a half-populated receipt.
       if (isImmatureContractRecord(receiptResponse)) {
+        // A child record lacks an index too, but it is no rejection: it is not an ethereum
+        // transaction at all, so it has no receipt of its own. Report it as not found, the way
+        // `eth_getTransactionByHash` already does for the same record.
+        if (isChildContractRecord(receiptResponse)) {
+          this.logger.trace(`child (synthetic) record has no receipt of its own for %s`, hash);
+          return null;
+        }
+
         throw await this.buildRejectedRecordError(hash, receiptResponse);
       }
 

--- a/tests/relay/lib/eth/eth_getTransactionReceipt.spec.ts
+++ b/tests/relay/lib/eth/eth_getTransactionReceipt.spec.ts
@@ -25,7 +25,7 @@ use(chaiAsPromised);
 
 describe('@ethGetTransactionReceipt eth_getTransactionReceipt tests', async function () {
   this.timeout(10000);
-  const { restMock, ethImpl, cacheService } = generateEthTestEnv();
+  const { restMock, ethImpl, mirrorNodeInstance, cacheService } = generateEthTestEnv();
   let sandbox: sinon.SinonSandbox;
   const emptyBloom = constants.EMPTY_BLOOM;
 
@@ -396,6 +396,106 @@ describe('@ethGetTransactionReceipt eth_getTransactionReceipt tests', async func
           'The transaction was rejected before execution and will never be included in a block.',
         );
       }
+    });
+  });
+
+  describe('records without a transaction index', function () {
+    const childTxHash = '0x51149a73c4094b5915457449f82eae9b0e45f705d24f6aeb33a858dfe0e765a5';
+    const rejectedParentTxHash = '0xf355f575abacc4c8b5493041b27247f957db285a91f25ad0d531abd831007850';
+
+    const childRecord = {
+      address: '0x0000000000000000000000000000000000000167',
+      amount: 0,
+      bloom: emptyBloom,
+      call_result: '0x0000000000000000000000000000000000000000000000000000000000000124',
+      contract_id: '0.0.359',
+      created_contract_ids: [],
+      error_message: 'SPENDER_DOES_NOT_HAVE_ALLOWANCE',
+      from: '0x0000000000000000000000000000000000893485',
+      function_parameters: '0x15dacbea',
+      gas_consumed: 15284,
+      gas_limit: 4577742,
+      gas_used: 15284,
+      timestamp: '1787298614.746518110',
+      to: '0x0000000000000000000000000000000000000167',
+      hash: childTxHash,
+      block_hash: '0xf299dce3f4b2a137c932dc476d566833e8061d7df9779ce12b69772a5cc6090f640ea131cbb346e04e441512d0045ea5',
+      block_number: 39523147,
+      logs: [],
+      result: 'SPENDER_DOES_NOT_HAVE_ALLOWANCE',
+      transaction_index: null,
+      state_changes: [],
+      status: '0x0',
+      failed_initcode: null,
+      access_list: [],
+      block_gas_used: 1482946,
+      chain_id: '0x128',
+      gas_price: '0x71',
+      max_fee_per_gas: null,
+      max_priority_fee_per_gas: null,
+      r: null,
+      s: null,
+      type: 0,
+      v: null,
+      nonce: null,
+    };
+
+    const rejectedParentRecord = {
+      ...childRecord,
+      address: '0xe8bf85ee602cb26402b73b3d0bb5b7442a2c3543',
+      call_result: '0x',
+      contract_id: '0.0.5508307',
+      error_message: '0x57524f4e475f4e4f4e4345', // WRONG_NONCE
+      from: '0x0000000000000000000000000000000000540d93',
+      function_parameters: '0xb1dc65a4',
+      gas_consumed: 0,
+      gas_used: 0,
+      gas_limit: 8000000,
+      timestamp: '1787298426.993500843',
+      to: '0xe8bf85ee602cb26402b73b3d0bb5b7442a2c3543',
+      hash: rejectedParentTxHash,
+      block_hash: '0xe4c45ec72408fa6a8b7ac221003c8ecd0bf24bf165786c871391018ac85f67861714e71718d89107e0caa710c71eb0f6',
+      block_number: 39523059,
+      result: 'WRONG_NONCE',
+      block_gas_used: 0,
+      gas_price: '0x87',
+      max_fee_per_gas: '0x',
+      max_priority_fee_per_gas: '0x',
+      r: '0x19ca0217817b3744f6bc22fe951ee4a84ae031242b31abf547c51a337d03bff1',
+      s: '0x3e38da1f058db712e57c37a779c229c0807909c03332f12a4f062bfd6bf71ea7',
+      v: 628,
+      nonce: 3019,
+    };
+
+    const collapseImmatureRecordPolling = () => {
+      sandbox.stub(mirrorNodeInstance, 'getMirrorNodeRequestRetryCount').returns(1);
+      sandbox.stub(mirrorNodeInstance, 'getMirrorNodeRetryDelay').returns(0);
+    };
+
+    it('should report a child (synthetic) record as not found rather than as a rejected transaction', async function () {
+      restMock.onGet(`contracts/results/${childTxHash}?hbar=false`).reply(200, JSON.stringify(childRecord));
+      collapseImmatureRecordPolling();
+
+      const receipt = await ethImpl.getTransactionReceipt(childTxHash, requestDetails);
+
+      expect(receipt).to.be.null;
+    });
+
+    it('should throw a -32003 rejection error for a rejected top-level transaction', async function () {
+      restMock
+        .onGet(`contracts/results/${rejectedParentTxHash}?hbar=false`)
+        .reply(200, JSON.stringify(rejectedParentRecord));
+      collapseImmatureRecordPolling();
+
+      const error = await ethImpl.getTransactionReceipt(rejectedParentTxHash, requestDetails).catch((e) => e);
+
+      expect(error).to.be.instanceOf(JsonRpcError);
+      const jsonRpcError = error as JsonRpcError;
+      expect(jsonRpcError.code).to.eq(-32003);
+      expect(jsonRpcError.message).to.eq('Transaction rejected: WRONG_NONCE');
+      const data = jsonRpcError.data as Record<string, unknown>;
+      expect(data.txHash).to.eq(rejectedParentTxHash);
+      expect(data.hederaStatus).to.eq('WRONG_NONCE');
     });
   });
 

--- a/tests/relay/lib/mirrorNodeClient.spec.ts
+++ b/tests/relay/lib/mirrorNodeClient.spec.ts
@@ -976,6 +976,52 @@ describe('MirrorNodeClient', async function () {
     expect(mock.history.get.length).to.eq(1);
   });
 
+  it('`getContractResultsWithRetry` should not poll a child tx record', async () => {
+    const hash = '0x2a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6396';
+    mock.onGet(`contracts/results/${hash}?hbar=false`).reply(
+      200,
+      JSON.stringify({
+        ...detailedContractResult,
+        transaction_index: null,
+        result: 'SUCCESS',
+        nonce: null,
+        v: null,
+        r: null,
+        s: null,
+      }),
+    );
+
+    const result = await mirrorNodeInstance.getContractResultWithRetry(mirrorNodeInstance.getContractResult.name, [
+      hash,
+      requestDetails,
+    ]);
+
+    expect(result.result).to.eq('SUCCESS');
+    expect(result.transaction_index).to.be.null;
+    expect(mock.history.get.length).to.eq(1);
+  });
+
+  it('`getContractResultsWithRetry` should still poll a top-level record with no block linkage yet', async () => {
+    const hash = '0x2a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6397';
+    mock
+      .onGet(`contracts/results/${hash}?hbar=false`)
+      .replyOnce(
+        200,
+        JSON.stringify({ ...detailedContractResult, transaction_index: null, block_number: null, block_hash: '0x' }),
+      )
+      .onGet(`contracts/results/${hash}?hbar=false`)
+      .replyOnce(200, JSON.stringify(detailedContractResult));
+
+    const result = await mirrorNodeInstance.getContractResultWithRetry(mirrorNodeInstance.getContractResult.name, [
+      hash,
+      requestDetails,
+    ]);
+
+    expect(result.transaction_index).to.eq(detailedContractResult.transaction_index);
+    expect(result.block_number).to.eq(detailedContractResult.block_number);
+    expect(mock.history.get.length).to.eq(2);
+  });
+
   it('`getContractResultsWithRetry` should return the immature record when the caller opts in', async () => {
     const hash = '0x2a563af33c4871b51a8b108aa2fe1dd5280a30dfb7236170ae5e5e7957eb6395';
     const immatureRecord = {


### PR DESCRIPTION

### Description

Cherry-pick #5661 to 0.78.

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #5661

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1.
2.
3.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
