### PR TITLE
feat: use `JSONBigInt.parse` only when it's needed

### DIFF
--- a/src/relay/lib/clients/mirrorNodeClient.ts
+++ b/src/relay/lib/clients/mirrorNodeClient.ts
@@ -437,6 +437,45 @@ export class MirrorNodeClient {
     return ip;
   }
 
+  /**
+   * Matches a JSON number literal that `json-bigint` would widen into a `BigNumber`.
+   *
+   * `json-bigint` widens a literal whose textual form is longer than 15 characters (`lib/parse.js`:
+   * `if (string.length > 15)`) - the form it measures includes the sign, the decimal point and the
+   * exponent, not just the integer digits. Both branches below therefore require a 16-character or
+   * longer literal, so nothing json-bigint widens can slip through.
+   *
+   * A JSON number only ever appears at the start of the document, after `[` or `,` in an array, or
+   * as an object value. Anchoring on those positions is what makes the probe usable at all: the
+   * zero-padded `data`, `topics` and `bloom` fields of a log response are long digit runs, and an
+   * unanchored scan would match nearly every response.
+   */
+  private static readonly WIDENED_NUMBER_LITERAL_REGEX = /(?:^|"\s*:|[,[])\s*(?:-[\d.eE+-]{15,}|\d[\d.eE+-]{15,})/;
+
+  /**
+   * Parses a response body and if there is a big number in it - uses JSONBigInt.parse instead of JSON.parse
+   *
+   * @param data - The raw response body as handed over by axios.
+   * @returns The parsed body, or `data` unchanged when it is empty or cannot be parsed.
+   */
+  private parseResponseBody(data: any): any {
+    // if the data is not valid, just return it to stick to the current behaviour
+    if (!data) {
+      return data;
+    }
+
+    try {
+      return typeof data === 'string' && !MirrorNodeClient.WIDENED_NUMBER_LITERAL_REGEX.test(data)
+        ? JSON.parse(data)
+        : JSONBigInt.parse(data);
+    } catch (error) {
+      this.logger.warn(`Failed to parse response data from Mirror Node: %s`, error);
+    }
+
+    // return raw data so response can be processed properly by subsequent operations.
+    return data;
+  }
+
   private async request<T>(
     path: string,
     pathLabel: string,
@@ -475,23 +514,9 @@ export class MirrorNodeClient {
           // is converted to a JS Number type, precision is lost due to rounding.
           // To prevent this, `transformResponse` is used to intercept
           // and process the response before Axios’s default JSON.parse conversion.
-          // JSONBigInt reads the string representation from the received JSON
-          // and converts large numbers into BigNumber objects to maintain accuracy.
-          axiosRequestConfig['transformResponse'] = [
-            (data): any => {
-              // if the data is not valid, just return it to stick to the current behaviour
-              if (data) {
-                try {
-                  return JSONBigInt.parse(data);
-                } catch (error) {
-                  this.logger.warn(`Failed to parse response data from Mirror Node: %s`, error);
-                }
-              }
-
-              // Return raw data so response can be processed properly by subsequent operations.
-              return data;
-            },
-          ];
+          // See parseResponseBody for how precision is preserved without paying for json-bigint
+          // on every response.
+          axiosRequestConfig['transformResponse'] = [(data): any => this.parseResponseBody(data)];
           response = await this.restClient.get<T>(path, axiosRequestConfig);
         }
       } else {

--- a/src/relay/lib/clients/mirrorNodeClient.ts
+++ b/src/relay/lib/clients/mirrorNodeClient.ts
@@ -455,7 +455,7 @@ export class MirrorNodeClient {
   /**
    * Parses a response body and if there is a big number in it - uses JSONBigInt.parse instead of JSON.parse
    *
-   * @param data - The raw response body as handed over by axios.
+   * @param data - The raw response body.
    * @returns The parsed body, or `data` unchanged when it is empty or cannot be parsed.
    */
   private parseResponseBody(data: any): any {

--- a/src/relay/lib/clients/mirrorNodeClient.ts
+++ b/src/relay/lib/clients/mirrorNodeClient.ts
@@ -514,8 +514,7 @@ export class MirrorNodeClient {
           // is converted to a JS Number type, precision is lost due to rounding.
           // To prevent this, `transformResponse` is used to intercept
           // and process the response before Axios’s default JSON.parse conversion.
-          // See parseResponseBody for how precision is preserved without paying for json-bigint
-          // on every response.
+          // See parseResponseBody for how precision is preserved without paying for json-bigint on every response.
           axiosRequestConfig['transformResponse'] = [(data): any => this.parseResponseBody(data)];
           response = await this.restClient.get<T>(path, axiosRequestConfig);
         }

--- a/src/relay/lib/clients/mirrorNodeClient.ts
+++ b/src/relay/lib/clients/mirrorNodeClient.ts
@@ -514,7 +514,6 @@ export class MirrorNodeClient {
           // is converted to a JS Number type, precision is lost due to rounding.
           // To prevent this, `transformResponse` is used to intercept
           // and process the response before Axios’s default JSON.parse conversion.
-          // See parseResponseBody for how precision is preserved without paying for json-bigint on every response.
           axiosRequestConfig['transformResponse'] = [(data): any => this.parseResponseBody(data)];
           response = await this.restClient.get<T>(path, axiosRequestConfig);
         }

--- a/tests/relay/lib/mirrorNodeClient.spec.ts
+++ b/tests/relay/lib/mirrorNodeClient.spec.ts
@@ -2,6 +2,7 @@
 
 import axios, { type AxiosInstance } from 'axios';
 import MockAdapter from 'axios-mock-adapter';
+import BigNumber from 'bignumber.js';
 import chai, { expect } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { ethers } from 'ethers';
@@ -3048,6 +3049,61 @@ describe('MirrorNodeClient', async function () {
           expect(uniqueHashes.size).to.equal(4);
         });
       });
+    });
+  });
+
+  describe('response body parsing', () => {
+    const getNetworkFeesWithBody = async (body: string): Promise<any> => {
+      mock.onGet('network/fees').reply(200, body);
+      return mirrorNodeInstance.getNetworkFees(requestDetails);
+    };
+
+    it('should preserve an integer beyond the safe range as a BigNumber', async () => {
+      const response = await getNetworkFeesWithBody('{"amount":1000000000000000000000}');
+
+      expect(BigNumber.isBigNumber(response.amount)).to.be.true;
+      expect(response.amount.toString()).to.equal('1000000000000000000000');
+    });
+
+    it('should preserve a negative integer beyond the safe range as a BigNumber', async () => {
+      const response = await getNetworkFeesWithBody('{"amount":-1000000000000000000000}');
+
+      expect(BigNumber.isBigNumber(response.amount)).to.be.true;
+      expect(response.amount.toString()).to.equal('-1000000000000000000000');
+    });
+
+    it('should widen at the same literal-length boundary as json-bigint', async () => {
+      const response = await getNetworkFeesWithBody('{"small":999999999999999,"big":1000000000000000}');
+
+      expect(response.small).to.be.a('number');
+      expect(response.small).to.equal(999999999999999);
+      expect(BigNumber.isBigNumber(response.big)).to.be.true;
+      expect(response.big.toString()).to.equal('1000000000000000');
+    });
+
+    it('should leave long digit runs inside strings untouched', async () => {
+      const paddedTopic = `0x${'0'.repeat(64)}`;
+      const response = await getNetworkFeesWithBody(
+        JSON.stringify({ data: paddedTopic, timestamp: '1700000000.123456789', gas: 57 }),
+      );
+
+      expect(response.data).to.equal(paddedTopic);
+      expect(response.timestamp).to.equal('1700000000.123456789');
+      expect(response.gas).to.equal(57);
+    });
+
+    it('should not treat a timestamp filter inside links.next as a widened literal', async () => {
+      const next = '/api/v1/contracts/results/logs?limit=100&order=desc&timestamp=lt:1788415891.548547568';
+      const response = await getNetworkFeesWithBody(JSON.stringify({ logs: [{ index: 3 }], links: { next } }));
+
+      expect(response.links.next).to.equal(next);
+      expect(response.logs[0].index).to.be.a('number').that.equals(3);
+    });
+
+    it('should return the raw body when it cannot be parsed', async () => {
+      const response = await getNetworkFeesWithBody('not a json body');
+
+      expect(response).to.equal('not a json body');
     });
   });
 });


