### PR TITLE
feat: edit docker compose for ws server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,15 +11,19 @@ services:
     volumes:
       - ./.env:/home/node/app/.env
     environment:
+      RPC_HTTP_ENABLED: "true"
+      RPC_WS_ENABLED: "false"
       REDIS_ENABLED: true
       REDIS_URL: "redis://redis:6379"
 
   relay-ws:
     container_name: hedera-json-rpc-relay-ws
     image: "ghcr.io/hiero-ledger/hiero-json-rpc-relay:main"
-    # Override the default HTTP server CMD with the WebSocket server entry-point in Dockerfile.
-    command: ["packages/ws-server/dist/index.js"]
+    # Uses the image default CMD (dist/index.js); the transport is selected with env vars,
+    # matching the Helm websocket chart and the `start:ws` script in package.json.
     environment:
+      RPC_HTTP_ENABLED: "false"
+      RPC_WS_ENABLED: "true"
       HEALTHCHECK_PORT: 8547
       SUBSCRIPTIONS_ENABLED: true
       REDIS_ENABLED: true


### PR DESCRIPTION
### Description|

docker compose up starts the HTTP relay (relay) successfully, but the WebSocket service (relay-ws) immediately exits. The same stale command path was previously reported for Helm in 5203 (fixed in 0.76.1) and observed in 0.76.0-rc2 in 5159. docker-compose.yml on main was never updated.

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #5653 

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1.
2.
3.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
