### PR TITLE
ci: harden workflow token permissions, pin dependencies, add property-based tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -8,7 +8,6 @@ on:
     tags: [v*]
 
 permissions:
-  checks: write
   contents: read
 
 concurrency:
@@ -18,6 +17,9 @@ concurrency:
 jobs:
   acceptance_tests:
     name: ${{ matrix.test.name }}
+    permissions:
+      checks: write
+      contents: read
     strategy:
       fail-fast: false
       max-parallel: 6
@@ -73,6 +75,9 @@ jobs:
     if: ${{ github.actor != 'dependabot[bot]' && !cancelled() }}
     needs: [acceptance_tests]
     runs-on: hiero-smart-contracts-linux-medium
+    permissions:
+      checks: write
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0

--- a/.github/workflows/conformity-workflow.yml
+++ b/.github/workflows/conformity-workflow.yml
@@ -47,7 +47,7 @@ jobs:
           node-version: 22
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
         working-directory: ./execution-apis
 
       - name: Build project

--- a/.github/workflows/dev-tool-test.yml
+++ b/.github/workflows/dev-tool-test.yml
@@ -7,6 +7,9 @@ on:
     branches: [main, release/**]
     tags: [v*]
 
+permissions:
+  contents: read
+
 concurrency:
   group: pr-checks-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -14,6 +17,9 @@ concurrency:
 jobs:
   hardhat:
     name: Hardhat
+    permissions:
+      contents: write
+      actions: read
     uses: ./.github/workflows/dev-tool-workflow.yml
     with:
       command: cd ./tools/hardhat-example/ && npx hardhat test
@@ -21,6 +27,9 @@ jobs:
 
   web3js:
     name: Web3js
+    permissions:
+      contents: write
+      actions: read
     uses: ./.github/workflows/dev-tool-workflow.yml
     needs: [hardhat]
     with:
@@ -29,6 +38,9 @@ jobs:
 
   golang-http:
     name: Golang HTTP
+    permissions:
+      contents: write
+      actions: read
     uses: ./.github/workflows/dev-tool-workflow.yml
     with:
       command: cd ./tools/golang-json-rpc-tests/ && go run .
@@ -36,6 +48,9 @@ jobs:
 
   golang-wss:
     name: Golang WSS
+    permissions:
+      contents: write
+      actions: read
     uses: ./.github/workflows/dev-tool-workflow.yml
     with:
       command: cd ./tools/golang-json-rpc-tests/ && go run . --wss

--- a/.github/workflows/manual-testing.yml
+++ b/.github/workflows/manual-testing.yml
@@ -13,14 +13,14 @@ on:
 
 run-name: Manual Test with N:${{ inputs.networkNodeTag }} and M:${{ inputs.mirrorNodeTag }}
 permissions:
-  contents: write
-  checks: write
-  pull-requests: write
-  actions: read
+  contents: read
 
 jobs:
   api_batch_1:
     name: API Batch 1
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: api_batch1
@@ -31,6 +31,9 @@ jobs:
 
   api_batch_2:
     name: API Batch 2
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: api_batch2
@@ -41,6 +44,9 @@ jobs:
 
   api_batch_3:
     name: API Batch 3
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: api_batch3
@@ -51,6 +57,9 @@ jobs:
 
   erc20:
     name: ERC20
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: erc20
@@ -61,6 +70,9 @@ jobs:
 
   ratelimiter:
     name: Rate Limiter
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: ratelimiter
@@ -73,6 +85,9 @@ jobs:
 
   hbarlimiter:
     name: HBar Limiter
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: hbarlimiter
@@ -83,6 +98,9 @@ jobs:
 
   tokencreate:
     name: Token Create
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: tokencreate
@@ -93,6 +111,9 @@ jobs:
 
   tokenmanagement:
     name: Token Management
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: tokenmanagement
@@ -103,6 +124,9 @@ jobs:
 
   htsprecompilev1:
     name: Precompile
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: htsprecompilev1
@@ -113,6 +137,9 @@ jobs:
 
   precompilecalls:
     name: Precompile Calls
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: precompile-calls
@@ -123,6 +150,9 @@ jobs:
 
   websocket-batch-1:
     name: Websocket Batch 1
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: ws_batch1
@@ -134,6 +164,9 @@ jobs:
 
   websocket-batch-2:
     name: Websocket Batch 2
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: ws_batch2
@@ -145,6 +178,9 @@ jobs:
 
   websocket-batch-3:
     name: Websocket Batch 3
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: ws_batch3
@@ -156,6 +192,9 @@ jobs:
 
   cacheservice:
     name: Cache Service
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: cache-service
@@ -166,6 +205,9 @@ jobs:
 
   server-config:
     name: Server Config
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: serverconfig
@@ -176,6 +218,9 @@ jobs:
 
   protocol-account-service:
     name: Protocol Account Service
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: protocol-account-service
@@ -187,6 +232,9 @@ jobs:
 
   protocol-block-service:
     name: Protocol Block Service
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: protocol-block-service
@@ -198,6 +246,9 @@ jobs:
 
   protocol-common-service:
     name: Protocol Common Service
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: protocol-common-service
@@ -209,6 +260,9 @@ jobs:
 
   protocol-contract-service:
     name: Protocol Contract Service
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: protocol-contract-service
@@ -220,6 +274,9 @@ jobs:
 
   protocol-transaction-service:
     name: Protocol Transaction Service
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: protocol-transaction-service
@@ -231,6 +288,9 @@ jobs:
 
   protocol-fee-service:
     name: Protocol Fee Service
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: protocol-fee-service
@@ -242,6 +302,9 @@ jobs:
 
   protocol-eth-plain:
     name: Protocol Eth Plain
+    permissions:
+      checks: write
+      contents: read
     uses: ./.github/workflows/acceptance-workflow.yml
     with:
       testfilter: protocol-eth-plain
@@ -280,6 +343,11 @@ jobs:
       - protocol-eth-plain
 
     runs-on: hiero-smart-contracts-linux-medium
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
+      actions: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0

--- a/.github/workflows/pr-label-milestone-check.yml
+++ b/.github/workflows/pr-label-milestone-check.yml
@@ -4,9 +4,16 @@ on:
   pull_request:
     types: [opened, edited, labeled, unlabeled, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   check_pr:
     runs-on: hiero-smart-contracts-linux-medium
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -8,9 +8,15 @@ on:
         type: string
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   branch_bump_tag:
     runs-on: hiero-smart-contracts-linux-medium
+    permissions:
+      contents: write
+      issues: write
     env:
       RELEASE_NOTES_FILENAME: release_notes
     outputs:
@@ -142,6 +148,9 @@ jobs:
     name: Create snapshot PR
     runs-on: hiero-smart-contracts-linux-medium
     needs: branch_bump_tag
+    permissions:
+      contents: write
+      pull-requests: write
     if: ${{ needs.branch_bump_tag.outputs.create_pr == 'true' }}
     env:
       NEXT_VERSION_SNAPSHOT: ${{ needs.branch_bump_tag.outputs.next_version_snapshot }}

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -10,11 +10,13 @@ env:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   publish:
     runs-on: hiero-smart-contracts-linux-medium
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/release-production.yml
+++ b/.github/workflows/release-production.yml
@@ -10,11 +10,13 @@ env:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   docker-image-publish:
     runs-on: hiero-smart-contracts-linux-medium
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
     branches: [main, release/**]
     tags: [v*]
 
+permissions:
+  contents: read
+
 concurrency:
   group: pr-checks-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -15,6 +18,11 @@ jobs:
   test-node:
     name: Tests
     runs-on: hiero-smart-contracts-linux-medium
+    permissions:
+      contents: read
+      checks: write
+      issues: read
+      pull-requests: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "eslint-plugin-n": "^17.24.0",
         "eslint-plugin-simple-import-sort": "^12.1.1",
         "execution-apis": "git://github.com/ethereum/execution-apis.git#7907424db935b93c2fe6a3c0faab943adebe8557",
+        "fast-check": "^4.9.0",
         "globals": "^17.11.0",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
@@ -4534,6 +4535,29 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-content-type-parse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
@@ -7192,6 +7216,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/pvtsutils": {
       "version": "1.3.6",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-n": "^17.24.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "execution-apis": "git://github.com/ethereum/execution-apis.git#7907424db935b93c2fe6a3c0faab943adebe8557",
+    "fast-check": "^4.9.0",
     "globals": "^17.11.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",

--- a/tests/relay/lib/formatters.property.spec.ts
+++ b/tests/relay/lib/formatters.property.spec.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { expect } from 'chai';
+import fc from 'fast-check';
+
+import {
+  ASCIIToHex,
+  hexToASCII,
+  isHex,
+  nanOrNumberInt64To0x,
+  numberTo0x,
+  prepend0x,
+  strip0x,
+  trimPrecedingZeros,
+} from '../../../src/relay/formatters';
+
+const INT64_MIN = -(BigInt(1) << BigInt(63));
+const INT64_MAX = (BigInt(1) << BigInt(63)) - BigInt(1);
+const UINT256_MAX = (BigInt(1) << BigInt(256)) - BigInt(1);
+
+// non-empty lowercase hex string without the 0x prefix
+const hexDigits = fc
+  .array(fc.constantFrom(...'0123456789abcdef'), { minLength: 1, maxLength: 64 })
+  .map((chars) => chars.join(''));
+
+// printable ASCII (0x20..0x7e), the range ASCIIToHex encodes with two hex digits per character
+const printableAscii = fc.array(fc.integer({ min: 0x20, max: 0x7e })).map((codes) => String.fromCharCode(...codes));
+
+describe('Formatters property-based tests', () => {
+  describe('prepend0x / strip0x', () => {
+    it('prepend0x is idempotent and strip0x inverts it', () => {
+      fc.assert(
+        fc.property(hexDigits, (hex) => {
+          const prefixed = prepend0x(hex);
+          expect(prefixed).to.equal(`0x${hex}`);
+          expect(prepend0x(prefixed)).to.equal(prefixed);
+          expect(strip0x(prefixed)).to.equal(hex);
+          expect(strip0x(hex)).to.equal(hex);
+          expect(isHex(prefixed)).to.be.true;
+        }),
+      );
+    });
+  });
+
+  describe('numberTo0x / trimPrecedingZeros', () => {
+    it('round-trips any non-negative integer through its 0x-prefixed hex form', () => {
+      fc.assert(
+        fc.property(fc.bigInt({ min: BigInt(0), max: UINT256_MAX }), (value) => {
+          const hex = numberTo0x(value);
+          expect(isHex(hex)).to.be.true;
+          expect(BigInt(hex)).to.equal(value);
+          expect(trimPrecedingZeros(hex)).to.equal(value.toString(16));
+        }),
+      );
+    });
+
+    it('trimPrecedingZeros ignores any number of leading zeros and an optional 0x prefix', () => {
+      fc.assert(
+        fc.property(hexDigits, fc.nat({ max: 16 }), (hex, zeros) => {
+          const expected = trimPrecedingZeros(hex);
+          expect(trimPrecedingZeros('0'.repeat(zeros) + hex)).to.equal(expected);
+          expect(trimPrecedingZeros(`0x${'0'.repeat(zeros)}${hex}`)).to.equal(expected);
+        }),
+      );
+    });
+  });
+
+  describe('nanOrNumberInt64To0x', () => {
+    it("encodes any int64 as two's complement that decodes back to the same value", () => {
+      fc.assert(
+        fc.property(fc.bigInt({ min: INT64_MIN, max: INT64_MAX }), (value) => {
+          const hex = nanOrNumberInt64To0x(value);
+          expect(isHex(hex)).to.be.true;
+          expect(BigInt.asIntN(64, BigInt(hex))).to.equal(value);
+          expect(nanOrNumberInt64To0x(value.toString())).to.equal(hex);
+        }),
+      );
+    });
+  });
+
+  describe('ASCIIToHex / hexToASCII', () => {
+    it('round-trips printable ASCII strings', () => {
+      fc.assert(
+        fc.property(printableAscii, (text) => {
+          const hex = ASCIIToHex(text);
+          expect(hex).to.have.lengthOf(text.length * 2);
+          expect(hexToASCII(hex)).to.equal(text);
+        }),
+      );
+    });
+  });
+});

--- a/tools/whbar-hardhat-example/Dockerfile
+++ b/tools/whbar-hardhat-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22-bullseye
+FROM node:22-bullseye@sha256:959fa6e5c12f4b08f58808f953c7a6a05f1f72629b57ef3a648b8809362fdad9
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -17,5 +17,5 @@ RUN apt-get update && \
 
 USER node
 
-RUN npm install --ignore-scripts
+RUN npm ci --ignore-scripts
 RUN npx hardhat compile


### PR DESCRIPTION
### Description

This PR hardens the GitHub Actions configuration to improve the repository's [OpenSSF Scorecard](https://securityscorecards.dev/viewer/?uri=github.com/hiero-ledger/hiero-json-rpc-relay) results, which currently report **Token-Permissions: 0** because several workflows grant `contents: write` / `packages: write` / `checks: write` at the workflow (top) level, or declare no `permissions` block at all and therefore fall back to the repository default (write-all).

Every workflow now declares a read-only top-level `permissions: contents: read`, and each write scope is moved to the specific job that needs it. No job loses a scope it uses; the effective permissions of every job are unchanged or narrowed only where the scope was unused. The remaining unpinned dependencies that could safely be pinned are pinned, and a property-based test suite is added so the Fuzzing check recognises the project.

#### Token-Permissions (0 → 10)

| Workflow | Before (top level) | After |
| --- | --- | --- |
| `acceptance.yml` | `checks: write` | top level `contents: read`; `checks: write` on `acceptance_tests` (reusable-workflow caller) and `publish_results` |
| `manual-testing.yml` | `contents: write`, `checks: write`, `pull-requests: write`, `actions: read` | top level `contents: read`; `checks: write` + `contents: read` on every `acceptance-workflow.yml` caller job (what the reusable workflow declares); `checks/pull-requests/actions` kept on `publish_results` |
| `release-production.yml` | `packages: write` | top level `contents: read`; `packages: write` only on `docker-image-publish` (`helm-chart-release` already had job-level `contents: write`) |
| `release-integration.yml` | `packages: write` | top level `contents: read`; `packages: write` on `publish` |
| `dev-tool-test.yml` | none (default write-all) | top level `contents: read`; `contents: write` + `actions: read` on the four `dev-tool-workflow.yml` caller jobs, matching what the reusable workflow declares |
| `pr-label-milestone-check.yml` | none (default write-all) | top level `contents: read`; `issues: write` + `pull-requests: write` on `check_pr` (`check-pr.js` reads PR/issue data and, for Snyk PRs, updates the title and adds a label) |
| `release-automation.yml` | none (default write-all) | top level `contents: read`; `contents: write` + `issues: write` on `branch_bump_tag` (commit/tag/release, close milestone); `contents: write` + `pull-requests: write` on `create_snapshot_pr` |
| `test.yml` | none (default write-all) | top level `contents: read`; `checks: write`, `issues: read`, `pull-requests: write` on `test-node` (unit-test-result publishing / PR comment) |

Note: reusable-workflow caller jobs need an explicit `permissions` block once the top level is read-only, because a called workflow cannot request more than the caller grants.

#### Pinned-Dependencies (9 → 9 locally; 2 warnings remain, see below)

- `tools/whbar-hardhat-example/Dockerfile`: pin `node:22-bullseye` by digest (`sha256:959fa6e5…`, verified with `docker buildx imagetools inspect`; Dependabot's `docker` entry already covers this directory so the digest will be kept current) and use `npm ci` instead of `npm install` (a `package-lock.json` is committed and the earlier production install in the same file already uses `npm ci`).
- `conformity-workflow.yml`: `npm install` → `npm ci` for the `ethereum/execution-apis` checkout. Verified locally that `npm ci` succeeds at the pinned ref `7907424d`, which ships an in-sync `package-lock.json`.

#### Fuzzing (0 → 10)

- Add `fast-check` as a devDependency and `tests/relay/lib/formatters.property.spec.ts` with property-based tests for the pure helpers in `src/relay/formatters.ts` (`prepend0x`/`strip0x`, `numberTo0x`/`trimPrecedingZeros`, `nanOrNumberInt64To0x` two's-complement round trip, `ASCIIToHex`/`hexToASCII` round trip). The file lives under `tests/relay/**` so it runs as part of the existing `npm test` mocha run.

#### Local Scorecard results

| Check | Before | After (`scorecard --local`) |
| --- | --- | --- |
| Token-Permissions | 0 | 10 |
| Pinned-Dependencies | 9 | 9 |
| Fuzzing | 0 | 10 |
| Binary-Artifacts | 10 | 10 |
| Dangerous-Workflow | 10 | 10 |

#### Intentionally not changed

- `charts.yml`: `curl … k3d/install.sh | bash` (download-then-run) — left as is; there is no checksum-verified install path for k3d in that script.
- `publish-npm-package.yml`: `npm install -g npm@11.7.0` is a global tool install, not a project dependency install, so `npm ci` does not apply.
- `dev-tool-workflow.yml`, `hoppscotch.yml`, `dapp.yml`, `subgraph.yml`, `flow-pr-title-check.yml`: already had a read-only top level with job-level write scopes; unchanged.
- No CodeQL workflow is added: this repository already runs CodeQL through GitHub's default setup (`actions`, `go`, `javascript-typescript`, `python`), and an advanced-configuration workflow cannot coexist with default setup.

### Related issue(s)

N/A — no existing issue tracks this work.

### Testing Guide

1. `actionlint .github/workflows/<file>` on every touched workflow — no new findings compared to `main` (only the pre-existing self-hosted runner-label and shellcheck notes).
2. `scorecard --local . --checks Token-Permissions,Pinned-Dependencies,Binary-Artifacts,Dangerous-Workflow,Fuzzing` — results in the table above.
3. `cp tests/relay/test.env .env && npx ts-mocha tests/relay/lib/formatters.property.spec.ts --exit` — 5 passing; `npx eslint --config eslint.config.ci.mjs tests/relay/lib/formatters.property.spec.ts` and `prettier --check` are clean.
4. `docker buildx imagetools inspect node:22-bullseye` reports digest `sha256:959fa6e5c12f4b08f58808f953c7a6a05f1f72629b57ef3a648b8809362fdad9`.
5. `git clone ethereum/execution-apis && git checkout 7907424d && npm ci` succeeds.

### Changes from original design (optional)

N/A

### Additional work needed (optional)

The `release-automation.yml` and `manual-testing.yml` workflows are `workflow_dispatch` only and cannot be exercised from a fork PR; the job-level scopes mirror what each job does today (see table), but a maintainer may want to keep an eye on the next release run.

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [x] I've updated documentation (code comments, README, etc. if applicable)
- [x] I've done sufficient testing (unit, integration, etc.)