### PR DESCRIPTION
### Description

Right now, every REST response is parsed with json-bigint to protect uint256 precision.

A regex can probe the raw body first. json-bigint runs only when the body actually contains a literal it would widen, anything else is parsed via native JSON.parse.

<!--
Briefly explain what this PR addresses and why it is needed. This should help reviewers understand the intent of the changes.

Start with something like:
"This PR introduces support for..." or "This PR fixes an issue where..."
-->

Test results:
```
#  route                          KB  parser        before   after      x
-------------------------------------------------------------------------
1  logs page, 100 blocks       123.2  JSON.parse    0.762   0.302   2.52x
2  contract results page *     207.3  json-bigint   1.713   1.666   1.03x
3  transactions page            78.4  JSON.parse    0.894   0.292   3.06x
4  blocks list, 100             79.2  JSON.parse    0.422   0.195   2.16x
5  block 40051986                0.9  JSON.parse    0.004   0.002   2.10x
6  contract results, 1 block     6.0  JSON.parse    0.042   0.017   2.47x
7  logs, block 40051986          4.8  JSON.parse    0.027   0.012   2.25x
8  tx 0x09886c4abc              11.1  JSON.parse    0.069   0.029   2.38x
9  tx 0x0b7ab4de18              11.1  JSON.parse    0.072   0.029   2.48x
10 contract 0x..009c7c46        13.0  JSON.parse    0.040   0.023   1.74x
11 account 0.0.2 *               1.6  json-bigint   0.015   0.016   0.93x
12 account 0.0.801               1.5  JSON.parse    0.021   0.007   3.00x
-------------------------------------------------------------------------
   ALL 12 routes                                    4.081   2.592   1.57x
   10 fast-path routes                              2.353   0.908   2.59x
   2 fallback routes (*)                            1.728   1.684   1.03x
* = response really carries a >15-char literal
```


