### PR TITLE
feat: add redis version compatibility testing

### DIFF
--- a/.github/workflows/redis-compat.yml
+++ b/.github/workflows/redis-compat.yml
@@ -1,0 +1,84 @@
+name: Redis Compatibility
+
+on:
+  workflow_dispatch:
+    inputs:
+      redis_version:
+        description: 'Redis version to test, e.g. 8.10.1 (leave blank for the newest release)'
+        required: false
+        default: ''
+
+run-name: Redis compatibility — ${{ inputs.redis_version || 'latest release' }}
+
+concurrency:
+  group: redis-compat-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  redis-compat:
+    name: Redis ${{ inputs.redis_version || 'latest' }}
+    runs-on: hiero-smart-contracts-linux-medium
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Resolve Redis version
+        id: resolve
+        env:
+          REQUESTED: ${{ inputs.redis_version }}
+        run: |
+          if [ -n "$REQUESTED" ]; then
+            VERSION="$REQUESTED"
+          else
+            VERSION=$(curl -sSfL https://api.github.com/repos/redis/redis/releases/latest \
+              | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).tag_name.replace(/^v/,'')))")
+          fi
+          if [ -z "$VERSION" ]; then
+            echo "Could not resolve a Redis version" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Testing against Redis $VERSION"
+
+      - name: Install build tools
+        run: sudo apt-get update && sudo apt-get install -y make gcc g++
+
+      - name: Create .env file
+        run: cp ./tests/relay/test.env .env
+
+      - name: Install dependencies
+        run: npm ci
+        env:
+          # The Redis binary is built in the next step instead, so a build failure is
+          # reported separately from a test failure.
+          REDISMS_DISABLE_POSTINSTALL: true
+
+      # A failure here is a toolchain problem, not a compatibility problem.
+      - name: Build Redis ${{ steps.resolve.outputs.version }}
+        env:
+          REDISMS_VERSION: ${{ steps.resolve.outputs.version }}
+          # Redis 8+ ships bundled modules that need pkg-config, python3, cmake and Rust.
+          # redis-memory-server keeps only src/redis-server, so build the core alone.
+          BUILD_ARGS: core
+        run: |
+          node -e "require('redis-memory-server/lib/util/RedisBinary').default.getPath({ version: process.env.REDISMS_VERSION })"
+
+      # A failure here means the relay behaves differently on this Redis version.
+      - name: Run Redis tests
+        env:
+          REDISMS_VERSION: ${{ steps.resolve.outputs.version }}
+        run: npm run test:redis

--- a/.github/workflows/redis-version-tests.yml
+++ b/.github/workflows/redis-version-tests.yml
@@ -1,4 +1,4 @@
-name: Redis Compatibility
+name: Redis Version Tests
 
 on:
   workflow_dispatch:
@@ -8,17 +8,17 @@ on:
         required: false
         default: ''
 
-run-name: Redis compatibility — ${{ inputs.redis_version || 'latest release' }}
+run-name: Redis version tests — ${{ inputs.redis_version || 'latest release' }}
 
 concurrency:
-  group: redis-compat-${{ github.workflow }}-${{ github.ref }}
+  group: redis-version-tests-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
-  redis-compat:
+  redis-version-tests:
     name: Redis ${{ inputs.redis_version || 'latest' }}
     runs-on: hiero-smart-contracts-linux-medium
     steps:
@@ -63,21 +63,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
         env:
-          # The Redis binary is built in the next step instead, so a build failure is
-          # reported separately from a test failure.
           REDISMS_DISABLE_POSTINSTALL: true
 
-      # A failure here is a toolchain problem, not a compatibility problem.
       - name: Build Redis ${{ steps.resolve.outputs.version }}
         env:
           REDISMS_VERSION: ${{ steps.resolve.outputs.version }}
