### PR TITLE
chore: cherry-pick JSON-RPC field ordering to 0.79 (final)

### DIFF
--- a/src/server/koaJsonRpc/lib/RpcResponse.ts
+++ b/src/server/koaJsonRpc/lib/RpcResponse.ts
@@ -32,7 +32,7 @@ export function jsonRespResult<Result>(id: IJsonRpcResponse['id'], result: Resul
     throw new Error('Missing result');
   }
 
-  return { jsonrpc: '2.0', id, result };
+  return { jsonrpc: '2.0', result, id };
 }
 
 /**
@@ -67,11 +67,11 @@ export function jsonRespError(id: IJsonRpcResponse['id'], error: IJsonRpcError, 
 
   return {
     jsonrpc: '2.0',
-    id,
     error: {
       code: error.code,
       message: `[Request ID: ${requestId}] ${error.message}`,
       data: error.data,
     },
+    id,
   };
 }

--- a/tests/server/integration/koaJsonRpc/rpcResponse.spec.ts
+++ b/tests/server/integration/koaJsonRpc/rpcResponse.spec.ts
@@ -54,11 +54,11 @@ describe('RpcResponse', function () {
       });
     });
 
-    it('should maintain JSON-RPC 2.0 field order: jsonrpc, id, result', () => {
+    it('should maintain JSON-RPC 2.0 field order: jsonrpc, result, id', () => {
       const response = jsonRespResult(1, { key: 'value' });
       const keys = Object.keys(response);
 
-      expect(keys).to.deep.equal(['jsonrpc', 'id', 'result']);
+      expect(keys).to.deep.equal(['jsonrpc', 'result', 'id']);
     });
   });
 
@@ -92,11 +92,11 @@ describe('RpcResponse', function () {
       expect(() => jsonRespError(id, error as any, '')).to.throw(TypeError, 'Invalid error message type number');
     });
 
-    it('should maintain JSON-RPC 2.0 field order: jsonrpc, id, error', () => {
+    it('should maintain JSON-RPC 2.0 field order: jsonrpc, error, id', () => {
       const response = jsonRespError(1, { code: 123, message: 'An error occurred' }, 'req-123');
       const keys = Object.keys(response);
 
-      expect(keys).to.deep.equal(['jsonrpc', 'id', 'error']);
+      expect(keys).to.deep.equal(['jsonrpc', 'error', 'id']);
     });
   });
 });


### PR DESCRIPTION
Cherry-pick ONLY the JSON-RPC field ordering fix to release/0.79

**Field Order (Ethereum JSON-RPC 2.0 Compliant):**
- Success: {jsonrpc, result, id}
- Error: {jsonrpc, error, id}

**Single commit:**
- fix: correct JSON-RPC response field order to jsonrpc, result/error, id

This ensures 0.79 has spec-compliant JSON-RPC responses with id field at the end.