Links, all pinned by block / hash / timestamp so they stay reproducible:
1. https://testnet.mirrornode.hedera.com/api/v1/contracts/results/logs?timestamp=gte:1788424335.081083104&timestamp=lte:1788424546.429494104&limit=100 | logs page, 100 blocks
2. https://testnet.mirrornode.hedera.com/api/v1/contracts/results?timestamp=gte:1788424335.081083104&timestamp=lte:1788424546.429494104&limit=100&hbar=false | contract results page *
3. https://testnet.mirrornode.hedera.com/api/v1/transactions?timestamp=gte:1788424335.081083104&timestamp=lte:1788424546.429494104&limit=100 | transactions page
4. https://testnet.mirrornode.hedera.com/api/v1/blocks?block.number=gte:40051964&limit=100&order=asc | blocks list, 100
5. https://testnet.mirrornode.hedera.com/api/v1/blocks/40051986 | block 40051986
6. https://testnet.mirrornode.hedera.com/api/v1/contracts/results?block.number=40051986&limit=100&hbar=false | contract results, 1 block
7. https://testnet.mirrornode.hedera.com/api/v1/contracts/results/logs?timestamp=gte:1788424381.438353104&timestamp=lte:1788424383.437444055&limit=100 | logs, block 40051986
8. https://testnet.mirrornode.hedera.com/api/v1/contracts/results/0x09886c4abc2f5a14d08694760c5c7eb2aa94d5964474b1486134b482a4bacb22?hbar=false | tx 0x09886c4abc
9. https://testnet.mirrornode.hedera.com/api/v1/contracts/results/0x0b7ab4de1824455149a9e0eac1da839beac56ac46bc4db2a9aa75d5fd2faf771?hbar=false | tx 0x0b7ab4de18
10. https://testnet.mirrornode.hedera.com/api/v1/contracts/0x00000000000000000000000000000000009c7c46 | contract 0x..009c7c46
11. https://testnet.mirrornode.hedera.com/api/v1/accounts/0.0.2?limit=1 | account 0.0.2 *
12. https://testnet.mirrornode.hedera.com/api/v1/accounts/0.0.801?limit=1 | account 0.0.801

### Related issue(s)

<!--
Link to the relevant issue(s). If no issue exists, consider creating one that clearly describes the problem this PR aims to solve, including context, expected behavior, and any relevant error messages or logs.
-->

Fixes #5725 

### Testing Guide

<!--
List clear, reproducible steps for testing this PR manually. Include example inputs and expected outcomes if applicable.
-->

1.
2.
3.

### Changes from original design (optional)

<!--
Mention any deviations from the planned solution, technical approach, or product spec. Default to N/A if there are none.
-->

N/A

### Additional work needed (optional)

<!--
Note any future work or technical debt that’s out of scope for this PR. Link technical debt issues if available. Default to N/A if there are none.
-->

N/A

### Checklist

- [ ] I've assigned an assignee to this PR and related issue(s) (if applicable)
- [ ] I've assigned a label to this PR and related issue(s) (if applicable)
- [ ] I've assigned a milestone to this PR and related issue(s) (if applicable)
- [ ] I've updated documentation (code comments, README, etc. if applicable)
- [ ] I've done sufficient testing (unit, integration, etc.)