-          # Redis 8+ ships bundled modules that need pkg-config, python3, cmake and Rust.
-          # redis-memory-server keeps only src/redis-server, so build the core alone.
+          # This builds only the Redis server and not bundled modules which are not used.
           BUILD_ARGS: core
         run: |
           node -e "require('redis-memory-server/lib/util/RedisBinary').default.getPath({ version: process.env.REDISMS_VERSION })"
 
-      # A failure here means the relay behaves differently on this Redis version.
       - name: Run Redis tests
         env:
           REDISMS_VERSION: ${{ steps.resolve.outputs.version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,10 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          # Redis 8+ ships bundled modules that need pkg-config, python3, cmake and Rust.
+          # redis-memory-server keeps only src/redis-server, so build the core alone.
+          BUILD_ARGS: core
 
       - name: Create .env file
         run: cp ./tests/relay/test.env .env

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
         env:
-          # Redis 8+ ships bundled modules that need pkg-config, python3, cmake and Rust.
-          # redis-memory-server keeps only src/redis-server, so build the core alone.
+          # This builds only the Redis server and not bundled modules which are not used.
           BUILD_ARGS: core
 
       - name: Create .env file

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -160,36 +160,36 @@ import { CacheClientFactory } from './cache-client-factory';
 
 chai.use(chaiAsPromised);
 
-describe('MyClass', function() {
+describe('MyClass', function () {
   let cacheClient: ICacheClient;
   let myClass: MyClass;
 
-  beforeEach(function() {
+  beforeEach(function () {
     // Common setup for all tests
     cacheClient = CacheClientFactory.create();
     myClass = new MyClass(cacheClient);
   });
 
-  afterEach(async function() {
+  afterEach(async function () {
     // Do not forget to clean up any changes in the state of the system
     await cacheClient.clear();
   });
 
-  describe('myMethod', function() {
-    describe('given a valid input', function() {
+  describe('myMethod', function () {
+    describe('given a valid input', function () {
       let validInput: string;
 
-      beforeEach(function() {
+      beforeEach(function () {
         // Set up for a valid input
         validInput = 'valid input';
       });
 
-      it('should return the expected result', function() {
+      it('should return the expected result', function () {
         const result = myClass.myMethod(validInput);
         expect(result).to.equal('expected result');
       });
 
-      it('should call the dependency method with correct arguments', async function() {
+      it('should call the dependency method with correct arguments', async function () {
         const expectedArgs = ['expected', 'arguments'];
         const spy = sinon.spy(myClass, 'dependencyMethod');
 
@@ -198,7 +198,7 @@ describe('MyClass', function() {
         expect(spy).to.have.been.calledOnceWith(...expectedArgs);
       });
 
-      it('should change someState after calling myMethod', async function() {
+      it('should change someState after calling myMethod', async function () {
         const expectedArgs = ['expected', 'arguments'];
         const spy = sinon.spy(myClass, 'dependencyMethod');
 
@@ -211,19 +211,19 @@ describe('MyClass', function() {
       });
     });
 
-    describe('given an invalid input', function() {
+    describe('given an invalid input', function () {
       let invalidInput: string;
 
-      beforeEach(function() {
+      beforeEach(function () {
         // Set up for an invalid input
         invalidInput = 'invalid input';
       });
 
-      it('should throw an error', function() {
+      it('should throw an error', function () {
         expect(() => myClass.myMethod(invalidInput)).to.throw('expected error message');
       });
 
-      it('should not call the dependency method', function() {
+      it('should not call the dependency method', function () {
         const spy = sinon.spy(myClass, 'dependencyMethod');
         expect(() => myClass.myMethod(invalidInput)).to.throw;
         expect(spy).not.to.have.been.called;
@@ -279,7 +279,7 @@ describe('MyClass', function() {
 
   // Start an in-memory Redis server on a specific port
   useInMemoryRedisServer(logger, 6379);
-  
+
   // Override environment variables for the duration of the describe block
   overrideEnvsInMochaDescribe({
     MY_ENV_VAR: 'common-value-of-env-applied-to-tests-unless-overridden-in-inner-describe',
@@ -327,6 +327,35 @@ describe('MyClass', function() {
   });
 });
 ```
+
+## Redis-backed Test Suites
+
+Thirteen suites run against a real Redis started by `useInMemoryRedisServer`. Run just those:
+
+```bash
+npm run test:redis
+```
+
+The script discovers them by searching for `useInMemoryRedisServer`, so a new suite is picked up automatically.
+
+### Testing against a different Redis version
+
+The version is pinned in `package.json` under `redisMemoryServer.version`, and `REDISMS_VERSION` overrides it for a single run:
+
+```bash
+REDISMS_VERSION=8.10.1 npm run test:redis       # a specific version
+npm run test:redis                              # the pinned default
+```
+
+The first run of a version downloads the Redis source and compiles it (about a minute); afterwards it is cached under `node_modules/.cache/redis-memory-server`. The version must exist as a source tarball at `download.redis.io/releases/` — real release numbers only, so `8.10.1` works but `8`, `latest` and `stable` do not.
+
+Redis 8 and later bundle modules that need `pkg-config`, `python3`, `cmake` and Rust to build. Those modules are discarded — only `src/redis-server` is kept — so set `BUILD_ARGS=core` to build the server alone and skip the extra toolchain:
+
+```bash
+BUILD_ARGS=core REDISMS_VERSION=8.10.1 npm run test:redis
+```
+
+Do not remove the pin to pick up the newest version automatically: the upstream `redis-stable` tarball no longer exists, so an unpinned install fails outright. To check the relay against a newer Redis before an upgrade, run the **Redis Compatibility** workflow (`.github/workflows/redis-compat.yml`) from the Actions tab, leaving the version blank for the newest release.
 
 ## Conclusion
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -355,7 +355,7 @@ Redis 8 and later bundle modules that need `pkg-config`, `python3`, `cmake` and 
 BUILD_ARGS=core REDISMS_VERSION=8.10.1 npm run test:redis
 ```
 
-Do not remove the pin to pick up the newest version automatically: the upstream `redis-stable` tarball no longer exists, so an unpinned install fails outright. To check the relay against a newer Redis before an upgrade, run the **Redis Compatibility** workflow (`.github/workflows/redis-compat.yml`) from the Actions tab, leaving the version blank for the newest release.
+Do not remove the pin to pick up the newest version automatically: the upstream `redis-stable` tarball no longer exists, so an unpinned install fails outright. To check the relay against a newer Redis before an upgrade, run the **Redis Version Tests** workflow (`.github/workflows/redis-version-tests.yml`) from the Actions tab, leaving the version blank for the newest release.
 
 ## Conclusion
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "hiero-relay": "./bin/hiero-relay.js"
   },
   "redisMemoryServer": {
-    "version": "7.2.15"
+    "version": "8.10.1"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "test:client-libraries": "ON_VALID_JSON_RPC_HTTP_RESPONSE_STATUS_CODE=200 TX_STATUS_TRACING=true READ_ONLY=true REDIS_ENABLED=false RATE_LIMIT_DISABLED=true ts-mocha --recursive './tests/client-libraries/**/*.spec.ts' --exit",
     "test:bin": "c8 ts-mocha --recursive './tests/bin/*.spec.ts' --exit",
     "test:relay": "c8 ts-mocha --recursive './tests/relay/**/*.spec.ts' --exit",
+    "test:redis": "ts-mocha $(grep -rl useInMemoryRedisServer tests --include='*.spec.ts' | sort) --exit",
     "test:server": "c8 ts-mocha --recursive './tests/server/integration/**/*.spec.ts' --exit",
     "test:ws-server": "c8 ts-mocha --recursive './tests/ws-server/unit/**/*.spec.ts' --exit",
     "typecheck": "tsc --noEmit -p tsconfig.eslint.json",

--- a/tests/relay/lib/clients/redisClientManager.spec.ts
+++ b/tests/relay/lib/clients/redisClientManager.spec.ts
@@ -15,7 +15,7 @@ describe('RedisClientManager Test Suite', async function () {
   const logger = pino({ level: 'silent' });
 
   // Use a dedicated port to avoid conflicts with other suites
-  useInMemoryRedisServer(logger, 6380);
+  useInMemoryRedisServer(logger, 6385);
 
   this.beforeAll(async () => {
     await RedisClientManager.getClient(logger);

--- a/tests/relay/lib/services/lockService/RedisLockStrategy.spec.ts
+++ b/tests/relay/lib/services/lockService/RedisLockStrategy.spec.ts
@@ -3,13 +3,16 @@
 import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { type Logger, pino } from 'pino';
-import { type RedisClientType } from 'redis';
+import { createClient, type RedisClientType } from 'redis';
 import * as sinon from 'sinon';
 
 import { ConfigService } from '../../../../../src/config-service/services';
-import { type LockMetricsService } from '../../../../../src/relay/lib/services/lockService/LockMetricsService';
+import {
+  type LockMetricsService,
+  LockMetricsService as LockMetricsServiceClass,
+} from '../../../../../src/relay/lib/services/lockService/LockMetricsService';
 import { RedisLockStrategy } from '../../../../../src/relay/lib/services/lockService/RedisLockStrategy';
-import { overrideEnvsInMochaDescribe } from '../../../helpers';
+import { overrideEnvsInMochaDescribe, useInMemoryRedisServer } from '../../../helpers';
 
 use(chaiAsPromised);
 
@@ -649,6 +652,200 @@ describe('RedisLockStrategy Test Suite', function () {
       expect(result).to.not.be.undefined;
       expect(mockRedisClient.lRange.called).to.be.false;
       expect(mockMetricsService.recordQueueRejoin.called).to.be.false;
+    });
+  });
+});
+
+describe('RedisLockStrategy Real Redis Test Suite', function () {
+  this.timeout(20000);
+
+  const logger = pino({ level: 'silent' });
+  const port = 6387;
+  const maxLockHoldMs = 300;
+
+  let redisClient: RedisClientType;
+  let strategy: RedisLockStrategy;
+  let addressCounter = 0;
+
+  const uniqueAddress = () => `0x${(++addressCounter).toString(16).padStart(40, '0')}`;
+
+  after(() => {
+    redisClient?.destroy();
+  });
+
+  overrideEnvsInMochaDescribe({
+    LOCK_MAX_HOLD_MS: maxLockHoldMs,
+    LOCK_QUEUE_POLL_INTERVAL_MS: 20,
+  });
+
+  useInMemoryRedisServer(logger, port);
+
+  before(async () => {
+    redisClient = createClient({ url: `redis://127.0.0.1:${port}` }) as RedisClientType;
+    await redisClient.connect();
+    strategy = new RedisLockStrategy(
+      redisClient,
+      logger,
+      sinon.createStubInstance(LockMetricsServiceClass) as unknown as LockMetricsService,
+    );
+  });
+
+  describe('mutual exclusion', () => {
+    it('should let a single caller acquire and release', async () => {
+      const address = uniqueAddress();
+
+      const result = await strategy.acquireLock(address);
+      expect(result).to.not.be.undefined;
+      expect(await redisClient.get(`lock:${address}`)).to.equal(result!.sessionKey);
+
+      await strategy.releaseLock(address, result!.sessionKey, result!.acquiredAt);
+      expect(await redisClient.exists(`lock:${address}`)).to.equal(0);
+    });
+
+    it('should not let a second caller hold the same lock concurrently', async () => {
+      const address = uniqueAddress();
+
+      const first = await strategy.acquireLock(address);
+      expect(first).to.not.be.undefined;
+
+      const second = await Promise.race([
+        strategy.acquireLock(address),
+        new Promise((resolve) => setTimeout(() => resolve('still-waiting'), 100)),
+      ]);
+      expect(second).to.equal('still-waiting');
+
+      await strategy.releaseLock(address, first!.sessionKey, first!.acquiredAt);
+    });
+
+    it('should hand the lock to the waiter once the holder releases', async () => {
+      const address = uniqueAddress();
+
+      const first = await strategy.acquireLock(address);
+      const waiter = strategy.acquireLock(address);
+
+      await strategy.releaseLock(address, first!.sessionKey, first!.acquiredAt);
+
+      const second = await waiter;
+      expect(second).to.not.be.undefined;
+      expect(second!.sessionKey).to.not.equal(first!.sessionKey);
+      expect(await redisClient.get(`lock:${address}`)).to.equal(second!.sessionKey);
+
+      await strategy.releaseLock(address, second!.sessionKey, second!.acquiredAt);
+    });
+
+    it('should not block a different address', async () => {
+      const held = uniqueAddress();
+      const other = uniqueAddress();
+
+      const first = await strategy.acquireLock(held);
+      const otherResult = await strategy.acquireLock(other);
+
+      expect(otherResult).to.not.be.undefined;
+
+      await strategy.releaseLock(held, first!.sessionKey, first!.acquiredAt);
+      await strategy.releaseLock(other, otherResult!.sessionKey, otherResult!.acquiredAt);
+    });
+
+    it('should treat addresses case-insensitively', async () => {
+      const address = '0xAbCdEf1234567890AbCdEf1234567890AbCdEf12';
+
+      const first = await strategy.acquireLock(address);
+      expect(await redisClient.get(`lock:${address.toLowerCase()}`)).to.equal(first!.sessionKey);
+
+      const second = await Promise.race([
+        strategy.acquireLock(address.toLowerCase()),
+        new Promise((resolve) => setTimeout(() => resolve('still-waiting'), 100)),
+      ]);
+      expect(second).to.equal('still-waiting');
+
+      await strategy.releaseLock(address, first!.sessionKey, first!.acquiredAt);
+    });
+  });
+
+  describe('release ownership', () => {
+    it('should ignore a release from a caller that does not own the lock', async () => {
+      const address = uniqueAddress();
+
+      const owner = await strategy.acquireLock(address);
+      await strategy.releaseLock(address, 'not-the-owner', process.hrtime.bigint());
+
+      expect(await redisClient.get(`lock:${address}`)).to.equal(owner!.sessionKey);
+
+      await strategy.releaseLock(address, owner!.sessionKey, owner!.acquiredAt);
+      expect(await redisClient.exists(`lock:${address}`)).to.equal(0);
+    });
+
+    it('should return the release Lua reply as a number, not a string', async () => {
+      const address = uniqueAddress();
+      const lockKey = `lock:${address}`;
+      const script = `
+        if redis.call("get", KEYS[1]) == ARGV[1] then
+          return redis.call("del", KEYS[1])
+        else
+          return 0
+        end
+      `;
+
+      await redisClient.set(lockKey, 'session-a');
+
+      // releaseLock compares with `result === 1`, so a string reply would break it silently.
+      expect(await redisClient.eval(script, { keys: [lockKey], arguments: ['session-b'] })).to.equal(0);
+      expect(await redisClient.eval(script, { keys: [lockKey], arguments: ['session-a'] })).to.equal(1);
+    });
+  });
+
+  describe('TTL expiry', () => {
+    it('should set a TTL on the lock key', async () => {
+      const address = uniqueAddress();
+
+      const result = await strategy.acquireLock(address);
+      const ttl = await redisClient.pTTL(`lock:${address}`);
+
+      expect(ttl).to.be.greaterThan(0);
+      expect(ttl).to.be.at.most(maxLockHoldMs);
+
+      await strategy.releaseLock(address, result!.sessionKey, result!.acquiredAt);
+    });
+
+    it('should free the address once the TTL expires without a release', async () => {
+      const address = uniqueAddress();
+
+      const abandoned = await strategy.acquireLock(address);
+      expect(abandoned).to.not.be.undefined;
+
+      // No release: the lock must expire on its own, otherwise the address is wedged forever.
+      await new Promise((resolve) => setTimeout(resolve, maxLockHoldMs + 100));
+      expect(await redisClient.exists(`lock:${address}`)).to.equal(0);
+
+      const next = await strategy.acquireLock(address);
+      expect(next).to.not.be.undefined;
+
+      await strategy.releaseLock(address, next!.sessionKey, next!.acquiredAt);
+    });
+  });
+
+  describe('queue hygiene', () => {
+    it('should leave no queue entry behind after a successful acquisition', async () => {
+      const address = uniqueAddress();
+
+      const result = await strategy.acquireLock(address);
+      expect(await redisClient.lLen(`lock:queue:${address}`)).to.equal(0);
+
+      await strategy.releaseLock(address, result!.sessionKey, result!.acquiredAt);
+    });
+
+    it('should prune a queued session whose heartbeat has expired', async () => {
+      const address = uniqueAddress();
+      const queueKey = `lock:queue:${address}`;
+
+      await redisClient.lPush(queueKey, 'zombie-session');
+
+      const result = await strategy.acquireLock(address);
+
+      expect(result).to.not.be.undefined;
+      expect(await redisClient.lRange(queueKey, 0, -1)).to.not.include('zombie-session');
+
+      await strategy.releaseLock(address, result!.sessionKey, result!.acquiredAt);
     });
   });
 });

--- a/tests/relay/lib/services/rateLimiterService/RedisRateLimitStore.spec.ts
+++ b/tests/relay/lib/services/rateLimiterService/RedisRateLimitStore.spec.ts
@@ -298,14 +298,18 @@ describe('RedisRateLimitStore Real Redis Test Suite', function () {
 
   it('should set the expiry on the first request only', async () => {
     const key = uniqueKey();
+    const longWindowStore = new RedisRateLimitStore(redisClient, logger, 5000);
 
-    await store.incrementAndCheck(key, 5);
-    const ttlAfterFirst = await redisClient.ttl(key.toString());
+    await longWindowStore.incrementAndCheck(key, 5);
+    const ttlAfterFirst = await redisClient.pTTL(key.toString());
     expect(ttlAfterFirst).to.be.greaterThan(0);
 
-    await store.incrementAndCheck(key, 5);
-    const ttlAfterSecond = await redisClient.ttl(key.toString());
-    expect(ttlAfterSecond).to.be.at.most(ttlAfterFirst);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    await longWindowStore.incrementAndCheck(key, 5);
+    const ttlAfterSecond = await redisClient.pTTL(key.toString());
+    expect(ttlAfterSecond).to.be.greaterThan(0);
+    expect(ttlAfterSecond).to.be.lessThan(ttlAfterFirst);
   });
 
   it('should allow requests again once the window has elapsed', async () => {

--- a/tests/relay/lib/services/rateLimiterService/RedisRateLimitStore.spec.ts
+++ b/tests/relay/lib/services/rateLimiterService/RedisRateLimitStore.spec.ts
@@ -3,11 +3,12 @@
 import { expect } from 'chai';
 import { type Logger, pino } from 'pino';
 import { Counter, Registry } from 'prom-client';
-import { type RedisClientType } from 'redis';
+import { createClient, type RedisClientType } from 'redis';
 import * as sinon from 'sinon';
 
 import { RedisRateLimitStore } from '../../../../../src/relay/lib/services/rateLimiterService/RedisRateLimitStore';
 import { RateLimitKey } from '../../../../../src/relay/lib/types/rateLimiter';
+import { useInMemoryRedisServer } from '../../../helpers';
 
 describe('RedisRateLimitStore Test Suite', function () {
   this.timeout(10000);
@@ -214,5 +215,134 @@ describe('RedisRateLimitStore Test Suite', function () {
       const evalOptions = evalCall.args[1] as { keys: string[]; arguments: string[] };
       expect(evalOptions.arguments[1]).to.equal('2'); // TTL ceiled to 2 seconds
     });
+  });
+});
+
+describe('RedisRateLimitStore Real Redis Test Suite', function () {
+  this.timeout(20000);
+
+  const logger = pino({ level: 'silent' });
+  const duration = 1000;
+  const port = 6386;
+
+  let redisClient: RedisClientType;
+  let store: RedisRateLimitStore;
+  let keyCounter = 0;
+
+  const uniqueKey = () => new RateLimitKey(`127.0.0.${++keyCounter}`, 'eth_chainId');
+
+  after(() => {
+    redisClient?.destroy();
+  });
+
+  useInMemoryRedisServer(logger, port);
+
+  before(async () => {
+    redisClient = createClient({ url: `redis://127.0.0.1:${port}` }) as RedisClientType;
+    await redisClient.connect();
+    store = new RedisRateLimitStore(redisClient, logger, duration);
+  });
+
+  it('should allow requests up to the limit', async () => {
+    const key = uniqueKey();
+
+    for (let i = 0; i < 5; i++) {
+      expect(await store.incrementAndCheck(key, 5)).to.be.false;
+    }
+  });
+
+  it('should block the request that exceeds the limit', async () => {
+    const key = uniqueKey();
+
+    for (let i = 0; i < 5; i++) {
+      await store.incrementAndCheck(key, 5);
+    }
+
+    expect(await store.incrementAndCheck(key, 5)).to.be.true;
+  });
+
+  it('should keep blocking once the limit is exceeded', async () => {
+    const key = uniqueKey();
+
+    for (let i = 0; i < 6; i++) {
+      await store.incrementAndCheck(key, 5);
+    }
+
+    expect(await store.incrementAndCheck(key, 5)).to.be.true;
+    expect(await store.incrementAndCheck(key, 5)).to.be.true;
+  });
+
+  it('should count each IP address independently', async () => {
+    const first = new RateLimitKey('10.0.0.1', 'eth_chainId');
+    const second = new RateLimitKey('10.0.0.2', 'eth_chainId');
+
+    for (let i = 0; i < 2; i++) {
+      await store.incrementAndCheck(first, 2);
+    }
+
+    expect(await store.incrementAndCheck(first, 2)).to.be.true;
+    expect(await store.incrementAndCheck(second, 2)).to.be.false;
+  });
+
+  it('should count each method independently', async () => {
+    const chainId = new RateLimitKey('10.0.1.1', 'eth_chainId');
+    const blockNumber = new RateLimitKey('10.0.1.1', 'eth_blockNumber');
+
+    for (let i = 0; i < 2; i++) {
+      await store.incrementAndCheck(chainId, 2);
+    }
+
+    expect(await store.incrementAndCheck(chainId, 2)).to.be.true;
+    expect(await store.incrementAndCheck(blockNumber, 2)).to.be.false;
+  });
+
+  it('should set the expiry on the first request only', async () => {
+    const key = uniqueKey();
+
+    await store.incrementAndCheck(key, 5);
+    const ttlAfterFirst = await redisClient.ttl(key.toString());
+    expect(ttlAfterFirst).to.be.greaterThan(0);
+
+    await store.incrementAndCheck(key, 5);
+    const ttlAfterSecond = await redisClient.ttl(key.toString());
+    expect(ttlAfterSecond).to.be.at.most(ttlAfterFirst);
+  });
+
+  it('should allow requests again once the window has elapsed', async () => {
+    const key = uniqueKey();
+
+    for (let i = 0; i < 3; i++) {
+      await store.incrementAndCheck(key, 2);
+    }
+    expect(await store.incrementAndCheck(key, 2)).to.be.true;
+
+    await new Promise((resolve) => setTimeout(resolve, duration + 500));
+
+    expect(await store.incrementAndCheck(key, 2)).to.be.false;
+  });
+
+  it('should count concurrent requests atomically', async () => {
+    const key = uniqueKey();
+    const limit = 10;
+
+    const results = await Promise.all(Array.from({ length: 25 }, () => store.incrementAndCheck(key, limit)));
+
+    expect(results.filter((blocked) => !blocked)).to.have.lengthOf(limit);
+  });
+
+  it('should return the Lua reply as a number, not a string', async () => {
+    const key = uniqueKey();
+
+    const underLimit = await redisClient.eval(RedisRateLimitStore['LUA_SCRIPT'], {
+      keys: [key.toString()],
+      arguments: ['1', '10'],
+    });
+    const overLimit = await redisClient.eval(RedisRateLimitStore['LUA_SCRIPT'], {
+      keys: [key.toString()],
+      arguments: ['1', '10'],
+    });
+
+    expect(underLimit).to.equal(0);
+    expect(overLimit).to.equal(1);
   });
 });


### PR DESCRIPTION
### Description

This PR adds real Redis coverage for the two components that had none, and a way to check the relay against any Redis version on demand.

`RedisRateLimitStore` and `RedisLockStrategy` are the only files in the codebase that run Lua inside Redis, and both of their test suites replaced the client with a `sinon` stub — so that Lua had never been executed by any Redis, at any version, in any test. The existing mocked suites are kept, since they cover the fail-open branches a healthy server will not produce; the new suites run alongside them against a real server.

Also included: a one-line port fix for a suite that intermittently failed the relay test run, a `test:redis` script that runs only the Redis-backed suites, an on-demand **Redis Compatibility** workflow, and documentation for `REDISMS_VERSION`.

**Changes**

- `RedisRateLimitStore` — 9 tests: limit enforcement, per-IP and per-method isolation, window expiry, concurrent atomicity, and that the Lua reply is a number (`incrementAndCheck` compares with `result === 1`, so a string reply would silently disable rate limiting)
- `RedisLockStrategy` — 11 tests: mutual exclusion, handoff to a waiter, release ownership, TTL expiry, and zombie queue pruning
- `redisClientManager.spec.ts` — moved off port 6380, which `hbarSpendingPlanRepository.spec.ts` already used. The two together left an abandoned client reconnecting to the next suite's server, timing out a `before all` hook. Before the fix the full relay run gave 2474 passing / 1 failing; after, 2475 / 0
- `npm run test:redis` — runs the 13 Redis-backed suites (~10s vs ~3m for the full relay suite), discovered by searching for `useInMemoryRedisServer` so new suites are picked up automatically
- `.github/workflows/redis-compat.yml` — `workflow_dispatch` with a version input (blank = newest release). The Redis build is a separate named step from the test run, so a toolchain failure is distinguishable from a real incompatibility
- `docs/testing-guide.md` — when a real Redis is needed, the port list, and how to target a specific version

**Both new suites were mutation-tested.** Dropping `NX` from the lock's `SET`, removing its `PX`, skipping zombie pruning, removing the ownership check from the release Lua, flipping the rate limiter's `>` to `>=`, dropping its `EXPIRE`, and returning a string instead of a number each produced failures. Before this PR every one of those mutations passed the suite.

**Result:** all 356 Redis tests pass against Redis 8.10.1, unchanged from 7.2.15. The August incident that led to the current pin was a build failure — `redis-memory-server` compiles Redis from source and the runner lacks the toolchain Redis 8's bundled modules need — not a behavioural one. Setting `BUILD_ARGS=core` builds the server alone and avoids it.

### Related issue(s)

Fixes #5511

### Testing Guide

1. `npm run test:redis` — 356 passing.
2. `REDISMS_VERSION=8.10.1 BUILD_ARGS=core npm run test:redis` — 356 passing, against Redis 8. First run compiles Redis (~1 min), then caches.
3. Run the **Redis Compatibility** workflow from the Actions tab, leaving the version blank to pick up the newest release.
4. To confirm the new tests have teeth, remove `NX: true` from the lock's `set` in `RedisLockStrategy.ts` and re-run — 3 tests fail.