### PR TITLE
chore: cherry-pick JSON-RPC field ordering fix to 0.79

### DIFF
--- a/src/server/koaJsonRpc/lib/RpcResponse.ts
+++ b/src/server/koaJsonRpc/lib/RpcResponse.ts
@@ -32,7 +32,7 @@ export function jsonRespResult<Result>(id: IJsonRpcResponse['id'], result: Resul
     throw new Error('Missing result');
   }
 
-  return { result, jsonrpc: '2.0', id };
+  return { jsonrpc: '2.0', id, result };
 }
 
 /**
@@ -66,12 +66,12 @@ export function jsonRespError(id: IJsonRpcResponse['id'], error: IJsonRpcError, 
   }
 
   return {
+    jsonrpc: '2.0',
+    id,
     error: {
       code: error.code,
       message: `[Request ID: ${requestId}] ${error.message}`,
       data: error.data,
     },
-    jsonrpc: '2.0',
-    id,
   };
 }

--- a/tests/server/acceptance/rpc_batch1.spec.ts
+++ b/tests/server/acceptance/rpc_batch1.spec.ts
@@ -326,9 +326,14 @@ describe('@api-batch-1 RPC Server Acceptance Tests', function () {
         expect(res[0]).to.have.property('transactionHash');
         expect(res[0].transactionHash).to.equal(createChildTx.hash);
         expect(res[0].logs).to.not.be.empty;
-        res[0].logs.map((log) =>
-          expect(log.blockTimestamp).to.equal(numberTo0x(Number(mirrorBlock.timestamp.to.split('.')[0]))),
-        );
+        const blockTimestampFrom = Number(mirrorBlock.timestamp.from.split('.')[0]);
+        const blockTimestampTo = Number(mirrorBlock.timestamp.to.split('.')[0]);
+        res[0].logs.map((log) => {
+          const logTimestamp = parseInt(log.blockTimestamp, 16);
+          // Transaction timestamp falls within block's time range [from, to]
+          expect(logTimestamp).to.be.at.least(blockTimestampFrom);
+          expect(logTimestamp).to.be.at.most(blockTimestampTo);
+        });
       });
 
       it('should execute "eth_getBlockReceipts" with block number successfully', async function () {

--- a/tests/server/integration/koaJsonRpc/rpcResponse.spec.ts
+++ b/tests/server/integration/koaJsonRpc/rpcResponse.spec.ts
@@ -53,6 +53,13 @@ describe('RpcResponse', function () {
         result: { key: 'value' },
       });
     });
+
+    it('should maintain JSON-RPC 2.0 field order: jsonrpc, id, result', () => {
+      const response = jsonRespResult(1, { key: 'value' });
+      const keys = Object.keys(response);
+
+      expect(keys).to.deep.equal(['jsonrpc', 'id', 'result']);
+    });
   });
 
   describe('jsonRespError', function () {
@@ -83,6 +90,13 @@ describe('RpcResponse', function () {
       const error = { code: 123, message: 456 };
 
       expect(() => jsonRespError(id, error as any, '')).to.throw(TypeError, 'Invalid error message type number');
+    });
+
+    it('should maintain JSON-RPC 2.0 field order: jsonrpc, id, error', () => {
+      const response = jsonRespError(1, { code: 123, message: 'An error occurred' }, 'req-123');
+      const keys = Object.keys(response);
+
+      expect(keys).to.deep.equal(['jsonrpc', 'id', 'error']);
     });
   });
 });


### PR DESCRIPTION
Cherry-pick of commit 66f0da7b from main to release/0.79

Includes:
- JSON-RPC response field ordering (spec compliance)  
- Flexible blockTimestamp test for eth_getBlockReceipts

This ensures the 0.79 release includes these fixes.

fixes #5729 